### PR TITLE
Add ONS digital blog to X-Frame-Options

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageStringResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageStringResponse.java
@@ -33,7 +33,7 @@ public class BabbageStringResponse extends BabbageResponse {
     @Override
     public void apply(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // https://acunetix.com/vulnerabilities/web/clickjacking--x-frame-options-header-missing
-        addHeader("X-Frame-Options", "SAMEORIGIN"); // DENY | SAMEORIGIN
+        addHeader("X-Frame-Options", "ALLOW-FROM https://blog.ons.digital"); // DENY | SAMEORIGIN
         super.apply(request, response);
         writeData(response);
     }


### PR DESCRIPTION
Support embedding content in an `<iframe>` from https://blog.ons.digital