### PR TITLE
Visualisation fixes.

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/filter/BabbageFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/BabbageFilter.java
@@ -1,0 +1,38 @@
+package com.github.onsdigital.babbage.api.filter;
+
+import com.google.common.collect.ImmutableList;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A single implementation of the Restolino filter interface allowing the run order of filters to be controlled.
+ * <p>
+ * Be sure to implement the com.github.onsdigital.babbage.api.filter.Filter interface and add it into the list
+ * contained in this class to specify when it is run.
+ */
+public class BabbageFilter implements com.github.davidcarboni.restolino.framework.Filter {
+
+    private static final List<Filter> filters = new ImmutableList.Builder<Filter>()
+            .add(
+                    new RequestContextFilter(),
+                    new CorsFilter(),
+                    new UrlRedirectFilter(),
+                    new ShortUrlFilter(),
+                    new StaticFilesFilter())
+            .build();
+
+    @Override
+    public boolean filter(HttpServletRequest request, HttpServletResponse response) {
+
+        for (Filter filter : filters) {
+            if (!filter.filter(request, response)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/github/onsdigital/babbage/api/filter/CorsFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/CorsFilter.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.babbage.api.filter;
 
-import com.github.davidcarboni.restolino.framework.Filter;
 import com.github.onsdigital.babbage.util.URIUtil;
 
 import javax.servlet.http.HttpServletRequest;

--- a/src/main/java/com/github/onsdigital/babbage/api/filter/Filter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/Filter.java
@@ -1,0 +1,18 @@
+package com.github.onsdigital.babbage.api.filter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A filter that is run before the HTTP request is processed.
+ */
+public interface Filter {
+
+    /**
+     * Return true if the request should continue to be processed.
+     * @param req
+     * @param res
+     * @return
+     */
+    boolean filter(HttpServletRequest req, HttpServletResponse res);
+}

--- a/src/main/java/com/github/onsdigital/babbage/api/filter/RequestContextFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/RequestContextFilter.java
@@ -1,0 +1,18 @@
+package com.github.onsdigital.babbage.api.filter;
+
+import com.github.onsdigital.babbage.util.RequestUtil;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Created by bren on 15/08/15.
+ */
+public class RequestContextFilter implements Filter {
+    @Override
+    public boolean filter(HttpServletRequest req, HttpServletResponse res) {
+        RequestUtil.clearContext();//clear if any request context bound to this thread before
+        RequestUtil.saveRequestContext(req);
+        return true;
+    }
+}

--- a/src/main/java/com/github/onsdigital/babbage/api/filter/ShortUrlFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/ShortUrlFilter.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.babbage.api.filter;
 
-import com.github.davidcarboni.restolino.framework.Filter;
 import com.github.onsdigital.babbage.url.redirect.RedirectException;
 import com.github.onsdigital.babbage.url.shortcut.ShortcutUrl;
 import com.github.onsdigital.babbage.url.shortcut.ShortcutUrlService;

--- a/src/main/java/com/github/onsdigital/babbage/api/filter/StaticFilesFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/StaticFilesFilter.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.babbage.api.filter;
 
-import com.github.davidcarboni.restolino.framework.Filter;
 import com.github.onsdigital.babbage.content.client.ContentClient;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
@@ -8,7 +7,6 @@ import com.github.onsdigital.babbage.response.BabbageContentBasedBinaryResponse;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.apache.commons.io.FilenameUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -34,28 +32,18 @@ public class StaticFilesFilter implements Filter {
 
 
             // only go in here if we have a URI that starts /visualisation/....
-            Path endpoint = requestPath.getName(0);
+            Path endpoint = requestPath.getName(0); // /visualisations
             if (endpoint.toString().equalsIgnoreCase(visualisationRoot)) {
 
-                Path uid = Paths.get(uri).getName(1);
+                Path uid = Paths.get(uri).getName(1);  // dvc123
                 String path = Paths.get("/" + visualisationRoot + "/" + uid).relativize(requestPath).toString();
 
-                if (path.length() == 0 || path.equals("/") || FilenameUtils.getExtension(path).length() == 0) {
-                    path = getIndexPagePath(uid);
-
-                    if (path == null || path.length() == 0 || path.equals("/")) {
-                        path = "index.html";
-                    }
-                } else {
-                    String indexPagePath = getIndexPagePath(uid);
-                    // resolve files that are referenced relative to the root html page.
-                    path = resolveRelativePath(indexPagePath, path);
-                }
-
                 String visualisationPath = String.format("/%s/%s/content/%s", visualisationRoot, uid, path);
-
                 ContentResponse contentResponse = ContentClient.getInstance().getResource(visualisationPath);
-                new BabbageContentBasedBinaryResponse(contentResponse, contentResponse.getDataStream(), contentResponse.getMimeType()).apply(request, response);
+                new BabbageContentBasedBinaryResponse(
+                        contentResponse,
+                        contentResponse.getDataStream(),
+                        contentResponse.getMimeType()).apply(request, response);
 
                 return false; // we have the response we require, do not continue to process this request.
             }

--- a/src/main/java/com/github/onsdigital/babbage/api/filter/UrlRedirectFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/UrlRedirectFilter.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.babbage.api.filter;
 
-import com.github.davidcarboni.restolino.framework.Filter;
 import com.github.onsdigital.babbage.api.error.ErrorHandler;
 import com.github.onsdigital.babbage.url.redirect.RedirectCategory;
 import com.github.onsdigital.babbage.url.redirect.RedirectException;


### PR DESCRIPTION
### What

Allow multiple html visualisation pages to be served under one visualisation directory. Remove ability to serve visualisation from root URL. Visualisations can now only be served using the absolute URL. Applied explicit ordering of babbage filters to fix random 401 responses. The StaticFilesFilter was being run before the RequestContentFilter which it depends on. 

### How to review

Upload a visualisation and preview the content of multiple HTML pages. Ensure all asset files are loaded with no 401 errors.

### Who can review
