### PR TITLE
Fix static methodology PDFs not displaying sections

### DIFF
--- a/src/main/web/templates/handlebars/pdf/pdf.handlebars
+++ b/src/main/web/templates/handlebars/pdf/pdf.handlebars
@@ -144,7 +144,7 @@
     {{> pdf/partials/header}}
 
     {{!-- DETECT WHICH PDF BODY TEMPLATE TO SERVE UP --}}
-    {{#if_any (eq type "bulletin") (eq type "article") (eq type "static_methodlogy") (eq type "compendium_chapter")}}
+    {{#if_any (eq type "bulletin") (eq type "article") (eq type "static_methodology") (eq type "compendium_chapter")}}
         {{> pdf/partials/publication}}
     {{/if_any}}
     {{#if_eq type "compendium_landing_page"}}


### PR DESCRIPTION
### What

Fix sections not displaying in PDFs for static methodology pages

### How to review

Once a static methodology page has been re-approved the sections will display in the PDF

### Who can review

Anyone

