### PR TITLE
Sort corrections in datasets and publications by date and reverse order

### DIFF
--- a/src/main/web/templates/handlebars/partials/correction.handlebars
+++ b/src/main/web/templates/handlebars/partials/correction.handlebars
@@ -3,7 +3,7 @@
 		{{#if_all versions alerts}}
 			<h3 class="alert--correction__title">{{labels.corrections}}</h3>
 		{{/if_all}}
-		{{#loop versions reverse=true}}
+		{{#loop versions orderBy="updateDate" reverse=true}}
 			<p class="alert__date">{{df updateDate outputFormat="d MMMM yyyy HH:mm"}}</p>
 			{{md correctionNotice}}
 			<a class="btn btn--tertiary margin-bottom-sm--3 margin-bottom-md--3 print--hide" href="{{uri}}">{{labels.view-superseded-version}}</a>

--- a/src/main/web/templates/handlebars/partials/notice.handlebars
+++ b/src/main/web/templates/handlebars/partials/notice.handlebars
@@ -7,12 +7,12 @@
 				{{#if_all has-corrections has-alerts}}
 					<h3 class="alert--notice__title">{{labels.corrections}}</h3>
 				{{/if_all}}
-				{{#each alerts}}
+				{{#loop alerts orderBy="date" reverse=true}}
 					{{#if_eq type "correction"}}
 						<p class="alert__date">{{df date}}</p>
 						{{md markdown}}
 					{{/if_eq}}
-				{{/each}}
+				{{/loop}}
 			</section>
 		{{/if}}
 		{{#if has-alerts}}
@@ -20,12 +20,13 @@
 				{{#if_all has-corrections has-alerts}}
 					<h3 class="alert--notice__title">{{labels.notices}}</h3>
 				{{/if_all}}
-				{{#each alerts}}
+				{{#loop alerts orderBy="date" reverse=true}}
 					{{#if_eq type "alert"}}
+                        {{@index}}
 						<p class="alert__date">{{df date}}</p>
 						{{md markdown}}
 					{{/if_eq}}
-				{{/each}}
+				{{/loop}}
 			</section>
 		{{/if}}
 
@@ -36,10 +37,10 @@
 			{{#if_all versions alerts}}
 				<h3 class="alert--notice__title">{{labels.notices}}</h3>
 			{{/if_all}}
-			{{#each alerts}}
+			{{#loop alerts orderBy="date" reverse=true}}
 				<p class="alert__date">{{df date}}</p>
 				{{md markdown}}
-			{{/each}}
+			{{/loop}}
 		</section>
 
 	{{/if_any}}


### PR DESCRIPTION
### What

Force corrections to display in descending date order.

### How to review

Look at corrections across various page type (eg bulletin, compendium chapter and dataset) and check ordering is correct despite creation order in Florence.

### Who can review

Anyone.

