### PR TITLE
PDF handler now throws error for any non existing legacy PDFs while w…

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.babbage.api.error;
 import com.github.davidcarboni.restolino.api.RequestHandler;
 import com.github.davidcarboni.restolino.framework.ServerError;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
+import com.github.onsdigital.babbage.error.LegacyPDFException;
 import com.github.onsdigital.babbage.template.TemplateService;
 import com.github.onsdigital.babbage.error.ResourceNotFoundException;
 import org.apache.commons.io.IOUtils;
@@ -43,6 +44,8 @@ public class ErrorHandler implements ServerError {
             return;
         } else if (t instanceof ResourceNotFoundException) {
             renderErrorPage(404, response);
+        } else if (t instanceof LegacyPDFException) {
+            renderErrorPage(501, response);
         } else {
             renderErrorPage(500, response);
         }

--- a/src/main/java/com/github/onsdigital/babbage/error/LegacyPDFException.java
+++ b/src/main/java/com/github/onsdigital/babbage/error/LegacyPDFException.java
@@ -1,0 +1,13 @@
+package com.github.onsdigital.babbage.error;
+
+/**
+ * Temp exception specifically for legacy PDF requests. will be removed once actual fix is in.
+ */
+public class LegacyPDFException extends BabbageException {
+
+    private static final String PDF_ERROR_MESSAGE = "We have a known issue with out PDF generation....";
+
+    public LegacyPDFException() {
+        super(501, PDF_ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PDFRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PDFRequestHandler.java
@@ -50,7 +50,7 @@ public class PDFRequestHandler extends BaseRequestHandler {
         return response;
     }
 
-    static BabbageResponse getPregeneartedPdf(String requestedUri) throws ContentReadException, IOException {
+    static BabbageResponse getPreGeneratedPDF(String requestedUri) throws ContentReadException, IOException {
         ContentResponse contentResponse;
         contentResponse = ContentClient.getInstance().getResource(requestedUri + "/page.pdf");
         BabbageContentBasedBinaryResponse response = new BabbageContentBasedBinaryResponse(contentResponse, contentResponse.getDataStream(), contentResponse.getMimeType());

--- a/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.babbage.template;
 
-import com.github.onsdigital.babbage.configuration.Configuration;
 import com.github.onsdigital.babbage.template.handlebars.HandlebarsRenderer;
 import com.github.onsdigital.babbage.util.ThreadContext;
 import org.apache.commons.lang3.ArrayUtils;
@@ -10,7 +9,11 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
 
-import static com.github.onsdigital.babbage.configuration.Configuration.HANDLEBARS.*;
+import static com.github.onsdigital.babbage.configuration.Configuration.HANDLEBARS.getMainChartConfigTemplateName;
+import static com.github.onsdigital.babbage.configuration.Configuration.HANDLEBARS.getMainContentTemplateName;
+import static com.github.onsdigital.babbage.configuration.Configuration.HANDLEBARS.getTemplatesDirectory;
+import static com.github.onsdigital.babbage.configuration.Configuration.HANDLEBARS.getTemplatesSuffix;
+import static com.github.onsdigital.babbage.configuration.Configuration.HANDLEBARS.isReloadTemplateChanges;
 import static com.github.onsdigital.babbage.util.json.JsonUtil.toMap;
 
 /**

--- a/src/main/web/templates/handlebars/error/501.handlebars
+++ b/src/main/web/templates/handlebars/error/501.handlebars
@@ -1,0 +1,34 @@
+{{#partial "block-main"}}
+<div class="page-header slate">
+    <div class="wrapper">
+        <p class="page-header--error-desc"><strong>We're Sorry</strong>
+        </p>
+        <h1 class="page-header__title flush--half--bottom">501 - Legacy PDF issue.</h1>
+    </div>
+    <!-- /nav-panel -->
+</div>
+<div class="wrapper panel--bottom-mar">
+    <div class="grid-wrap">
+        <div class="grid-col desktop-grid-full-width">
+            <article>
+                <div class="box box--padded box--red-dark box--red-dark--separated-left sectioned">
+                    <header class="box__header">
+                        <h2 class="gamma">TODO GET WORDING - We are currently experiencing issues with some of our PDF generation....</h2>
+                    </header>
+                    <!-- /box__header -->
+                    <div class="grid-wrap">
+                        <div class="grid-col desktop-full-width">
+                            <p>TODO</p>
+                        </div>
+                    </div>
+                </div>
+            </article>
+        </div>
+        <!-- /article__content -->
+    </div>
+    <!-- /grid-col -->
+</div>
+{{/partial}}
+
+{{!-- Inheriting from base template --}}
+{{> base/base}}

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -107,6 +107,7 @@
 			{{#if_eq code 404}}{{> error/404}}
 				{{else if_eq code 401}}{{> error/401}}
 				{{else if_eq code 500}}{{> error/500}}
+                {{else if_eq code 501}}{{> error/501}}
 			{{/if_eq}}
 		{{/if_eq}}
 


### PR DESCRIPTION
### What

Working theory for file descriptors issue is caused in part by the on the fly legacy PDF generation. This is a temp fix to keep the site alive while we investigate further. Now if a legacy PDF is requested that doesn't exist (& would therefore be generated on the fly) an error page will be displayed explaining the issue.

### How to review

Request a legacy PDF that doesn't exist - you should get a 501 error with an explanation. 
Request a legacy PDF that does exist and you should download the file successfully.

### Who can review

@CarlHembrough @ian-kent @LloydGriffiths @Crispioso @jondewijones 