### PR TITLE
Thousand separator on tooltip fix

### DIFF
--- a/src/main/web/templates/handlebars/highcharts/config/linechartconfig.handlebars
+++ b/src/main/web/templates/handlebars/highcharts/config/linechartconfig.handlebars
@@ -231,9 +231,11 @@ if(!description.isIndex) {
  };
 
 
-function numberWithCommas(number) {
-    return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-}
+    function numberWithCommas(number) {
+    var parts = number.toString().split(".");
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    return parts.join(".");
+    }
 
 window.linechart = linechart;
 return linechart;


### PR DESCRIPTION
### What

Split string and add thousand separator to number and not decimal. This prevents thousand separator being added to decimal numbers longer than 3.

### How to review

Test timeseries charts work and that values in tooltip are formatted corrected e.g. whole numbers over 1000 get a separator, decimal places longer than 3 digits don't have separator added. 

### Who can review

Anyone.

