### PR TITLE
Feature/logging improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
             <version>0.9.9</version>
         </dependency>
 
-        <!--&lt;!&ndash; Logging &ndash;&gt;-->
+        <!--Logging-->
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>dp-logging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,13 @@
             <version>0.9.9</version>
         </dependency>
 
+        <!--&lt;!&ndash; Logging &ndash;&gt;-->
+        <dependency>
+            <groupId>com.github.ONSdigital</groupId>
+            <artifactId>dp-logging</artifactId>
+            <version>master-SNAPSHOT</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -227,5 +234,23 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <!-- Adding maven central repo explicitly to perent jitpack.io resolve artifacts that are already on Github. Otherwise handlebars-java fails -->
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>http://repo.maven.apache.org/maven2</url>
+        </repository>
+        <!--Jitpack io allows us include projects and libraries available on github but not built and published to maven central-->
+        <!-- It is used for including internal project modules. See more on https://jitpack.io/-->
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
 
 </project>

--- a/run-publishing.sh
+++ b/run-publishing.sh
@@ -27,6 +27,6 @@ java $JAVA_OPTS \
  -Drestolino.files=$RESTOLINO_STATIC \
  -Drestolino.classes=$RESTOLINO_CLASSES \
  -Drestolino.packageprefix=$PACKAGE_PREFIX \
- -cp "target/dependency/*" \
+ -cp "target/classes/:target/dependency/*" \
  com.github.davidcarboni.restolino.Main
 

--- a/run.sh
+++ b/run.sh
@@ -25,5 +25,5 @@ java $JAVA_OPTS \
  -Drestolino.files=$RESTOLINO_STATIC \
  -Drestolino.classes=$RESTOLINO_CLASSES \
  -Drestolino.packageprefix=$PACKAGE_PREFIX \
- -cp "target/dependency/*" \
+ -cp "target/classes/:target/dependency/*" \
  com.github.davidcarboni.restolino.Main

--- a/src/main/java/com/github/onsdigital/babbage/logging/Log.java
+++ b/src/main/java/com/github/onsdigital/babbage/logging/Log.java
@@ -1,0 +1,7 @@
+package com.github.onsdigital.babbage.log;
+
+/**
+ * Created by carlhembrough on 23/12/2016.
+ */
+public class Logger {
+}

--- a/src/main/java/com/github/onsdigital/babbage/logging/Log.java
+++ b/src/main/java/com/github/onsdigital/babbage/logging/Log.java
@@ -1,7 +1,36 @@
-package com.github.onsdigital.babbage.log;
+package com.github.onsdigital.babbage.logging;
+
+import ch.qos.logback.classic.Level;
 
 /**
- * Created by carlhembrough on 23/12/2016.
+ * High level static interface to logging in babbage.
  */
-public class Logger {
+public class Log {
+
+    /**
+     * Log the given messsage to a default debug log level.
+     * @param message
+     */
+    public static void debug(String message) {
+        new LogMessageBuilder(message, Level.DEBUG).log();
+    }
+
+    /**
+     * Helper method to provide a log message builder for the debug log level.
+     * @param message
+     * @return
+     */
+    public static LogMessageBuilder buildDebug(String message) {
+        return build(message, Level.DEBUG);
+    }
+
+    /**
+     * Create a log message builder using the given message and log level.
+     * @param message
+     * @param level
+     * @return
+     */
+    public static LogMessageBuilder build(String message, Level level) {
+        return new LogMessageBuilder(message, level);
+    }
 }

--- a/src/main/java/com/github/onsdigital/babbage/logging/LogMessageBuilder.java
+++ b/src/main/java/com/github/onsdigital/babbage/logging/LogMessageBuilder.java
@@ -3,11 +3,11 @@ package com.github.onsdigital.babbage.logging;
 import ch.qos.logback.classic.Level;
 
 /**
- * Implementation of abstract LogMessageBuilder
+ * Babbage Implementation of abstract LogMessageBuilder
  */
 public class LogMessageBuilder extends com.github.onsdigital.logging.builder.LogMessageBuilder {
 
-    public static final String LOG_NAME = "Babbage";
+    public static final String LOG_NAME = "com.github.onsdigital.babbage";
 
     public LogMessageBuilder(String eventDescription) {
         super(eventDescription);

--- a/src/main/java/com/github/onsdigital/babbage/logging/LogMessageBuilder.java
+++ b/src/main/java/com/github/onsdigital/babbage/logging/LogMessageBuilder.java
@@ -1,0 +1,32 @@
+package com.github.onsdigital.babbage.logging;
+
+import ch.qos.logback.classic.Level;
+
+/**
+ * Implementation of abstract LogMessageBuilder
+ */
+public class LogMessageBuilder extends com.github.onsdigital.logging.builder.LogMessageBuilder {
+
+    public static final String LOG_NAME = "Babbage";
+
+    public LogMessageBuilder(String eventDescription) {
+        super(eventDescription);
+    }
+
+    public LogMessageBuilder(String description, Level logLevel) {
+        super(description, logLevel);
+    }
+
+    public LogMessageBuilder(Throwable t, Level level, String description) {
+        super(t, level, description);
+    }
+
+    public LogMessageBuilder(Throwable t, String description) {
+        super(t, description);
+    }
+
+    @Override
+    public String getLoggerName() {
+        return LOG_NAME;
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,11 +10,11 @@
     </appender>
 
     <!-- Use this appender if you want the log output in plain/standard log format. -->
-    <!--<appender name="PLAIN_TEXT" class="ch.qos.logback.core.ConsoleAppender">-->
-        <!--<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">-->
-            <!--<layout class="com.github.onsdigital.logging.layouts.TextLayout"/>-->
-        <!--</encoder>-->
-    <!--</appender>-->
+    <appender name="PLAIN_TEXT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="com.github.onsdigital.logging.layouts.TextLayout"/>
+        </encoder>
+    </appender>
 
     <!--&lt;!&ndash; Use this appender if you want the log output in json &ndash;&gt;-->
     <!--<appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">-->
@@ -29,11 +29,11 @@
     <!--</encoder>-->
     <!--</appender>-->
 
-    <!--<logger name="com.github.onsdigital.babbage" level="debug" additivity="false">-->
-        <!--&lt;!&ndash;<appender-ref ref="JSON"/>&ndash;&gt;-->
-        <!--&lt;!&ndash;<appender-ref ref="PRETTY_JSON"/>&ndash;&gt;-->
-        <!--<appender-ref ref="PLAIN_TEXT"/>-->
-    <!--</logger>-->
+    <logger name="com.github.onsdigital.babbage" level="debug" additivity="false">
+        <!--<appender-ref ref="JSON"/>-->
+        <!--<appender-ref ref="PRETTY_JSON"/>-->
+        <appender-ref ref="PLAIN_TEXT"/>
+    </logger>
 
     <root level="WARN">
         <appender-ref ref="STDOUT" />

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,42 @@
+<configuration>
+
+    <appender name="STDOUT"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <!-- Use this appender if you want the log output in plain/standard log format. -->
+    <!--<appender name="PLAIN_TEXT" class="ch.qos.logback.core.ConsoleAppender">-->
+        <!--<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">-->
+            <!--<layout class="com.github.onsdigital.logging.layouts.TextLayout"/>-->
+        <!--</encoder>-->
+    <!--</appender>-->
+
+    <!--&lt;!&ndash; Use this appender if you want the log output in json &ndash;&gt;-->
+    <!--<appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">-->
+        <!--<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">-->
+            <!--<layout class="com.github.onsdigital.logging.layouts.JsonLayout" />-->
+        <!--</encoder>-->
+    <!--</appender>-->
+
+    <!--<appender name="PRETTY_JSON" class="ch.qos.logback.core.ConsoleAppender">-->
+    <!--<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">-->
+    <!--<layout class="com.github.onsdigital.logging.layouts.PrettyJsonLayout" />-->
+    <!--</encoder>-->
+    <!--</appender>-->
+
+    <!--<logger name="com.github.onsdigital.babbage" level="debug" additivity="false">-->
+        <!--&lt;!&ndash;<appender-ref ref="JSON"/>&ndash;&gt;-->
+        <!--&lt;!&ndash;<appender-ref ref="PRETTY_JSON"/>&ndash;&gt;-->
+        <!--<appender-ref ref="PLAIN_TEXT"/>-->
+    <!--</logger>-->
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
### What

Added dp-logging dependency to babbage and provided a babbage specific implementation of the log builder. 

Currently babbage is using only system.out.println calls to log messages. These log messages have no structure or timestamps which limits their value when debugging.

### How to review

Make a call to the Log class and make sure the log is output correctly.

### Who can review

Anyone but me
