### PR TITLE
Bugfix/update search on delete

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/publishing/Upcoming.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/publishing/Upcoming.java
@@ -2,12 +2,12 @@ package com.github.onsdigital.babbage.api.endpoint.publishing;
 
 import com.github.davidcarboni.cryptolite.Password;
 import com.github.davidcarboni.restolino.framework.Api;
-import com.github.onsdigital.babbage.configuration.Configuration;
 import com.github.onsdigital.babbage.error.BabbageException;
 import com.github.onsdigital.babbage.error.BadRequestException;
 import com.github.onsdigital.babbage.publishing.PublishingManager;
-import com.github.onsdigital.babbage.publishing.model.ResponseMessage;
+import com.github.onsdigital.babbage.publishing.model.ContentDetail;
 import com.github.onsdigital.babbage.publishing.model.PublishNotification;
+import com.github.onsdigital.babbage.publishing.model.ResponseMessage;
 import com.github.onsdigital.babbage.util.json.JsonUtil;
 
 import javax.servlet.http.HttpServletRequest;
@@ -53,9 +53,6 @@ public class Upcoming {
 
     protected Object process(HttpServletResponse response, PublishNotification publishNotification) throws IOException {
         verifyKey(publishNotification);
-        if (!Configuration.GENERAL.isCacheEnabled()) {
-            return new ResponseMessage("Caching is not enabled, ignoring notification");
-        }
         if (verifyUriList) {
             verifyUriList(publishNotification);
         }
@@ -65,8 +62,11 @@ public class Upcoming {
     }
 
     private void verifyUriList(PublishNotification publishNotification) {
-        List<String> uriList = publishNotification.getUrisToUpdate();
-        if (uriList == null || uriList.isEmpty()) {
+        List<String> urisToUpdate = publishNotification.getUrisToUpdate();
+        List<ContentDetail> urisToDelete = publishNotification.getUrisToDelete();
+
+        if ((urisToUpdate == null || urisToUpdate.isEmpty())
+                && (urisToDelete == null || urisToDelete.isEmpty())) {
             throw new BadRequestException("Please speficy uri list");
         }
     }

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentClient.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentClient.java
@@ -185,7 +185,7 @@ public class ContentClient {
         List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair("key", key));
         parameters.add(new BasicNameValuePair("uri", uri));
-        parameters.add(new BasicNameValuePair("contentType", contentType));
+        parameters.add(new BasicNameValuePair("pageType", contentType));
         return sendDelete(getReindexEndpoint(), parameters);
     }
 


### PR DESCRIPTION
### What

The search index was not being updated for deleted content. There were two issues:

- When caching was disabled the 'upcoming' notifications were ignored. There did not appear to be any reason we should do this. We still want to process the notifications so we know what pages need updating in search when a collection is published.
- There was a parameter name mismatch when calling Zebedee from Babbage to delete items from the search index.

### How to review

There is already an automated test that @pathimanoj has created to test this scenario. When a page is deleted from the site it should also no longer be available in search.

### Who can review

Anyone