### PR TITLE
Do not output a stack trace for 404 responses.

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
@@ -36,19 +36,24 @@ public class ErrorHandler implements ServerError {
     }
 
     public static void handle(HttpServletRequest req, HttpServletResponse response, Throwable t) throws IOException {
-        logError(t);
+
         response.setContentType(MediaType.TEXT_HTML);
         if (ContentReadException.class.isAssignableFrom(t.getClass())) {
             ContentReadException exception = (ContentReadException) t;
             renderErrorPage(exception.getStatusCode(), response);//renderTemplate template with status code name e.g. 404
+            logError(t);
             return;
         } else if (t instanceof ResourceNotFoundException) {
+            System.err.println(t.getMessage() + ", cause: " + (t.getCause() != null ? t.getCause().getMessage() : ""));
             renderErrorPage(404, response);
+            return;
         } else if (t instanceof LegacyPDFException) {
             renderErrorPage(501, response);
         } else {
             renderErrorPage(500, response);
         }
+
+        logError(t);
     }
 
 

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentClient.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentClient.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.babbage.content.client;
 
 import com.github.onsdigital.babbage.configuration.Configuration;
+import com.github.onsdigital.babbage.error.ResourceNotFoundException;
 import com.github.onsdigital.babbage.publishing.PublishingManager;
 import com.github.onsdigital.babbage.publishing.model.PublishInfo;
 import com.github.onsdigital.babbage.util.ThreadContext;
@@ -134,11 +135,11 @@ public class ContentClient {
             int maxAge = Configuration.GENERAL.getDefaultContentCacheTime();
             Integer timeToExpire = null;
             if (nextPublishDate != null) {
-                Long time = (nextPublishDate.getTime() - new Date().getTime())/1000;
+                Long time = (nextPublishDate.getTime() - new Date().getTime()) / 1000;
                 timeToExpire = time.intValue();
             }
 
-            if(timeToExpire == null) {
+            if (timeToExpire == null) {
                 response.setMaxAge(maxAge);
             } else if (timeToExpire > 0) {
                 response.setMaxAge(timeToExpire < maxAge ? timeToExpire : maxAge);
@@ -202,7 +203,12 @@ public class ContentClient {
             return new ContentResponse(client.sendGet(path, getHeaders(), getParameters));
         } catch (HttpResponseException e) {
             IOUtils.closeQuietly(response);
+
+            if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND)
+                throw new ResourceNotFoundException(e.getMessage());
+
             throw wrapException(e);
+
         } catch (IOException e) {
             IOUtils.closeQuietly(response);
             throw wrapException(e);


### PR DESCRIPTION
### What

Currently when a requested URI cannot be found a full stack trace is output to the logs. When this happens we only really need the URI. I have updated the logging for ResourceNotFound exceptions so that it still logs the 404, but does not output the stack trace.

### How to review

Review the log output for a page that cannot be found.

### Who can review

Anyone
