### PR TITLE
feature/pipeline-creds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
 
     stage('Image') {
         docker.withRegistry(registry['uri'], { ->
-            sh registry['login']
+            if (registry.containsKey('login')) sh registry['login']
             docker.build(registry['image']).push(registry['tag'])
         })
     }
@@ -58,13 +58,12 @@ def deploymentGroupsFor(branch) {
 def registry(branch, tag) {
     [
         hub: [
-            login: 'docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS',
+            login: 'docker --config .dockerhub login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS',
             image: "${env.DOCKERHUB_REPOSITORY}/babbage",
             tag: 'live',
             uri: "https://${env.DOCKERHUB_REPOSITORY_URI}",
         ],
         ecr: [
-            login: '$(aws ecr get-login)',
             image: 'babbage',
             tag: tag,
             uri: "https://${env.ECR_REPOSITORY_URI}",


### PR DESCRIPTION
### What

Remove explicit ECR login command from build pipeline. We've rolled out the ECR credentials manager now - if we explicitly attempt to call `docker login` an error will now be thrown.

Due to the fact we still push some images to DockerHub, the login command has been modified to use a different configuration directory (credentials manager will complain if we attempt to use the same config).

### How to review

Check the build for this branch is passing.

### Who can review

Anyone but myself.
