### PR TITLE
Bugfix/handle figure 404

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/ChartTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/ChartTagReplacer.java
@@ -46,7 +46,7 @@ public class ChartTagReplacer extends TagReplacementStrategy {
             return TemplateService.getInstance().renderTemplate(template, contentResponse.getDataStream());
         } catch (ResourceNotFoundException e) {
             Log.buildDebug("Failed to find figure data for chart.").addParameter("URL", figureUri).log();
-            return matcher.group();
+            return TemplateService.getInstance().renderTemplate(figureNotFoundTemplate);
         } catch (ContentReadException e) {
             return matcher.group();
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/ChartTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/ChartTagReplacer.java
@@ -3,6 +3,8 @@ package com.github.onsdigital.babbage.template.handlebars.helpers.markdown.util;
 import com.github.onsdigital.babbage.content.client.ContentClient;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.error.ResourceNotFoundException;
+import com.github.onsdigital.babbage.logging.Log;
 import com.github.onsdigital.babbage.template.TemplateService;
 
 import java.io.IOException;
@@ -42,6 +44,9 @@ public class ChartTagReplacer extends TagReplacementStrategy {
         try {
             ContentResponse contentResponse = ContentClient.getInstance().getContent(figureUri);
             return TemplateService.getInstance().renderTemplate(template, contentResponse.getDataStream());
+        } catch (ResourceNotFoundException e) {
+            Log.buildDebug("Failed to find figure data for chart.").addParameter("URL", figureUri).log();
+            return matcher.group();
         } catch (ContentReadException e) {
             return matcher.group();
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/ImageTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/ImageTagReplacer.java
@@ -4,6 +4,8 @@ import com.github.davidcarboni.restolino.json.Serialiser;
 import com.github.onsdigital.babbage.content.client.ContentClient;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.error.ResourceNotFoundException;
+import com.github.onsdigital.babbage.logging.Log;
 import com.github.onsdigital.babbage.template.TemplateService;
 
 import java.io.IOException;
@@ -49,6 +51,9 @@ public class ImageTagReplacer extends TagReplacementStrategy {
         try {
             ContentResponse contentResponse = ContentClient.getInstance().getContent(figureUri);
             return TemplateService.getInstance().renderTemplate(template, contentResponse.getDataStream());
+        } catch (ResourceNotFoundException e) {
+            Log.buildDebug("Failed to find figure data for image.").addParameter("URL", figureUri).log();
+            return matcher.group();
         } catch (ContentReadException e) {
             return TemplateService.getInstance().renderTemplate(template, Serialiser.serialise(new ImageData(figureUri)));
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/ImageTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/ImageTagReplacer.java
@@ -53,7 +53,7 @@ public class ImageTagReplacer extends TagReplacementStrategy {
             return TemplateService.getInstance().renderTemplate(template, contentResponse.getDataStream());
         } catch (ResourceNotFoundException e) {
             Log.buildDebug("Failed to find figure data for image.").addParameter("URL", figureUri).log();
-            return matcher.group();
+            return TemplateService.getInstance().renderTemplate(figureNotFoundTemplate);
         } catch (ContentReadException e) {
             return TemplateService.getInstance().renderTemplate(template, Serialiser.serialise(new ImageData(figureUri)));
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/MathjaxTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/MathjaxTagReplacer.java
@@ -46,7 +46,7 @@ public class MathjaxTagReplacer extends TagReplacementStrategy {
             return TemplateService.getInstance().renderTemplate(template, contentResponse.getDataStream());
         } catch (ResourceNotFoundException e) {
             Log.buildDebug("Failed to find figure data for equation.").addParameter("URL", figureUri).log();
-            return matcher.group();
+            return TemplateService.getInstance().renderTemplate(figureNotFoundTemplate);
         } catch (ContentReadException e) {
             return matcher.group();
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/MathjaxTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/MathjaxTagReplacer.java
@@ -3,6 +3,8 @@ package com.github.onsdigital.babbage.template.handlebars.helpers.markdown.util;
 import com.github.onsdigital.babbage.content.client.ContentClient;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.error.ResourceNotFoundException;
+import com.github.onsdigital.babbage.logging.Log;
 import com.github.onsdigital.babbage.template.TemplateService;
 
 import java.io.IOException;
@@ -42,6 +44,9 @@ public class MathjaxTagReplacer extends TagReplacementStrategy {
         try {
             ContentResponse contentResponse = ContentClient.getInstance().getContent(figureUri);
             return TemplateService.getInstance().renderTemplate(template, contentResponse.getDataStream());
+        } catch (ResourceNotFoundException e) {
+            Log.buildDebug("Failed to find figure data for equation.").addParameter("URL", figureUri).log();
+            return matcher.group();
         } catch (ContentReadException e) {
             return matcher.group();
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TableTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TableTagReplacer.java
@@ -3,6 +3,8 @@ package com.github.onsdigital.babbage.template.handlebars.helpers.markdown.util;
 import com.github.onsdigital.babbage.content.client.ContentClient;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.error.ResourceNotFoundException;
+import com.github.onsdigital.babbage.logging.Log;
 import com.github.onsdigital.babbage.template.TemplateService;
 
 import java.io.IOException;
@@ -50,6 +52,9 @@ public class TableTagReplacer extends TagReplacementStrategy {
             ContentResponse contentResponse = ContentClient.getInstance().getContent(figureUri);
             String result = TemplateService.getInstance().renderTemplate(template, contentResponse.getDataStream());
             return result;
+        } catch (ResourceNotFoundException e) {
+            Log.buildDebug("Failed to find figure data for table.").addParameter("URL", figureUri).log();
+            return matcher.group();
         } catch (ContentReadException e) {
             System.err.println("Failed rendering table, uri:" + figureUri);
             return matcher.group();

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TableTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TableTagReplacer.java
@@ -54,7 +54,7 @@ public class TableTagReplacer extends TagReplacementStrategy {
             return result;
         } catch (ResourceNotFoundException e) {
             Log.buildDebug("Failed to find figure data for table.").addParameter("URL", figureUri).log();
-            return matcher.group();
+            return TemplateService.getInstance().renderTemplate(figureNotFoundTemplate);
         } catch (ContentReadException e) {
             System.err.println("Failed rendering table, uri:" + figureUri);
             return matcher.group();

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TagReplacementStrategy.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TagReplacementStrategy.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 public abstract class TagReplacementStrategy {
 
     private final Path path;
+    static final String figureNotFoundTemplate = "partials/figureNotFound";
 
     /**
      * Create an instance of a tag replacement strategy with the given page path.

--- a/src/main/web/templates/handlebars/content/base/publication.handlebars
+++ b/src/main/web/templates/handlebars/content/base/publication.handlebars
@@ -16,66 +16,76 @@
         {{!-- Content --}}
         <article class="col col--md-36 col--lg-39 page-content__main-content js-sticky-toc__trigger">
             {{#each sections}}
-                <section id="{{slugify title}}" class="section__content--markdown js-sticky-toc__section">
-                    <header>
-                        <h2><span class="section__content-number">{{@index_1}}.</span> {{title}}</h2>
-                    </header>
-                    {{md markdown}}
-                    <a class="print--hide js-scroll" href="#toc">{{labels.back-to-table-of-contents}}</a>
-                </section>
+                <div id="{{slugify title}}" class="section__content--markdown js-sticky-toc__section">
+                    <section>
+                        <header>
+                            <h2><span class="section__content-number">{{@index_1}}.</span> {{title}}</h2>
+                        </header>
+                        {{md markdown}}
+                        <a class="print--hide js-scroll" href="#toc">{{labels.back-to-table-of-contents}}</a>
+                    </section>
+                </div>
             {{/each}}
             <!-- Accordion -->
             {{#if_any accordion relatedMethodology}}
                 <div class="margin-top--4 margin-bottom--4">
                     {{#each accordion}}
-                        <section id="{{slugify title}}" class="js-show-hide js-sticky-toc__section section__content--markdown border-top--iron-sm border-top--iron-md{{#if @last}}{{#unless relatedMethodology}} border-bottom--iron-sm border-bottom--iron-md{{/unless}}{{/if}}">
-                            <div class="show-hide show-hide--light">
-                                <div class="js-show-hide__title">
-                                    <h2 class="show-hide__title flush">
-                                        <span class="section__content-number">{{nf (add sections.size @index_1)}}.</span>{{title}}
-                                    </h2>
+                        <div id="{{slugify title}}" class="js-show-hide js-sticky-toc__section section__content--markdown border-top--iron-sm border-top--iron-md{{#if @last}}{{#unless relatedMethodology}} border-bottom--iron-sm border-bottom--iron-md{{/unless}}{{/if}}">
+                            <section>
+                                <div class="show-hide show-hide--light">
+                                    <div class="js-show-hide__title">
+                                        <h2 class="show-hide__title flush">
+                                            <span class="section__content-number">{{nf (add sections.size @index_1)}}
+                                                .</span>{{title}}
+                                        </h2>
+                                    </div>
+                                    <div class="js-show-hide__content margin-bottom--4">
+                                        {{md markdown}}
+                                        <a class="print--hide js-scroll"
+                                           href="#toc">{{labels.back-to-table-of-contents}}</a>
+                                    </div>
                                 </div>
-                                <div class="js-show-hide__content margin-bottom--4">
-                                    {{md markdown}}
-                                    <a class="print--hide js-scroll" href="#toc">{{labels.back-to-table-of-contents}}</a>
-                                </div>
-                            </div>
-                        </section>
+                            </section>
+                        </div>
                     {{/each}}
                     {{#if relatedMethodology}}
-                        <section id="methodology" class="js-show-hide js-sticky-toc__section section__content--markdown border-top--iron-sm border-top--iron-md border-bottom--iron-sm border-bottom--iron-md">
-                            <div class="show-hide show-hide--light">
-                                <div class="js-show-hide__title">
-                                    <h2 class="show-hide__title flush">
-                                        {{!-- Make section number by adding accordion and section size if accordions exist --}}
-                                        {{#if accordion}}
-                                            <span class="section__content-number">{{nf (increment (add sections.size accordion.size))}}
-                                                .</span>
-                                        {{else}}
-                                        {{!-- If no accordions then add index to number of sections --}}
-                                            <span class="section__content-number">{{nf (increment sections.size)}}
-                                                .</span>{{title}}
-                                        {{/if}}
-                                        Methodology
-                                    </h2>
+                        <div id="methodology" class="js-show-hide js-sticky-toc__section section__content--markdown border-top--iron-sm border-top--iron-md border-bottom--iron-sm border-bottom--iron-md">
+                            <section>
+                                <div class="show-hide show-hide--light">
+                                    <div class="js-show-hide__title">
+                                        <h2 class="show-hide__title flush">
+                                            {{!-- Make section number by adding accordion and section size if accordions exist --}}
+                                            {{#if accordion}}
+                                                <span class="section__content-number">{{nf
+                                                        (increment (add sections.size accordion.size))}}
+                                                    .</span>
+                                            {{else}}
+                                            {{!-- If no accordions then add index to number of sections --}}
+                                                <span class="section__content-number">{{nf (increment sections.size)}}
+                                                    .</span>{{title}}
+                                            {{/if}}
+                                            Methodology
+                                        </h2>
+                                    </div>
+                                    <div class="js-show-hide__content margin-bottom--3">
+                                        <ul class="list--neutral">
+                                            {{#each relatedMethodology}}
+                                                {{#resolve this.uri filter="description"}}
+                                                    <li><a href="{{absolute uri}}">{{description.title}}</a></li>
+                                                {{/resolve}}
+                                            {{/each}}
+                                            {{#each relatedMethodologyArticle}}
+                                                {{#resolve this.uri filter="description"}}
+                                                    <li><a href="{{absolute uri}}">{{description.title}}</a></li>
+                                                {{/resolve}}
+                                            {{/each}}
+                                        </ul>
+                                        <a class="print--hide js-scroll"
+                                           href="#toc">{{labels.back-to-table-of-contents}}</a>
+                                    </div>
                                 </div>
-                                <div class="js-show-hide__content margin-bottom--3">
-                                    <ul class="list--neutral">
-                                        {{#each relatedMethodology}}
-                                            {{#resolve this.uri filter="description"}}
-                                                <li><a href="{{absolute uri}}">{{description.title}}</a></li>
-                                            {{/resolve}}
-                                        {{/each}}
-                                        {{#each relatedMethodologyArticle}}
-                                            {{#resolve this.uri filter="description"}}
-                                                <li><a href="{{absolute uri}}">{{description.title}}</a></li>
-                                            {{/resolve}}
-                                        {{/each}}
-                                    </ul>
-                                    <a class="print--hide js-scroll" href="#toc">{{labels.back-to-table-of-contents}}</a>
-                                </div>
-                            </div>
-                        </section>
+                            </section>
+                        </div>
                     {{/if}}
                 </div>
             {{/if_any}}

--- a/src/main/web/templates/handlebars/partials/figureNotFound.handlebars
+++ b/src/main/web/templates/handlebars/partials/figureNotFound.handlebars
@@ -1,1 +1,3 @@
-<div class="missing-figure">Fix me</div>
+<div class="markdown-chart-container markdown-chart-container--error panel--bottom-mar print--avoid-break">
+    <span class="markdown-chart-container--error__message">Chart unavailable</span>
+</div>

--- a/src/main/web/templates/handlebars/partials/figureNotFound.handlebars
+++ b/src/main/web/templates/handlebars/partials/figureNotFound.handlebars
@@ -1,0 +1,1 @@
+<div class="missing-figure">Fix me</div>


### PR DESCRIPTION
### What

Handle resource not found exceptions when a figure link is broken. Currently the entire page fails to render and a HTTP 500 error is returned. There is now a template that gets rendered for broken links so that is visible to publishers that the link is broken.

### How to review

Add a new chart in Florence, then delete it from the list of charts but not from the markdown. You should get shown a 'Chart unavailable' in it's original space on babbage now.

### Who can review

Anyone
