### PR TITLE
Fix incorrect JS file/s being request in embedded chart template

### DIFF
--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,12 +51,8 @@ The commented code below is what needs to go in the parent.
   {{/if}}
 {{/if}}
 
-{{#if is_dev}}
-  <script type="text/javascript" src="//{{location.hostname}}:9000/dist/js/main.js"></script>
-  <script type="text/javascript" src="/js/app.js"></script>
-{{else}}
-  <script type="text/javascript" src="/assets/js/babbage.js"></script>
-{{/if}}
+<script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/6cc1837{{/if}}/js/main.js"></script>
+<script type="text/javascript" src="/js/app.js"></script>
 
 <script type="text/javascript" src="//pym.nprapps.org/pym.v1.min.js"></script>
 


### PR DESCRIPTION
### What

Embeddable charts weren't working, eg
https://www.ons.gov.uk/embed?uri=/economy/nationalaccounts/balanceofpayments/bulletins/uktrade/june2016/ce82974b

They were trying to use the old `assets/babbage.js` instead of the latest version where the `app.js` and sixteens `main.js` were split up. At the time main.handlebars must've been updated but this template was missed.

### How to review

JS requests in `embeddedchart.handlebars` matches those in `main.handlebars`. It's difficult to test locally because it'll attempt to use local JS files instead. If these match though then it should be fine.

### Who can review

Anyone but me (@Crispioso).
