### PR TITLE
Feature/update dd urls

### DIFF
--- a/src/main/web/templates/handlebars/content/t8-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t8-3.handlebars
@@ -178,6 +178,11 @@
                     {{#if_any
                             (eq uri "/peoplepopulationandcommunity/housing/datasets/membersofthearmedforcesbyresidencetypebysexbyageaf001ew")
                             (eq uri "/economy/inflationandpriceindices/datasets/consumerpricesindexcoicop")
+                            (eq uri "/businessindustryandtrade/business/businessservices/datasets/annualbusinesssurveynumberofenterprises")
+                            (eq uri "/businessindustryandtrade/business/businessservices/datasets/annualbusinesssurveyemployment")
+                            (eq uri "/businessindustryandtrade/business/businessservices/datasets/annualbusinesssurveyukbusinessvalue")
+                            (eq uri "/economy/inflationandpriceindices/datasets/consumerpricesindexspecialaggregate")
+                            (eq uri "/businessindustryandtrade/manufacturingandproductionindustry/datasets/ukmanufacturerssalesbyproductprodcom01")
                     }}
                         <div id="js-dd-dimensions"></div>
                         <h2 class="margin-bottom--1">Editions</h2>


### PR DESCRIPTION
### What

Add following URLs as DD datasets, so script runs to enhance them with DD functionality:

- /businessindustryandtrade/business/businessservices/datasets/annualbusinesssurveynumberofenterprises                         - /businessindustryandtrade/business/businessservices/datasets/annualbusinesssurveyemployment
- /businessindustryandtrade/business/businessservices/datasets/annualbusinesssurveyukbusinessvalue
- /economy/inflationandpriceindices/datasets/consumerpricesindexspecialaggregate
- /businessindustryandtrade/manufacturingandproductionindustry/datasets/ukmanufacturerssalesbyproductprodcom01

### How to review

Existing datasets aren't broken and a check that those match the URLs Rob Chamber has requested to be added.

### Who can review

Anyone but me
