### PR TITLE
New shortcut for Economic statistics and analysis strategy

### DIFF
--- a/src/main/resources/url-shortcuts/shortcut-url-mapping.csv
+++ b/src/main/resources/url-shortcuts/shortcut-url-mapping.csv
@@ -3,3 +3,4 @@
 /aes,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/adulteducationsurveyaes,
 /datacampus,/aboutus/whatwedo/datasciencecampus,
 /datasciencecampus,/aboutus/whatwedo/datasciencecampus,
+/esas,/methodology/classificationsandstandards/economicstatisticsclassifications/economicstatisticsandanalysisstrategy,

--- a/src/main/resources/url-shortcuts/shortcut-url-mapping.csv
+++ b/src/main/resources/url-shortcuts/shortcut-url-mapping.csv
@@ -4,3 +4,5 @@
 /datacampus,/aboutus/whatwedo/datasciencecampus,
 /datasciencecampus,/aboutus/whatwedo/datasciencecampus,
 /esas,/methodology/classificationsandstandards/economicstatisticsclassifications/economicstatisticsandanalysisstrategy,
+/censushelp,/census/censustransformationprogramme/2017censustest,
+/helpcyfrifiad,/census/censustransformationprogramme/2017censustest,ons_welsh_domain


### PR DESCRIPTION
https://www.ons.gov.uk/esas to redirect to https://www.ons.gov.uk/methodology/classificationsandstandards/economicstatisticsclassifications/economicstatisticsandanalysisstrategy,

### What

New redirect

### How to review

Ensure /esas redirects to right place (page will 404 on develop)

### Who can review

Anyone other than Rob
