### PR TITLE
Updated to latest sixteens (4bb14b9) and remove icon--hide class

### DIFF
--- a/src/main/web/templates/handlebars/content/partials/metadata/contact.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/metadata/contact.handlebars
@@ -1,6 +1,6 @@
 {{!-- Contact --}}
 <p class="col {{class}} meta__item">
-    {{#if description.nationalStatistic}} <a class="icon--hide"
+    {{#if description.nationalStatistic}} <a
             href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
             class="meta__image" src="/img/national-statistics.png"
             alt="National Statistics logo"/></a>{{/if}}

--- a/src/main/web/templates/handlebars/content/partials/metadata/ns-logo.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/metadata/ns-logo.handlebars
@@ -1,7 +1,7 @@
 {{!-- NS logo --}}
 {{#if description.nationalStatistic}}
 <p class="col col--md-4 col--lg-4 padding-left">
-    <a class="icon--hide" href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
+    <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
             class="meta__image" src="/node_modules/ONS-Pattern-Library/dist/img/national-statistics.png"
             alt="National Statistics logo"/></a>
 </p>

--- a/src/main/web/templates/handlebars/content/t1.handlebars
+++ b/src/main/web/templates/handlebars/content/t1.handlebars
@@ -91,7 +91,7 @@
                     <div class="col col--md-11 col--lg-14 height-sm--23 height-md--23 background--white margin-left-md--1 margin-bottom--2 js-hover-click">
                         <div class="padding-left--1 padding-right--1 padding-top--2 padding-bottom--1">
                             <div class="box__content box__content--homepage height--23 padding-top-md--11 padding-top-lg--14 padding-left-sm--10">
-                                <h2 class="tiles__title tiles__title-h2--home"><a class="icon--hide" href="https://www.gov.uk/government/statistics" target="_blank">{{labels.other-official-statistics}}<span class="image-holder width-sm--9 width-md--9 width-lg--12"><img src="../../img/t1-gov-uk--black.png" alt="GOV.UK logo" class="no-border"></span></a></h2>
+                                <h2 class="tiles__title tiles__title-h2--home"><a href="https://www.gov.uk/government/statistics" target="_blank">{{labels.other-official-statistics}}<span class="image-holder width-sm--9 width-md--9 width-lg--12"><img src="../../img/t1-gov-uk--black.png" alt="GOV.UK logo" class="no-border"></span></a></h2>
                                 <p class="hide--md hide--lg">{{labels.find-official-statistics-produced-by-other-governmnet-departments}}</p>
                             </div>
                         </div>

--- a/src/main/web/templates/handlebars/content/t7-1.handlebars
+++ b/src/main/web/templates/handlebars/content/t7-1.handlebars
@@ -60,7 +60,7 @@
                     {{#if description.nationalStatistic}}
 
                         <div class="col col--md-4 {{#if_all description.surveyName description.frequency description.compilation description.sampleSize description.geographicCoverage}}col--lg-5{{else}}col--lg-4{{/if_all}}">
-                            <a class="icon--hide" href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
+                            <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
                                     class="meta__image padding-left padding-top--half"
                                     src="/img/national-statistics.png" alt="National Statistics logo"/></a>
                         </div>

--- a/src/main/web/templates/handlebars/list/t11.handlebars
+++ b/src/main/web/templates/handlebars/list/t11.handlebars
@@ -34,7 +34,7 @@
 {{#partial "block-results-extra"}}
 	<p class="float-right margin-top-sm--0 margin-top-md--3 margin-bottom-sm--0 margin-bottom-md--0">
         <a id="rss-calendar-link" class="margin-right--2" href="feed://{{location.host}}{{location.pathname}}?rss{{#if parameters.view.0}}&view={{parameters.view.0}}{{/if}}{{#if parameters.query.0}}&query={{parameters.query.0}}{{/if}}"><span class="icon icon-rss--dark-small"></span>RSS feed</a>
-		<a class="margin-right--2 icon--hide" href="https://public.govdelivery.com/accounts/UKONS/subscribers/new">
+		<a class="margin-right--2" href="https://public.govdelivery.com/accounts/UKONS/subscribers/new">
             <span class="icon icon-email--dark-small"></span>
             Email alerts
         </a>

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -17,14 +17,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1e59ad8{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/4bb14b9{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1e59ad8{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/4bb14b9{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1e59ad8{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1e59ad8{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/4bb14b9{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/4bb14b9{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
         <!-- Google Tag Manager -->
@@ -138,7 +138,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1e59ad8{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/4bb14b9{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
         <![endif]-->
 	</body>

--- a/src/main/web/templates/handlebars/partials/footer.handlebars
+++ b/src/main/web/templates/handlebars/partials/footer.handlebars
@@ -42,18 +42,16 @@
                         <h3 class="footer-nav__heading">{{labels.connect-with-us}}</h3>
                         <ul class="footer-nav__list">
                             <li class="footer-nav__item">
-                                <a href="https://twitter.com/ONS" class="icon--hide">{{labels.twitter}}</a>
+                                <a href="https://twitter.com/ONS">{{labels.twitter}}</a>
                             </li>
                             <li class="footer-nav__item">
-                                <a href="https://www.facebook.com/ONS" class="icon--hide">{{labels.facebook}}</a>
+                                <a href="https://www.facebook.com/ONS">{{labels.facebook}}</a>
                             </li>
                             <li class="footer-nav__item">
-                                <a href="https://www.linkedin.com/company/office-for-national-statistics"
-                                   class="icon--hide">{{labels.linkedin}}</a>
+                                <a href="https://www.linkedin.com/company/office-for-national-statistics">{{labels.linkedin}}</a>
                             </li>
                             <li class="footer-nav__item">
-                                <a href="https://public.govdelivery.com/accounts/UKONS/subscribers/new"
-                                   class="icon--hide">{{labels.email-alerts}}</a>
+                                <a href="https://public.govdelivery.com/accounts/UKONS/subscribers/new">{{labels.email-alerts}}</a>
                             </li>
                         </ul>
                     </div>

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -25,11 +25,11 @@
                         <dt class="language__title">Language:</dt>
                         {{#if_eq location.hostname (concat "cy." (replace location.hostname "cy." ""))}}
                             <dd class="language__item">
-                                <a href="{{> partials/language-toggle language="en"}}" class="language__link icon--hide">English (EN)</a>
+                                <a href="{{> partials/language-toggle language="en"}}" class="language__link">English (EN)</a>
                             </dd>
                         {{else}}
                             <dd class="language__item">
-                                <a href="{{> partials/language-toggle language="cym"}}" class="language__link icon--hide">Cymraeg (CY)</a>
+                                <a href="{{> partials/language-toggle language="cym"}}" class="language__link">Cymraeg (CY)</a>
                             </dd>
                         {{/if_eq}}
                     </dl>
@@ -56,7 +56,7 @@
 							<a class="secondary-nav__link {{#if_eq uri '/aboutus'}}secondary-nav__link--active{{/if_eq}} js-nav-clone__link" href="/aboutus">{{labels.about}}</a>
 						</li>
 						<li class="secondary-nav__item">
-							<a class="secondary-nav__link icon--hide js-nav-clone__link" target="_blank" rel="noopener noreferrer" href="https://blog.ons.gov.uk/">{{labels.blog}}</a>
+							<a class="secondary-nav__link js-nav-clone__link" target="_blank" rel="noopener noreferrer" href="https://blog.ons.gov.uk/">{{labels.blog}}</a>
 						</li>
 					</ul>
 				</div>

--- a/src/main/web/templates/handlebars/pdf/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/pdf/partials/header.handlebars
@@ -16,12 +16,15 @@
 
 <div class="meta">
     <div class="meta__block meta__block--ns">
-        {{#if description.nationalStatistic}} <a class="icon--hide"
-                                                 href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
-                class="meta__image"
-                src="https://www.ons.gov.uk/img/national-statistics.png"
-                alt="National Statistics logo" width="47"
-                height="47"/></a>{{/if}}
+        {{#if description.nationalStatistic}}
+            <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">
+                <img
+                    class="meta__image"
+                    src="https://www.ons.gov.uk/img/national-statistics.png"
+                    alt="National Statistics logo" width="47"
+                    height="47"/>
+            </a>
+        {{/if}}
     </div>
     <div class="meta__block">
         <p class="flush">


### PR DESCRIPTION
### What

The related [sixteens PR](https://github.com/ONSdigital/sixteens/pull/18) must be approved and built first. Then check the sixteens ID used in PR is matches that from Jenkins build logs.

Updated to latest sixteens, which has removed the external link icon. Also remove the class `icon--hide` because it's no longer needed to suppress external link icon.

### How to review

No external link icon shows on any links.

### Who can review

@jondewijones 
