### PR TITLE
Remove hardcoded target=_blank attribute and hardcoded external link icon

### DIFF
--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -21,7 +21,7 @@ census=Census
 discover-how-our-census-statistics-help-paint-a-picture-of-the-nation-and-how-we-live=Discover how our census statistics help paint a picture of the nation and how we live
 visualons-is-a-website-exploring-new-approaches-to-making-ons-statistics-accessible-and-relevant-to-a-wide-public-audience=Visual.ONS is a website exploring new approaches to making ONS statistics accessible and relevant to a wide public audience
 legal=Legal
-ogl=All content is available under the <a class="icon--hide" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a> <span class="icon icon-external--light-small"></span>, except where otherwise stated
+ogl=All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated
 business-transparency=Business transparency
 terms-and-conditions=Terms and conditions
 copyright=Copyright

--- a/src/main/resources/LabelsBundle_cy.properties
+++ b/src/main/resources/LabelsBundle_cy.properties
@@ -22,7 +22,7 @@ census=Cyfrifiad
 discover-how-our-census-statistics-help-paint-a-picture-of-the-nation-and-how-we-live=Darganfyddwch sut mae ein hystadegau o'r Cyfrifiad yn helpu i roi darlun o'r wlad a'r ffordd rydym yn byw
 visualons-is-a-website-exploring-new-approaches-to-making-ons-statistics-accessible-and-relevant-to-a-wide-public-audience=Mae Visual.ONS yn wefan sy'n archwilio i ddulliau newydd o wneud ystadegau ONS yn hygyrch ac yn berthnasol i gynulleidfa gyhoeddus eang.
 legal=Cyfreithiol
-ogl=Mae'r holl gynnwys ar gael o dan delerau'r <a class="icon--hide" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Drwydded Llywodraeth Agored f3.0</a> <span class="icon icon-external--light-small"></span>, ac eithrio lle y nodir fel arall
+ogl=Mae'r holl gynnwys ar gael o dan delerau'r <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Drwydded Llywodraeth Agored f3.0</a>, ac eithrio lle y nodir fel arall
 business-transparency=Tryloywder busnes
 terms-and-conditions=Telerau ac amodau
 copyright=Hawlfraint

--- a/src/main/web/templates/handlebars/content/t1.handlebars
+++ b/src/main/web/templates/handlebars/content/t1.handlebars
@@ -91,7 +91,7 @@
                     <div class="col col--md-11 col--lg-14 height-sm--23 height-md--23 background--white margin-left-md--1 margin-bottom--2 js-hover-click">
                         <div class="padding-left--1 padding-right--1 padding-top--2 padding-bottom--1">
                             <div class="box__content box__content--homepage height--23 padding-top-md--11 padding-top-lg--14 padding-left-sm--10">
-                                <h2 class="tiles__title tiles__title-h2--home"><a href="https://www.gov.uk/government/statistics" target="_blank">{{labels.other-official-statistics}}<span class="image-holder width-sm--9 width-md--9 width-lg--12"><img src="../../img/t1-gov-uk--black.png" alt="GOV.UK logo" class="no-border"></span></a></h2>
+                                <h2 class="tiles__title tiles__title-h2--home"><a href="https://www.gov.uk/government/statistics">{{labels.other-official-statistics}}<span class="image-holder width-sm--9 width-md--9 width-lg--12"><img src="../../img/t1-gov-uk--black.png" alt="GOV.UK logo" class="no-border"></span></a></h2>
                                 <p class="hide--md hide--lg">{{labels.find-official-statistics-produced-by-other-governmnet-departments}}</p>
                             </div>
                         </div>

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -56,7 +56,7 @@
 							<a class="secondary-nav__link {{#if_eq uri '/aboutus'}}secondary-nav__link--active{{/if_eq}} js-nav-clone__link" href="/aboutus">{{labels.about}}</a>
 						</li>
 						<li class="secondary-nav__item">
-							<a class="secondary-nav__link js-nav-clone__link" target="_blank" rel="noopener noreferrer" href="https://blog.ons.gov.uk/">{{labels.blog}}</a>
+							<a class="secondary-nav__link js-nav-clone__link" rel="noopener noreferrer" href="https://blog.ons.gov.uk/">{{labels.blog}}</a>
 						</li>
 					</ul>
 				</div>


### PR DESCRIPTION
### What

Remove `target="_blank"` from GOV.UK link on homepage and link to blog in header.

Also remove external link icon from OGL link.

### How to review

Blog and GOV.UK link on homepage don't open in new window. OGL link in footer doesn't show icon or open in new window.

### Who can review

Anyone but me.
