### PR TITLE
Add annotationOptions property to hide annotation options pane

### DIFF
--- a/src/main/web/templates/handlebars/highcharts/config/linechartconfig.handlebars
+++ b/src/main/web/templates/handlebars/highcharts/config/linechartconfig.handlebars
@@ -100,6 +100,10 @@ var linechart = {
      enabled: false
    },
 
+    annotationsOptions: {
+        enabledButtons: false
+    },
+
    plotOptions: {
      series: {
        turboThreshold:0,


### PR DESCRIPTION
### What

Removed annotation options panel from timeseries charts

### How to review

Check options panel no longer appears and that timeseries charts still work. May need to re run Babbage to see change

### Who can review

Anyone
