### PR TITLE
Fix x axis labels not displaying labels for timeseries and sparkline images

### DIFF
--- a/src/main/web/templates/handlebars/highcharts/config/linechartconfig.handlebars
+++ b/src/main/web/templates/handlebars/highcharts/config/linechartconfig.handlebars
@@ -46,7 +46,7 @@ var linechart = {
      }
    },
    xAxis: {
-     categories: [],
+     categories: [{{#each series}}"{{name}}",{{/each}}],
       tickPositioner: function () {
        var positions = [];
        var increment = Math.ceil(((this.dataMax) - (this.dataMin)) / 16);
@@ -64,22 +64,22 @@ var linechart = {
        return positions;
      },
      labels: {
-       formatter: function() {
-         var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-         var response = '';
-         if (w < 768) {
-           if (this.isFirst) {
-             count = 0;
-           }
-           if (count % 4 === 0 || this.isLast) {
-             response = this.value;
-           }
-           count++;
-         } else {
-           response = this.value;
-         }
-         return response;
-       }
+        formatter: function() {
+          var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+          var response = '';
+          if (w < 768) {
+            if (this.isFirst) {
+              count = 0;
+            }
+            if (count % 4 === 0 || this.isLast) {
+              response = this.value;
+            }
+            count++;
+          } else {
+            response = this.value;
+          }
+          return response;
+        }
      },
      tickmarkPlacement: 'on'
    },

--- a/src/main/web/templates/handlebars/highcharts/config/sparklineconfig.handlebars
+++ b/src/main/web/templates/handlebars/highcharts/config/sparklineconfig.handlebars
@@ -27,7 +27,7 @@ var sparkline{{description.cdid}} = {
 		enabled: false
 	},
 	xAxis: {
-		categories: [],
+		categories: [{{#each series}}"{{name}}",{{/each}}],
 		labels: {
 			crop: false,
 			style: {


### PR DESCRIPTION
### What

Timeseries and sparkline PNG images were just showing number eg `325`, instead of the label text eg `June 2016`.

### How to review

Both sparkline and timeseries images show same axis label as is shown on client rendered ones. Either show them by downloading their image or turning JS off.

### Who can review

Jon Jones plz.
