### PR TITLE
Only call extra source files if page contains charts

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -116,10 +116,14 @@
         <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/81674c0{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
-        <script type="text/javascript" src="/js/third-party/highcharts-annotations-5.0.7.js"></script>
-        <script type="text/javascript" src="/js/third-party/highcharts-broken-axis-5.0.7.js"></script>
-		<script type="text/javascript" src="/js/third-party/highcharts-heatmap-5.0.7.js"></script>
-		<script type="text/javascript" src="/js/third-party/highcharts-exporting-5.0.7.js"></script>
+        {{!-- Add extra highcharts source files if page contains any charts --}}
+        {{#if charts.0}}
+            <script type="text/javascript" src="/js/third-party/highcharts-annotations-5.0.7.js"></script>
+            <script type="text/javascript" src="/js/third-party/highcharts-broken-axis-5.0.7.js"></script>
+            <script type="text/javascript" src="/js/third-party/highcharts-heatmap-5.0.7.js"></script>
+            <script type="text/javascript" src="/js/third-party/highcharts-exporting-5.0.7.js"></script>
+        {{/if}}
+
         <![endif]-->
         <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
### What

Add if statement around extra highchart source files to prevent them being called when no charts are on the page

### How to review

Check that extra files are called when charts are added to a page and test all new charts still work

### Who can review

@Crispioso 
