### PR TITLE
Fix tracking external links click

### DIFF
--- a/src/main/web/js/app/analytics.js
+++ b/src/main/web/js/app/analytics.js
@@ -15,7 +15,10 @@ var trackEvent = function(category, label) {
 
 $(function() {
     // external link tracking
-    $("a[target='_blank']").on( "click", function() {
+    var $externalLinks = $("a").filter(function() {
+        return this.hostname && this.hostname !== location.hostname;
+    });
+    $externalLinks.on( "click", function(evt) {
         var href = $(this).attr("href");
         trackEvent("outbound", href);
     });


### PR DESCRIPTION
### What

Fix external link clicks, so that Google Analytics even is sent whenever an external link is clicked. This was broken after removing auto-generated of the `target="_blank"` on links with external hrefs.

### How to review

Try a few links to check that the correct link clicks are being captured and sending the right GA event.

### Who can review

Jon Jones
