### PR TITLE
Show correct labels on timeseries after frequency/period change

### DIFF
--- a/src/main/web/js/app/linechart.js
+++ b/src/main/web/js/app/linechart.js
@@ -225,8 +225,8 @@ var renderLineChart = function (timeseries) {
 
 
     function renderChart() {
-        //console.log(chartData);
         chart.series[0].data = chartData.values;
+        chart.xAxis.categories = categories(chartData.values);
         chart.xAxis.tickInterval = tickInterval(chartData.values.length);
         if (!timeseries.description.isIndex) {
             var min = chartData.min;
@@ -252,6 +252,18 @@ var renderLineChart = function (timeseries) {
         } else if (to < from) {
             throw new Error('Sorry, the chosen date range is not valid');
         }
+    }
+
+    function categories(values) {
+        var length = values.length;
+        var index = 0;
+        var categories = [];
+
+        for (index; index < length; index++) {
+            categories.push(values[index].label)
+        }
+
+        return categories;
     }
 
     function tickInterval(length) {


### PR DESCRIPTION
### What

Labels weren't updating to show correct range/frequency after the timeseries has been changed using the radio buttons. See [an example on the live site](https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/lf24/lms).

### How to review

Timeseries labels update to correct frequency and period now. See sandpit for a working version to compare against.

### Who can review

Jon Jones
