### PR TITLE
Remove header stopping telephone format detection

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -11,7 +11,6 @@
         <meta charset="utf-8" />
         <meta content="width=device-width,initial-scale=1.0,user-scalable=1" name="viewport">
         <meta content="on" http-equiv="cleartype" />
-        <meta name="format-detection" content="telephone=no">
         <meta name="theme-color" content="#58595B">
         <meta name="apple-mobile-web-app-status-bar-style" content="#58595B">
 


### PR DESCRIPTION
### What
Remove header stopping telephone format detection so phone numbers open properly in mobile

### How to review

Meta tag for format detection header has been removed.

### Who can review

Anyone but me.
