### PR TITLE
Fix right aligned yAxis titles

### DIFF
--- a/src/main/web/templates/handlebars/highcharts/config/base/base-chart-config.handlebars
+++ b/src/main/web/templates/handlebars/highcharts/config/base/base-chart-config.handlebars
@@ -311,7 +311,7 @@ TODO: split out colours palette selection, axis alignment and positioning
     {{else}}
     	{{#if_eq yAxisPos "right"}}
 	options.yAxis.title.align = 'high';
-	//options.yAxis.title.offset = (-1 * textWidth);
+	options.yAxis.title.offset = (-1 * textWidth);
 	options.yAxis.title.y = -4;
     	{{else}}
 	options.yAxis.title.align = 'high';


### PR DESCRIPTION
### What

Stop axis title disappearing off side of highcharts container when yAxis right aligned.

### How to review

A quick code review and checking that when switching a yAxis title to align right in Florence it now shows on the preview and on Babbage.

### Who can review

@jondewijones 
