### PR TITLE
Remove location.hostname from beginning of unpublished related publication

### DIFF
--- a/src/main/web/templates/handlebars/partials/related/documents.handlebars
+++ b/src/main/web/templates/handlebars/partials/related/documents.handlebars
@@ -35,7 +35,7 @@
 
 							{{else}}
 								<li>
-									[Unpublished] <span class="break-word">{{location.host}}{{uri}}</span>
+									[Unpublished] <span class="break-word">{{uri}}</span>
 								</li>
 							{{/resolve}}
 						{{/if_eq}}


### PR DESCRIPTION
### What

On publishing the page would show `babbage:8080` before the URL to any publication - it now just shows the relative path.

### How to review

Simple code check should be fine.

### Who can review

Jon Jones
