### PR TITLE
Add 'startsWith' string helper and only have google tag manager on certain pages

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
@@ -49,6 +49,21 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
         }
     },
 
+    startsWith {
+        @Override
+        public CharSequence apply(String context, Options options) throws IOException {
+            if (options.isFalsy(context) || options.params.length == 0) {
+                return null;
+            }
+            return context.startsWith(options.<String>param(0)) ? "true" : null;
+        }
+
+        @Override
+        public void register(Handlebars handlebars) {
+            handlebars.registerHelper(this.name(), this);
+        }
+    },
+
     endsWith {
         @Override
         public CharSequence apply(String context, Options options) throws IOException {

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -40,7 +40,7 @@
 	<body class="{{type}}">
 
 		{{!-- Testing Google Tag Manager on a few specific URLs --}}
-		{{#if_any (eq uri "/aboutus") (eq uri "/surveys")}}
+		{{#if_any (startsWith uri "/aboutus") (startsWith uri "/surveys")}}
 			<!-- Google Tag Manager (noscript) -->
 			<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
 			height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -27,7 +27,7 @@
         <![endif]-->
 
 		{{!-- Testing Google Tag Manager on a few specific URLs --}}
-		{{#if_any (eq uri "/aboutus") (eq uri "/surveys")}}
+		{{#if_any (startsWith uri "/aboutus") (startsWith uri "/surveys")}}
 			<!-- Google Tag Manager -->
 			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -143,9 +143,10 @@
         {{/if}}
 
         <![endif]-->
-
 		{{!-- Testing Google Tag Manager on a few specific URLs, so removing old GA code on them --}}
-		{{#if_all (ne uri "/aboutus") (ne uri "/surveys")}}
+		{{!-- This conditional is pretty ugly - it is basically saying that we want this code block to 
+		render on any page that doesn't start with '/aboutus' or '/surveys' --}}
+		{{#if_all (ne (startsWith uri "/aboutus") "true") (ne (startsWith uri "/surveys") "true")}}
 			<script>
 				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
### What

- Added a string helper to determine whether a string starts with a particular subString.
- Used the new helper to only use Google Tag Manager on pages that starts with '/aboutus' and '/surveys'.

### How to review

A code check over the Java stuff would be needed.

### Who can review

Anyone but me
