### PR TITLE
set page title on 404

### DIFF
--- a/src/main/web/templates/handlebars/partials/page-title.handlebars
+++ b/src/main/web/templates/handlebars/partials/page-title.handlebars
@@ -15,5 +15,5 @@
     {{#if_eq listType "releasecalendar"}}Release calendar{{/if_eq}}
     {{#if_eq listType "timeseriestool"}}Time series explorer{{/if_eq}}
 {{else}}
-    {{#if description.title}}{{description.title}}{{else}}{{{sub (sup title clear=true) clear=true}}}{{/if}}
+    {{#if description.title}}{{description.title}}{{else}}{{#if title}}{{{sub (sup title clear=true) clear=true}}}{{else}}Page not found{{/if}}{{/if}}
 {{/if_eq}}


### PR DESCRIPTION
### What

Set the page title for 404 pages to 'Page not found'

### How to review

* Run babbage
* Check the title on http://localhost:8080/a/b/c displays "Page not found - Office for National Statistics"

### Who can review

@Crispioso 
