### PR TITLE
Update to new banner styling and position

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -16,14 +16,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/ee328ac{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/ee328ac{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/ee328ac{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/ee328ac{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
 		{{!-- Testing Google Tag Manager on a few specific URLs --}}
@@ -131,7 +131,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/ee328ac{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -5,12 +5,6 @@
     </a>
 	{{!-- produced for download analytics function --}}
 	<div id="pagePath" class="hide">{{uri}}</div>
-	{{!-- Prototype banner --}}
-	<div class="beta-banner">
-		<div class="wrapper">
-			{{#resolve "/"}}{{md serviceMessage}}{{/resolve}}
-		</div>
-	</div>
 	{{!-- LANGUAGE TOGGLE AND SECONDARY NAV - DESKTOP --}}
 		<div class="wrapper">
 			<div class="header col-wrap">
@@ -129,4 +123,22 @@
 			</div>
 		</div>
 	{{/block}}
+
+	{{!-- BANNER --}}
+	{{#resolve "/"}}
+		{{#if serviceMessage}}
+			<div class="banner">
+				<div class="wrapper">
+					<div class="col-wrap">
+						<div class="col">
+							<span class="banner__icon icon icon-info"></span>
+							<div class="banner__body">
+								{{md serviceMessage}}
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		{{/if}}
+	{{/resolve}}
 </header>


### PR DESCRIPTION
### What

Update banner to latest styling update:
https://onsdigital.github.io/dp-ux/sprint/14/pop-up-alternatives/option-3

### How to review

- Make sure you've pulled the latest version on Sixteens develop branch.
- Start up Babbage on this branch
- Add a service message in Florence (it can be found in the homepage)
- On the frontend it should be shown as the new design (linked above)
- Remove the message again in Florence and it should no longer show

### Who can review

Anyone but me.
