### PR TITLE
Move banner location on search results pages

### DIFF
--- a/src/main/web/templates/handlebars/list/t10-2.handlebars
+++ b/src/main/web/templates/handlebars/list/t10-2.handlebars
@@ -2,6 +2,9 @@
 {{/partial}}
 
 {{#partial "block-search-bar"}}
+	<div class="hide--sm">
+		{{> partials/banner}}
+	</div>
 	{{> list/partials/search-header}}
 	<div class="background--ship-grey padding-top-sm--2">
 		<div class="wrapper">

--- a/src/main/web/templates/handlebars/list/t10-3.handlebars
+++ b/src/main/web/templates/handlebars/list/t10-3.handlebars
@@ -2,6 +2,9 @@
 {{/partial}}
 
 {{#partial "block-search-bar"}}
+	<div class="hide--sm">
+		{{> partials/banner}}
+	</div>
 	{{> list/partials/search-header}}
 	<div class="background--ship-grey padding-top-sm--2">
 		<div class="wrapper">

--- a/src/main/web/templates/handlebars/list/t10.handlebars
+++ b/src/main/web/templates/handlebars/list/t10.handlebars
@@ -2,6 +2,7 @@
 {{/partial}}
 
 {{#partial "block-search-bar"}}
+    {{> partials/banner}}
 	{{> list/partials/search-header}}
 	<div class="background--ship-grey padding-top-sm--2">
 		<div class="wrapper">

--- a/src/main/web/templates/handlebars/list/t10.handlebars
+++ b/src/main/web/templates/handlebars/list/t10.handlebars
@@ -2,7 +2,10 @@
 {{/partial}}
 
 {{#partial "block-search-bar"}}
-    {{> partials/banner}}
+    {{!-- Banner on small on search pages goes above 'menu' and 'search' buttons, so is in header.handlers file --}}
+    <div class="hide--sm">
+		{{> partials/banner}}
+	</div>
 	{{> list/partials/search-header}}
 	<div class="background--ship-grey padding-top-sm--2">
 		<div class="wrapper">

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -16,14 +16,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b66411f{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b66411f{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b66411f{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b66411f{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
 		{{!-- Testing Google Tag Manager on a few specific URLs --}}
@@ -131,7 +131,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/8322048{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b66411f{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/banner.handlebars
@@ -1,0 +1,16 @@
+{{#resolve "/"}}
+		{{#if serviceMessage}}
+			<div class="banner">
+				<div class="wrapper">
+					<div class="col-wrap">
+						<div class="col">
+							<span class="banner__icon icon icon-info"></span>
+							<div class="banner__body">
+								{{md serviceMessage}}
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		{{/if}}
+	{{/resolve}}

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -62,6 +62,14 @@
 			</div>
 		</div>
 	{{!-- /wrapper --}}
+
+	{{!-- Banner needs to be above the 'menu' and 'search' buttons on search pages on mobile --}}
+	{{#if_any (eq listType "search") (eq listType "searchdata") (eq listType "searchpublication")}}
+		<div class="hide--md hide--lg">
+			{{> partials/banner}}
+		</div>
+	{{/if_any}}
+
 	{{!-- MAIN NAV --}}
 	<div class="primary-nav print--hide">
 		<nav>

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -122,23 +122,7 @@
 				</form>
 			</div>
 		</div>
+		{{> partials/banner}}
 	{{/block}}
-
-	{{!-- BANNER --}}
-	{{#resolve "/"}}
-		{{#if serviceMessage}}
-			<div class="banner">
-				<div class="wrapper">
-					<div class="col-wrap">
-						<div class="col">
-							<span class="banner__icon icon icon-info"></span>
-							<div class="banner__body">
-								{{md serviceMessage}}
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		{{/if}}
-	{{/resolve}}
+	
 </header>


### PR DESCRIPTION
### What

Move the banner to between the search input and taxonomy links on search results page (eg `/search?cpi`). On mobile it then moves above the 'menu' and 'search' buttons. It stays in the same location (below the search input) on any other types of pages.

### How to review

A quick eye-balling of the code should do.

### Who can review

Anyone but me, perhaps @ian-kent?
