### PR TITLE
Add GTM for new routes and page types

### DIFF
--- a/src/main/web/templates/handlebars/content/t5-1.handlebars
+++ b/src/main/web/templates/handlebars/content/t5-1.handlebars
@@ -202,14 +202,39 @@
 		<div class="col-wrap flexbox__item">
 			{{#if relatedDocuments}}
 				<div class="col {{#if_all relatedDocuments relatedMethodology}}col--md-one-third col--lg-one-third{{else}}col--md-half col--lg-half{{/if_all}} background--mercury margin-bottom-sm--2 margin-bottom-md--2">
-					{{#partial "block-documents-title"}}
-                        <div class="background--gallery padding-top-md--2 padding-top-sm--2 padding-right-md--1 padding-right-sm--1 padding-bottom-sm--3 padding-bottom-md--4 padding-left-md--1 padding-left-sm--1 border-bottom--iron-md border-bottom--iron-sm height-md--10">
-                            <h2 class="flush">
-                                {{labels.publications-that-use-this-data}}
-                            </h2>
-                        </div>
-					{{/partial}}
-					{{> partials/related/documents}}
+					<div class="tiles__item tiles__item--nav-type flush-col print--hide">
+						<div class="background--gallery padding-top-md--2 padding-top-sm--2 padding-right-md--1 padding-right-sm--1 padding-bottom-sm--3 padding-bottom-md--4 padding-left-md--1 padding-left-sm--1 border-bottom--iron-md border-bottom--iron-sm height-md--10">
+							<h2 class="flush">
+								{{labels.publications-that-use-this-data}}
+							</h2>
+						</div>
+						<div class="tiles__content tiles__content--nav">
+							<ul class="list--neutral">
+								{{#each relatedDocuments}}
+									{{#resolve this.uri filter="title"}}
+										{{!-- Add the related publication into the Google Tag Manager data layer object --}}
+										<script>
+											dataLayer[0].publications.push({
+												title: "{{title}}{{#if edition}}: {{edition}}{{/if}}",
+												uri: "{{uri}}"
+											});
+										</script>
+
+										<li>
+											<a href="{{uri}}">
+												{{title}}
+												{{#if edition}}
+													{{#if_ne edition 'yes'}}
+														: {{edition}}
+													{{/if_ne}}
+												{{/if}}
+											</a>
+										</li>
+									{{/resolve}}
+								{{/each}}
+							</ul>
+						</div>
+					</div>
 				</div>
 			{{/if}}
 			{{#if relatedMethodology}}

--- a/src/main/web/templates/handlebars/content/t8-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t8-3.handlebars
@@ -201,7 +201,37 @@
                 {{> partials/contact }}
 
                 {{!-- Related articles and bulletins --}}
-                {{> partials/related/documents }}
+                {{#if relatedDocuments}}
+                    <div class="tiles__item tiles__item--nav-type flush-col print--hide">
+                            <h3 class="tiles__title-h3 tiles__title-h3--nav">{{labels.publications-that-use-this-data}}</h3>
+                        <div class="tiles__content tiles__content--nav">
+                            <ul class="list--neutral">
+                                {{#each relatedDocuments}}
+                                    {{#resolve this.uri filter="title"}}
+                                        {{!-- Add the related publication into the Google Tag Manager data layer object --}}
+                                        <script>
+                                            dataLayer[0].publications.push({
+                                                title: "{{title}}{{#if edition}}: {{edition}}{{/if}}",
+                                                uri: "{{uri}}"
+                                            });
+                                        </script>
+
+                                        <li>
+                                            <a href="{{uri}}">
+                                                {{title}}
+                                                {{#if edition}}
+                                                    {{#if_ne edition 'yes'}}
+                                                        : {{edition}}
+                                                    {{/if_ne}}
+                                                {{/if}}
+                                            </a>
+                                        </li>
+                                    {{/resolve}}
+                                {{/each}}
+                            </ul>
+                        </div>
+                    </div>
+                {{/if}}
 
                 {{!-- Related methodology --}}
                 {{> partials/related/methodology }}

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -25,26 +25,19 @@
         <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e33b0a4{{/if}}/css/main.css">
 		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e33b0a4{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
-
-		{{!-- Testing Google Tag Manager on a few specific URLs --}}
-		{{#if_any (startsWith uri "/aboutus") (startsWith uri "/surveys")}}
-			<!-- Google Tag Manager -->
-			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-			'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-			})(window,document,'script','dataLayer','GTM-MBCBVQS');</script>
-			<!-- End Google Tag Manager -->
-		{{/if_any}}
 	</head>
 	<body class="{{type}}">
-
-		{{!-- Testing Google Tag Manager on a few specific URLs --}}
-		{{#if_any (startsWith uri "/aboutus") (startsWith uri "/surveys")}}
-			<!-- Google Tag Manager (noscript) -->
-			<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
-			height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-			<!-- End Google Tag Manager (noscript) -->
+		{{#if_any (startsWith uri "/aboutus") (startsWith uri "/surveys") (eq type "dataset_landing_page") (eq type "timeseries")}}
+			<script>
+				var dataLayer = []
+				{{#if_any (eq type "dataset_landing_page") (eq type "timeseries")}}
+					dataLayer.push({
+						datasetTitle: "{{description.title}}",
+						releaseDate: "{{df description.releaseDate outputFormat='yyyy/MM/dd'}}",
+						publications: []
+					});
+				{{/if_any}}
+			</script>
 		{{/if_any}}
 
         {{!-- Sends a message out of window - for Florance preview use, so that she can see when the preview window is loading (rather than looking for the iframe onload event which is only fired after all JS has loaded) --}}
@@ -143,10 +136,23 @@
         {{/if}}
 
         <![endif]-->
-		{{!-- Testing Google Tag Manager on a few specific URLs, so removing old GA code on them --}}
-		{{!-- This conditional is pretty ugly - it is basically saying that we want this code block to 
-		render on any page that doesn't start with '/aboutus' or '/surveys' --}}
-		{{#if_all (ne (startsWith uri "/aboutus") "true") (ne (startsWith uri "/surveys") "true")}}
+
+		{{!-- Use Google Tag Manager on about page that starts with '/aboutus' or '/surveys' or is a dataset of some form.
+			Otherwise use old Google Analytics. --}}
+		{{#if_any (startsWith uri "/aboutus") (startsWith uri "/census") (startsWith uri "/help") (startsWith uri "/news") (startsWith uri "/surveys") (eq type "dataset_landing_page") (eq type "timeseries")}}
+			<!-- Google Tag Manager -->
+			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+			'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+			})(window,document,'script','dataLayer','GTM-MBCBVQS');</script>
+			<!-- End Google Tag Manager -->
+
+			<!-- Google Tag Manager (noscript) -->
+			<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
+			height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+			<!-- End Google Tag Manager (noscript) -->
+		{{else}}
 			<script>
 				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -186,7 +192,7 @@
 				setTimeout(timer181,181000);
 				setTimeout(timer601,601000);
 				setTimeout(timer1801,1801000);
-			</script>
-		{{/if_all}}
+			</script> 
+		{{/if_any}}
 	</body>
 </html>

--- a/src/main/web/templates/handlebars/partials/related/documents.handlebars
+++ b/src/main/web/templates/handlebars/partials/related/documents.handlebars
@@ -1,8 +1,6 @@
 {{#if relatedDocuments}}
 	<div class="tiles__item tiles__item--nav-type flush-col print--hide">
-		{{#block "block-documents-title"}}
-			<h3 class="tiles__title-h3 tiles__title-h3--nav">{{#if_eq type "dataset_landing_page"}}{{labels.publications-that-use-this-data}}{{else}}{{labels.related-publications}}{{/if_eq}}</h3>
-		{{/block}}
+		<h3 class="tiles__title-h3 tiles__title-h3--nav">{{labels.related-publications}}</h3>
 		<div class="tiles__content tiles__content--nav">
 			<ul class="list--neutral">
 				{{#each relatedDocuments}}


### PR DESCRIPTION
### What

Add GTM onto any content page that exists on the path `datasets` (eg timeseries and dataset_landing_page).

Add the following properties to the GTM data layer for dataset pages:
1) The dataset title
2) The release date (in yyyy/mm/dd format)
3) The title of the publication that uses this data - accessed on the Right nav under 'Publications that use this data'

Add GTM for `/census`, `/help` and `/news` routes as well as keeping the existing routes.

### How to review

Do a code check for the GTM data layer edits.

Navigate to some dataset pages and check that GTM is being sent as a request, rather than Google Analytics (this request should look something like `gtm.js?id=.....`).

### Who can review

Anyone but me
