### PR TITLE
Set legend.navigation.enabled to false to prevent legend pagination o…

### DIFF
--- a/src/main/web/templates/handlebars/highcharts/config/base/base-chart-config.handlebars
+++ b/src/main/web/templates/handlebars/highcharts/config/base/base-chart-config.handlebars
@@ -192,7 +192,10 @@ TODO: split out colours palette selection, axis alignment and positioning
 				fontWeight: 'normal',
 				color:'rgb(112, 112,112)'{{#if_eq chartType 'small-multiples'}},
 				width: 110{{/if_eq}}
-	        }
+	        },
+            navigation: {
+                enabled: false
+            }
 		},
 		plotOptions: {
 			series: { {{#if isStacked }}


### PR DESCRIPTION
…n charts with large legends

### What

Added `navigation: { enabled: false }` to legend object to disable chart legends having the default pagination. 

### How to review

Find a chart that has pagination on the legend (e.g Figure 8: https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/earningsandworkinghours/articles/contractsthatdonotguaranteeaminimumnumberofhours/may2017 (render image, not JS version)) on local, then try the same chart after pulling the code.  

### Who can review

@Crispioso 
