### PR TITLE
Add attachment to content disposition header to fix chart downloads

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/highcharts/ChartRenderer.java
+++ b/src/main/java/com/github/onsdigital/babbage/highcharts/ChartRenderer.java
@@ -33,8 +33,8 @@ import static java.text.MessageFormat.format;
 public class ChartRenderer {
 
     static final String CONTENT_DISPOSITION_HEADER = "Content-Disposition";
-    static final String CONTENT_DISPOSITION_HEADER_FMT = "filename=\"{0}.png\"";
-    static final String DEFAULT_CONTENT_DISPOSITION_HEADER_FMT = "filename=\"Chart-{0}.png\"";
+    static final String CONTENT_DISPOSITION_HEADER_FMT = "attachment; filename=\"{0}.png\"";
+    static final String DEFAULT_CONTENT_DISPOSITION_HEADER_FMT = "attachment; filename=\"Chart-{0}.png\"";
     static final String HIGHCHARTS_TEMPLATE = "highcharts/chart";
     static final String EMBEDED_HIGHCHARTS_TEMPLATE = "partials/highcharts/embeddedchart";
     static final String PNG_MIME_TYPE = "image/png";


### PR DESCRIPTION
### What

Add attachment to content disposition header to fix chart downloads

### How to review

Start Babbage on this branch and check that you clicking the 'image' download option for a chart in a publication opens up the the download dialogue box (rather than open it as a preview in the browser).

### Who can review

Anyone but me
