### PR TITLE
Add neutral/simple article template

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/InteractiveTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/InteractiveTagReplacer.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 
 public class InteractiveTagReplacer extends TagReplacementStrategy {
 
-    private static final Pattern pattern = Pattern.compile("<ons-interactive\\surl=\"([-A-Za-z0-9+&@#/%?=~_|!:,.;()*$]+)\"\\s?(?:\\s?full-width=\"(.*[^\"])\")?/>");
+    private static final Pattern pattern = Pattern.compile("<ons-interactive\\surl=\"([-A-Za-z0-9+&@#/%?=~_|!:,.;()*$]+)\"\\s?(?:\\s?full-width=\"([a-zA-Z]*)\")?/>");
     private final String template;
 
     /**

--- a/src/main/web/templates/handlebars/content/t4-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t4-3.handlebars
@@ -69,7 +69,7 @@
                 <ul class="list--neutral">
                 {{#each relatedDocuments}}
                     {{#resolve this.uri}}
-                        <li>
+                        <li class="margin-bottom--3">
                             <a href="{{this.uri}}" class="font-size--h4">{{this.description.title}}</a>
                             <p class="flush">
                                 {{> type-label type_code=this.type }}

--- a/src/main/web/templates/handlebars/content/t4-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t4-3.handlebars
@@ -1,0 +1,105 @@
+{{#partial "block-main"}}
+    <div class="page-neutral-intro {{#if_eq type "home_page"}}background--astral{{else}}background--gallery{{/if_eq}}">
+        <div class="wrapper">
+            <div class="col-wrap">
+                <div class="col">
+                    <nav>
+                        <div class="breadcrumb-neutral print--hide">
+                            <ol class="breadcrumb-neutral__list">
+                                {{#each breadcrumb}}
+                                    <li class="breadcrumb-neutral__item">
+                                        <a class="breadcrumb-neutral__link" href="{{uri}}">{{description.title}}</a>
+                                    </li>
+                                {{/each}}
+                                <li class="breadcrumb-neutral__item">
+                                    {{description.title}}
+                                </li>
+                            </ol>
+                        </div>
+                    </nav>
+
+                    {{#block "block-intro"}}
+                        <div class="col col--md-47 col--lg-46">
+                            <div class="page-neutral-intro__type">Article</div>
+
+                            <h1 class="page-neutral-intro__title {{#if_any description._abstract description.summary}}{{else}}margin-bottom-sm--4 margin-bottom-md--4{{/if_any}}{{#if_eq type "home_page_census"}}h1--census{{/if_eq}}">
+                                {{description.title}}{{#if description.edition}}: {{description.edition}}{{/if}}
+                            </h1>
+
+                            {{#if description._abstract}}
+                                <p class="page-neutral-intro__content">{{description._abstract}}</p>
+                            {{/if}}
+                            {{#if description.releaseDate}}
+                                <p class="margin-top--0 margin-bottom--3">{{df description.releaseDate}}</p>
+                            {{/if}}
+                        </div>
+                    {{/block}}
+                </div> {{!-- /col --}}
+            </div> {{!-- /col-wrap --}}
+        </div> {{!-- /wrapper --}}
+    </div>
+    <div class="wrapper margin-bottom--2">
+        <div class="col-wrap">
+            <article class="col col--md-36 col--lg-36 page-neutral-content__main-content margin-top--4 margin-left-md--1">
+                {{#each sections}}
+                    <div id="{{slugify title}}" class="section__content--markdown section__content--markdown-flush">
+                        <section>
+                            {{#if title}}
+                                <header>
+                                    <h2>{{title}}</h2>
+                                </header>
+                            {{/if}}
+                            {{md markdown}}
+                        </section>
+                    </div>
+                {{/each}}
+            </article>
+        </div>
+
+        {{!-- Related items ---}}
+        {{#if relatedData}}
+            <a class="btn btn--primary width--36 margin-bottom--2" href="{{this.uri}}/relateddata" >
+                View all data used in this article
+            </a>
+        {{/if}}
+
+        {{#if relatedDocuments}}
+        <div class="tile-neutral width--36 margin-bottom--2">
+            <h3 class="tile-neutral__heading margin-top--1">Related</h3>
+                <ul class="list--neutral">
+                {{#each relatedDocuments}}
+                    {{#resolve this.uri}}
+                        <li>
+                            <a href="{{this.uri}}" class="font-size--h4">{{this.description.title}}</a>
+                            <p class="flush">
+                                {{> type-label type_code=this.type }}
+                                {{#if this.description.releaseDate}}
+                                    | Released on {{df this.description.releaseDate}}
+                                {{/if}}
+                            </p>
+                            <p class="margin-top--0">{{this.description.summary}}</p>
+                        </li>
+                    {{/resolve}}
+                {{/each}}
+                </ul>
+        </div>
+        {{/if}}
+
+        {{#if description.contact}}
+            <div class="tile-neutral width--36 margin-bottom--6">
+                <h3 class="tile-neutral__heading margin-top--1 margin-bottom--1">Contact</h3>
+                <address>
+                    {{#if description.contact.name}}{{description.contact.name}}<br/>{{/if}}
+                    <a href="mailto:{{description.contact.email}}">{{description.contact.email}}</a><br/>
+                    {{#if description.contact.telephone}}{{labels.telephone}}: {{description.contact.telephone}}{{/if}}
+                </address>
+            </div>
+        {{/if}}
+
+
+
+    </div>
+{{/partial}}
+
+
+{{> base/base}}

--- a/src/main/web/templates/handlebars/content/t4-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t4-3.handlebars
@@ -22,7 +22,7 @@
                         <div class="col col--md-47 col--lg-46">
                             <div class="page-neutral-intro__type">Article</div>
 
-                            <h1 class="page-neutral-intro__title {{#if_any description._abstract description.summary}}{{else}}margin-bottom-sm--4 margin-bottom-md--4{{/if_any}}{{#if_eq type "home_page_census"}}h1--census{{/if_eq}}">
+                                <h1 class="page-neutral-intro__title {{#if_eq type "home_page_census"}}h1--census{{/if_eq}}">
                                 {{description.title}}{{#if description.edition}}: {{description.edition}}{{/if}}
                             </h1>
 
@@ -42,7 +42,7 @@
         <div class="col-wrap">
             <article class="col col--md-36 col--lg-36 page-neutral-content__main-content margin-top--4 margin-left-md--1">
                 {{#each sections}}
-                    <div id="{{slugify title}}" class="section__content--markdown section__content--markdown-flush">
+                    <div id="{{slugify title}}" class="section__content--markdown section__content--markdown--neutral-article">
                         <section>
                             {{#if title}}
                                 <header>
@@ -58,26 +58,26 @@
 
         {{!-- Related items ---}}
         {{#if relatedData}}
-            <a class="btn btn--primary width--36 margin-bottom--2" href="{{this.uri}}/relateddata" >
+            <a class="btn btn--primary btn--full-width width-md--36 margin-bottom--2" href="{{this.uri}}/relateddata" >
                 View all data used in this article
             </a>
         {{/if}}
 
         {{#if relatedDocuments}}
-        <div class="tile-neutral width--36 margin-bottom--2">
+        <div class="tile-neutral width-md--36 margin-bottom--2">
             <h3 class="tile-neutral__heading margin-top--1">Related</h3>
-                <ul class="list--neutral">
+                <ul class="list--neutral margin-bottom--0">
                 {{#each relatedDocuments}}
                     {{#resolve this.uri}}
-                        <li class="margin-bottom--3">
-                            <a href="{{this.uri}}" class="font-size--h4">{{this.description.title}}</a>
-                            <p class="flush">
+                        <li class="{{#if @last}}margin-bottom--0{{else}}margin-bottom--3{{/if}}">
+                            <a href="{{this.uri}}" class="tile-neutral-content__title">{{this.description.title}}</a>
+                            <p class="tile-neutral-content__meta">
                                 {{> type-label type_code=this.type }}
                                 {{#if this.description.releaseDate}}
-                                    | Released on {{df this.description.releaseDate}}
+                                    <span class="text--aluminium">|</span> Released on {{df this.description.releaseDate}}
                                 {{/if}}
                             </p>
-                            <p class="margin-top--0">{{this.description.summary}}</p>
+                            <p class="margin-top--0 margin-bottom--0">{{this.description.summary}}</p>
                         </li>
                     {{/resolve}}
                 {{/each}}
@@ -86,7 +86,7 @@
         {{/if}}
 
         {{#if description.contact}}
-            <div class="tile-neutral width--36 margin-bottom--6">
+            <div class="tile-neutral width-md--36 margin-bottom--6">
                 <h3 class="tile-neutral__heading margin-top--1 margin-bottom--1">Contact</h3>
                 <address>
                     {{#if description.contact.name}}{{description.contact.name}}<br/>{{/if}}

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -70,7 +70,10 @@
 			{{else}} 						 				{{> content/t3}}
 			{{/if_eq}}
 		{{else if_eq type "bulletin"}} 						{{> content/t4-1}}
-		{{else if_eq type "article"}} 						{{> content/t4-2}}
+		{{else if_eq type "article"}}
+            {{#if isPrototypeArticle}}                      {{> content/t4-3}}
+            {{else}}                                        {{> content/t4-2}}
+            {{/if}}
         {{else if_eq type "article_download"}} 				{{> content/t4-2}}
 		{{else if_eq type "timeseries"}}
 			{{#if previous}} 								{{> content/t12-2}}


### PR DESCRIPTION
### What

Added templates for rendering "neutral"/"prototype"/"visual" articles 

### How to review

To run you'll need the following services and branches
Babbage - `feature/visual-article`
Florence - `feature/prototype-article`
Zebedee - `feature/prototype-article`
Sixteens - `feature/prototype-article`

### Who can review

Anyone but me