### PR TITLE
Add page neutral meta class and extend content area to 40 cols

### DIFF
--- a/src/main/web/templates/handlebars/content/t4-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t4-3.handlebars
@@ -30,7 +30,7 @@
                                 <p class="page-neutral-intro__content">{{description._abstract}}</p>
                             {{/if}}
                             {{#if description.releaseDate}}
-                                <p class="margin-top--0 margin-bottom--3">{{df description.releaseDate}}</p>
+                                <p class="page-neutral-intro__meta margin-top--0 margin-bottom--3">{{df description.releaseDate}}</p>
                             {{/if}}
                         </div>
                     {{/block}}
@@ -40,7 +40,7 @@
     </div>
     <div class="wrapper margin-bottom--2">
         <div class="col-wrap">
-            <article class="col col--md-36 col--lg-36 page-neutral-content__main-content margin-top--4 margin-left-md--1">
+            <article class="col col--md-40 col--lg-40 page-neutral-content__main-content margin-top--4 margin-left-md--1">
                 {{#each sections}}
                     <div id="{{slugify title}}" class="section__content--markdown section__content--markdown--neutral-article">
                         <section>

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -16,14 +16,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b3c7947{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/d14c8ee{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b3c7947{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/d14c8ee{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b3c7947{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b3c7947{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/d14c8ee{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/d14c8ee{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
         
         {{> partials/gtm-data-layer }}
@@ -131,7 +131,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b3c7947{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/d14c8ee{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}


### PR DESCRIPTION
### What

Add page neutral meta class and extend content area to 40 cols

### How to review

Pull sixteens branch `feature/stripped-article` and check that changes match [prototype](https://onsdigital.github.io/dp-design-manual/sprint/9/visual-article-iteration/). 

### Who can review

Probably @Crispioso and @benjystanton 
