### PR TITLE
Added handling of new tables (ons-table-v2 tags)

### DIFF
--- a/scripts/codedeploy/application-start.sh
+++ b/scripts/codedeploy/application-start.sh
@@ -4,30 +4,32 @@ ECR_REPOSITORY_URI=
 GIT_COMMIT=
 
 if [[ $DEPLOYMENT_GROUP_NAME =~ [a-z]+-publishing ]]; then
-  docker run -d                                           \
-    --env=CONTENT_SERVICE_URL=http://zebedee:8080         \
-    --env=ELASTIC_SEARCH_CLUSTER=cluster                  \
-    --env=ELASTIC_SEARCH_SERVER=elasticsearch             \
-    --env=GHOSTSCRIPT_PATH=/usr/bin/gs                    \
-    --env=HIGHCHARTS_EXPORT_SERVER=http://highcharts:8080 \
-    --env=IS_PUBLISHING=Y                                 \
-    --name=babbage                                        \
-    --net=publishing                                      \
-    --restart=always                                      \
+  docker run -d                                              \
+    --env=CONTENT_SERVICE_URL=http://zebedee:8080            \
+    --env=ELASTIC_SEARCH_CLUSTER=cluster                     \
+    --env=ELASTIC_SEARCH_SERVER=elasticsearch                \
+    --env=GHOSTSCRIPT_PATH=/usr/bin/gs                       \
+    --env=HIGHCHARTS_EXPORT_SERVER=http://highcharts:8080    \
+    --env=TABLE_RENDERER_HOST=http://dp-table-renderer:23300 \
+    --env=IS_PUBLISHING=Y                                    \
+    --name=babbage                                           \
+    --net=publishing                                         \
+    --restart=always                                         \
     $ECR_REPOSITORY_URI/babbage:$GIT_COMMIT
 else
-  docker run -d                                           \
-    --env=CONTENT_SERVICE_MAX_CONNECTION=1000             \
-    --env=CONTENT_SERVICE_URL=http://zebedee-reader:8080  \
-    --env=ELASTIC_SEARCH_CLUSTER=cluster                  \
-    --env=ELASTIC_SEARCH_SERVER=elasticsearch             \
-    --env=ENABLE_CACHE=Y                                  \
-    --env=GHOSTSCRIPT_PATH=/usr/bin/gs                    \
-    --env=GLOBAL_CACHE_SIZE=5000                          \
-    --env=HIGHCHARTS_EXPORT_SERVER=http://highcharts:8080 \
-    --env=PHANTOMJS_PATH=/usr/local/bin/phantomjs         \
-    --name=babbage                                        \
-    --net=website                                         \
-    --restart=always                                      \
+  docker run -d                                              \
+    --env=CONTENT_SERVICE_MAX_CONNECTION=1000                \
+    --env=CONTENT_SERVICE_URL=http://zebedee-reader:8080     \
+    --env=ELASTIC_SEARCH_CLUSTER=cluster                     \
+    --env=ELASTIC_SEARCH_SERVER=elasticsearch                \
+    --env=ENABLE_CACHE=Y                                     \
+    --env=GHOSTSCRIPT_PATH=/usr/bin/gs                       \
+    --env=GLOBAL_CACHE_SIZE=5000                             \
+    --env=HIGHCHARTS_EXPORT_SERVER=http://highcharts:8080    \
+    --env=PHANTOMJS_PATH=/usr/local/bin/phantomjs            \
+    --env=TABLE_RENDERER_HOST=http://dp-table-renderer:23300 \
+    --name=babbage                                           \
+    --net=website                                            \
+    --restart=always                                         \
     $ECR_REPOSITORY_URI/babbage:$GIT_COMMIT
 fi

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Configuration.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Configuration.java
@@ -217,6 +217,31 @@ public class Configuration {
         }
     }
 
+    /** Server side table rendering configuration. */
+    public static class TABLE_RENDERER {
+        private static final String HOST = defaultIfBlank(getValue("TABLE_RENDERER_HOST"), "http://localhost:23100");
+        private static final String HTML_PATH = defaultIfBlank(getValue("TABLE_RENDERER_HTML_PATH"), "/render/html");
+        private static final int MAX_RENDERER_CONNECTIONS = defaultNumberIfBlank(getNumberValue("ABLE_RENDERER_MAX_CONNECTION"), 10);
+
+         /**
+         * @return the hostname of the table renderer).
+         */
+        public static String getHost() {
+            return HOST;
+        }
+
+         /**
+         * @return the path to invoke when rendering an html table).
+         */
+        public static String getHtmlPath() {
+            return HTML_PATH;
+        }
+
+        public static int getMaxServerConnection() {
+            return MAX_RENDERER_CONNECTIONS;
+        }
+    }
+
     /**
      * Gets a configured value for the given key from either the system
      * properties or an environment variable.

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Configuration.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Configuration.java
@@ -219,9 +219,9 @@ public class Configuration {
 
     /** Server side table rendering configuration. */
     public static class TABLE_RENDERER {
-        private static final String HOST = defaultIfBlank(getValue("TABLE_RENDERER_HOST"), "http://localhost:23100");
+        private static final String HOST = defaultIfBlank(getValue("TABLE_RENDERER_HOST"), "http://localhost:23300");
         private static final String HTML_PATH = defaultIfBlank(getValue("TABLE_RENDERER_HTML_PATH"), "/render/html");
-        private static final int MAX_RENDERER_CONNECTIONS = defaultNumberIfBlank(getNumberValue("ABLE_RENDERER_MAX_CONNECTION"), 10);
+        private static final int MAX_RENDERER_CONNECTIONS = defaultNumberIfBlank(getNumberValue("TABLE_RENDERER_MAX_CONNECTIONS"), 10);
 
          /**
          * @return the hostname of the table renderer).

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/CustomMarkdownHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/CustomMarkdownHelper.java
@@ -56,6 +56,7 @@ public class CustomMarkdownHelper extends MarkdownHelper implements BabbageHandl
     protected String processCustomMarkdownTags(String path, String markdown) throws IOException {
         markdown = new ChartTagReplacer(path, "partials/highcharts/chart").replaceCustomTags(markdown);
         markdown = new TableTagReplacer(path, "partials/table").replaceCustomTags(markdown);
+        markdown = new TableTagV2Replacer(path, "partials/table-v2").replaceCustomTags(markdown);
         markdown = new ImageTagReplacer(path, "partials/image").replaceCustomTags(markdown);
         markdown = new MathjaxTagReplacer(path, "partials/equation").replaceCustomTags(markdown);
         markdown = new InteractiveTagReplacer(path, "partials/interactive").replaceCustomTags(markdown);

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TableTagV2Replacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TableTagV2Replacer.java
@@ -1,0 +1,115 @@
+package com.github.onsdigital.babbage.template.handlebars.helpers.markdown.util;
+
+import ch.qos.logback.classic.Level;
+import com.github.onsdigital.babbage.configuration.Configuration;
+import com.github.onsdigital.babbage.content.client.ContentClient;
+import com.github.onsdigital.babbage.content.client.ContentReadException;
+import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.error.ResourceNotFoundException;
+import com.github.onsdigital.babbage.logging.Log;
+import com.github.onsdigital.babbage.template.TemplateService;
+import com.github.onsdigital.babbage.util.http.ClientConfiguration;
+import com.github.onsdigital.babbage.util.http.PooledHttpClient;
+import com.github.onsdigital.babbage.util.json.JsonUtil;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Defines the format of the custom markdown tags for charts and defines how to replace them.
+ */
+public class TableTagV2Replacer extends TagReplacementStrategy {
+
+    private static final Pattern pattern = Pattern.compile("<ons-table-v2\\spath=\"([-A-Za-z0-9+&@#/%?=~_|!:,.;()*$]+)\"?\\s?/>");
+    private static final String RENDERER_HOST = Configuration.TABLE_RENDERER.getHost();
+    private static final String RENDERER_PATH = Configuration.TABLE_RENDERER.getHtmlPath();
+    static final PooledHttpClient HTTP_CLIENT = new PooledHttpClient(RENDERER_HOST, createHttpConfiguration());
+
+    private final String template;
+    private final ContentClient contentClient;
+    private final TemplateService templateService;
+    private final PooledHttpClient httpClient;
+
+    public TableTagV2Replacer(String path, String template) {
+        this(path, template, ContentClient.getInstance(), TemplateService.getInstance(), HTTP_CLIENT);
+    }
+
+    public TableTagV2Replacer(String path, String template, ContentClient contentClient, TemplateService templateService, PooledHttpClient httpClient) {
+        super(path);
+        this.template = template;
+        this.contentClient = contentClient;
+        this.templateService = templateService;
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Gets the pattern that this strategy is applied to.
+     *
+     * @return
+     */
+    @Override
+    public Pattern getPattern() {
+        return pattern;
+    }
+
+    /**
+     * The function that generates the replacement text for each match.
+     *
+     * @param matcher
+     * @return
+     * @throws IOException
+     */
+    @Override
+    public String replace(Matcher matcher) throws IOException {
+
+        String tagPath = matcher.group(1);
+        String figureUri = resolveFigureUri(this.getPath(), Paths.get(tagPath)) + ".json";
+
+        try {
+            ContentResponse contentResponse = contentClient.getResource(figureUri);
+            String tableJson = contentResponse.getAsString();
+            String html = invokeTableRenderer(tableJson);
+            Map<String, Object> context = JsonUtil.toMap(tableJson);
+            String result = templateService.renderTemplate(template, context, Collections.singletonMap("tableHtml", html));
+            return result;
+        } catch (ResourceNotFoundException e) {
+            Log.buildDebug("Failed to find figure data for table.").addParameter("URL", figureUri).log();
+            return templateService.renderTemplate(figureNotFoundTemplate);
+        } catch (ContentReadException | TableRendererException e) {
+            Log.build("Failed rendering table-v2, uri: " + figureUri + ", error: " + e, Level.ERROR).log();
+            return matcher.group();
+        }
+    }
+
+    private String invokeTableRenderer(String postBody) throws TableRendererException {
+        try (CloseableHttpResponse response = httpClient.sendPost(RENDERER_PATH, null, postBody)){
+            return IOUtils.toString(response.getEntity().getContent());
+        } catch (IOException e) {
+            throw new TableRendererException(e);
+        }
+    }
+
+    private static ClientConfiguration createHttpConfiguration() {
+        ClientConfiguration configuration = new ClientConfiguration();
+        configuration.setMaxTotalConnection(Configuration.TABLE_RENDERER.getMaxServerConnection());
+        configuration.setDisableRedirectHandling(true);
+        return configuration;
+    }
+
+    /** TableRendererException is thrown and caught internally in this class only. */
+    private static class TableRendererException extends Exception {
+        public TableRendererException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/src/main/web/templates/handlebars/partials/table-v2.handlebars
+++ b/src/main/web/templates/handlebars/partials/table-v2.handlebars
@@ -1,0 +1,13 @@
+{{!--Not having line breaks before and after the div markups breaks tables displaying on the page--}}
+<div class="markdown-table-container print--avoid-break">
+    <div class="markdown-table-wrap">
+        {{{tableHtml}}}
+    </div>
+
+    {{!-- 'View table' button for mobile --}}
+    <button class="btn btn--secondary btn--mobile-table-show nojs--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="view-table">View table</button>
+
+    <h5 class="print--hide font-size--h6">Download this table</h5>
+    <a href="/download/table?format=xlsx&uri={{uri}}" title="Download as xlsx" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xlsx">.xlsx</a>
+    <a href="/download/table?format=csv&uri={{uri}}" title="Download as csv" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-csv">.csv</a>
+</div>

--- a/src/main/web/templates/handlebars/partials/table-v2.handlebars
+++ b/src/main/web/templates/handlebars/partials/table-v2.handlebars
@@ -8,6 +8,6 @@
     <button class="btn btn--secondary btn--mobile-table-show nojs--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="view-table">View table</button>
 
     <h5 class="print--hide font-size--h6">Download this table</h5>
-    <a href="/download/table?format=xlsx&uri={{uri}}" title="Download as xlsx" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xlsx">.xlsx</a>
-    <a href="/download/table?format=csv&uri={{uri}}" title="Download as csv" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-csv">.csv</a>
+    <a href="/download/table?format=xlsx&uri={{uri}}.json" title="Download as xlsx" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xlsx">.xlsx</a>
+    <a href="/download/table?format=csv&uri={{uri}}.json" title="Download as csv" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-csv">.csv</a>
 </div>

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TableTagV2ReplacerTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/TableTagV2ReplacerTest.java
@@ -1,0 +1,97 @@
+package com.github.onsdigital.babbage.template.handlebars.helpers.markdown.util;
+
+import com.github.onsdigital.babbage.configuration.Configuration;
+import com.github.onsdigital.babbage.content.client.ContentClient;
+import com.github.onsdigital.babbage.content.client.ContentReadException;
+import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.error.ResourceNotFoundException;
+import com.github.onsdigital.babbage.template.TemplateService;
+import com.github.onsdigital.babbage.util.http.PooledHttpClient;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.regex.Matcher;
+
+import static com.github.onsdigital.babbage.search.helpers.SearchRequestHelper.extractPublishDates;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+public class TableTagV2ReplacerTest {
+
+
+    private final String tableHtml = "<table></table>";
+    private final String path = "/myPath/";
+	private final String template = "myTemplate";
+	private final String markdownContent = "<ons-table-v2 path=\"tableid\" />";
+    private final String renderedTemplate = "renderedTemplate";
+	@Mock
+    private ContentClient contentClientMock;
+	@Mock
+    private TemplateService templateServiceMock;
+    @Mock
+    private PooledHttpClient httpClientMock;
+    @Mock
+    private ContentResponse contentResponseMock;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private CloseableHttpResponse responseMock;
+    @Mock
+    private ContentReadException readException;
+
+    private Matcher matcher;
+    private TableTagV2Replacer testObj;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        testObj = new TableTagV2Replacer(path, template, contentClientMock, templateServiceMock, httpClientMock);
+
+        when(contentClientMock.getResource(path + "tableid.json")).thenReturn(contentResponseMock);
+
+        matcher = testObj.getPattern().matcher(markdownContent);
+        matcher.find();
+    }
+
+    @Test
+    public void replaceShouldGetContentAndinvokeTableRenderer() throws Exception {
+        String json = "{\"foo\": \"bar\"}";
+        when(contentResponseMock.getAsString()).thenReturn(json);
+        when(httpClientMock.sendPost(Configuration.TABLE_RENDERER.getHtmlPath(), null, json)).thenReturn(responseMock);
+        when(responseMock.getEntity().getContent()).thenReturn(IOUtils.toInputStream(tableHtml));
+        when(templateServiceMock.renderTemplate(template, singletonMap("foo", "bar"), singletonMap("tableHtml", tableHtml))).thenReturn(renderedTemplate);
+
+        String result = testObj.replace(matcher);
+
+        assertThat(result, equalTo(renderedTemplate));
+    }
+
+    @Test
+    public void replaceShouldRenderFigureNotFoundTemplateIfResourceNotFound() throws Exception {
+        when(contentClientMock.getResource(anyString())).thenThrow(new ResourceNotFoundException());
+        when(templateServiceMock.renderTemplate(TagReplacementStrategy.figureNotFoundTemplate)).thenReturn(TagReplacementStrategy.figureNotFoundTemplate);
+
+        String result = testObj.replace(matcher);
+
+        assertThat(result, equalTo(TagReplacementStrategy.figureNotFoundTemplate));
+    }
+
+    @Test
+    public void replaceShouldRenderOriginalContentWhenContentNotFound() throws Exception {
+        when(contentClientMock.getResource(anyString())).thenThrow(readException);
+
+        String result = testObj.replace(matcher);
+
+        assertThat(result, equalTo(markdownContent));
+    }
+}


### PR DESCRIPTION
### What

Added a new template and tag replacer for the new table tag (ons-table-v2). This will not have any effect unless the new format table tag is encountered: <ons-table-v2 path="/path/to/content/filename.json" />

### How to review

Add the new tag to come content (pointing to a json file in this format: https://github.com/ONSdigital/dp-table-renderer/blob/develop/testdata/exampleRequest.json), view the page and confirm that the ocntent is rendered as a table.

### Who can review

Anyone but me.
