### PR TITLE
Use heap_mem variable for JVM args in nomad plan

### DIFF
--- a/babbage.nomad
+++ b/babbage.nomad
@@ -37,7 +37,7 @@ job "babbage" {
 
         args = [
           "java",
-          "-Xmx2048m",
+          "-Xmx{{WEB_RESOURCE_HEAP_MEM}}m",
           "-cp target/dependency/*:target/classes/",
           "-Drestolino.files=target/web",
           "-Drestolino.classes=target/classes",
@@ -98,7 +98,7 @@ job "babbage" {
 
         args = [
           "java",
-          "-Xmx2048m",
+          "-Xmx{{PUBLISHING_RESOURCE_HEAP_MEM}}m",
           "-cp target/dependency/*:target/classes/",
           "-Drestolino.files=target/web",
           "-Drestolino.classes=target/classes",


### PR DESCRIPTION
### What

Use new heap_mem variable for JVM args in nomad plan to prevent app requesting too much memory

### How to review

Check correct vars are being used

### Who can review

Anyone