### PR TITLE
add `data-gtm-uri` to search result links

### DIFF
--- a/src/main/web/templates/handlebars/list/partials/results-title.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/results-title.handlebars
@@ -1,3 +1,3 @@
 <h3 class="search-results__title">
-        <a href="/redir/{{ sign_url uri parameters.query.0 parameters.q.0 result.paginator.currentPage @index_1 listType parameters.size.0 }}">{{{description.title}}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}</a>
+        <a href="/redir/{{ sign_url uri parameters.query.0 parameters.q.0 result.paginator.currentPage @index_1 listType parameters.size.0 }}" data-gtm-uri="{{ uri }}">{{{description.title}}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}</a>
 </h3>


### PR DESCRIPTION
### What

Add a `data-gtm-uri` attribute to search results for GTM tracking

### How to review

Search, check result has `data-gtm-uri` attribute

### Who can review

Anyone except @ian-kent