### PR TITLE
Feature/track latest url in gtm

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -16,6 +16,10 @@
 
         {{#if_any description.metaDescription description.summary description._abstract}}<meta name="description" content="{{#if description.metaDescription}}{{description.metaDescription}}{{else}}{{#if description.summary}}{{description.summary}}{{else}}{{description._abstract}}{{/if}}{{/if}}">{{/if_any}}
 
+        {{#if_any (eq type "bulletin") (eq type "article") (eq type "compendium_landing_page") (eq type "compendium_chapter")}}
+            <link rel="canonical" href="{{uri}}" />
+        {{/if_any}}
+
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
 		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/7b354cb{{/if}}/css/old-ie.css"/>

--- a/src/main/web/templates/handlebars/partials/gtm-data-layer.handlebars
+++ b/src/main/web/templates/handlebars/partials/gtm-data-layer.handlebars
@@ -40,6 +40,7 @@
         {{#unless (endsWith (parentPath uri) "previous")}}
             {{#if description.latestRelease}}
                 dataLayer[0]["latestRelease"] = "yes";
+                dataLayer[0]["url"] = "{{uri}}";
             {{else}}
                 dataLayer[0]["latestRelease"] = "no";
             {{/if}}


### PR DESCRIPTION
### What

- Pass content uri to GTM datalayer when on latest release
- Add canonical links for publication page types


### Who can review

Anyone
