### PR TITLE
fix to page-title for timeseries_dataset

### DIFF
--- a/src/main/web/templates/handlebars/partials/page-title.handlebars
+++ b/src/main/web/templates/handlebars/partials/page-title.handlebars
@@ -17,6 +17,10 @@
         {{#if_eq listType "releasecalendar"}}Release calendar{{/if_eq}}
         {{#if_eq listType "timeseriestool"}}Time series explorer{{/if_eq}}
     {{else}}
+        {{#if_eq type "timeseries_dataset"}}
+            {{#resolve (parentPath uri)}}{{description.title}}{{/resolve}}
+            {{else}}
         {{#if description.title}}{{description.title}}{{else}}{{#if title}}{{{sub (sup title clear=true) clear=true}}}{{else}}Page not found{{/if}}{{/if}}
+        {{/if_eq}}
     {{/if_eq}}
 {{/minify}}


### PR DESCRIPTION
### What

timeseries_dataset pages displaying 'page not found'

### How to review

test title is "Consumer Price Inflation time series dataset"
https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceindices/current 

### Who can review

all