### PR TITLE
Related box. Summary for articles.

### DIFF
--- a/src/main/web/templates/handlebars/content/t4-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t4-3.handlebars
@@ -77,7 +77,9 @@
                                     <span class="text--aluminium">|</span> Released on {{df this.description.releaseDate}}
                                 {{/if}}
                             </p>
-                            <p class="tile-neutral-content__description margin-top--0 margin-bottom--0 ">{{this.description.summary}}</p>
+                            {{#if_any this.description.summary this.description._abstract}}
+                                <p class="tile-neutral-content__description margin-top--0 margin-bottom--0 ">{{#if this.description.summary}}{{this.description.summary}}{{else}}{{this.description._abstract}}{{/if}}</p>
+                            {{/if_any}}
                         </li>
                     {{/resolve}}
                 {{/each}}


### PR DESCRIPTION
### What

added related box summary(_abstract) for articles.
https://trello.com/c/fA8D8E3q/3019-related-box-summary-for-bulletins-gets-displayed-but-not-for-articles

### Who can review

all
