### PR TITLE
added time to corrections in pdf

### DIFF
--- a/src/main/web/templates/handlebars/pdf/partials/corrections-alerts.handlebars
+++ b/src/main/web/templates/handlebars/pdf/partials/corrections-alerts.handlebars
@@ -4,7 +4,7 @@
     <div class="correction">
         <h2>Correction</h2>
         {{#each versions}}
-            <h3>{{df updateDate}}</h3>
+            <h3>{{df updateDate outputFormat="d MMMM yyyy HH:mm"}}</h3>
             {{md correctionNotice}}
         {{/each}}
     </div>


### PR DESCRIPTION
### What

added outputFormat to corrections-alerts in pdf 
(29 June 2018) to (29 June 2018 09:48)
https://trello.com/c/Grtw9CvA/3258-add-correction-notice-time-to-pdf-8

### How to review

add bulletin
add correction
approve collection
download as pdf

### Who can review

all
