### PR TITLE
Use slightly different variable names when assigning hasCorrections a…

### DIFF
--- a/src/main/web/templates/handlebars/partials/gtm-data-layer.handlebars
+++ b/src/main/web/templates/handlebars/partials/gtm-data-layer.handlebars
@@ -54,25 +54,25 @@
     {{#if alerts}}
         {{#each alerts}}
             {{#if_eq type "correction"}}
-                {{#assign "has-corrections"}}
+                {{#assign "hasCorrections"}}
                 true
                 {{/assign}}
             {{/if_eq}}
 
             {{#if_eq type "alert"}}
-                {{#assign "has-alerts"}}
+                {{#assign "hasAlerts"}}
                 true
                 {{/assign}}
             {{/if_eq}}
         {{/each}}
 
         {{#if_ne type "dataset"}}
-            {{#if has-corrections}}
+            {{#if hasCorrections}}
                 dataLayer[0]["corrections"] = "yes";
             {{else}}
                 dataLayer[0]["corrections"] = "no";
             {{/if}}
-            {{#if has-alerts}}
+            {{#if hasAlerts}}
                 dataLayer[0]["notices"] = "yes";
             {{else}}
                 dataLayer[0]["notices"] = "no";
@@ -84,14 +84,14 @@
     {{#if versions}}
         {{#each versions}}
             {{#if correctionNotice}}
-                {{#assign "has-corrections"}}
+                {{#assign "hasCorrections"}}
                 true
                 {{/assign}}
             {{/if}}
         {{/each}}
 
         {{#if_ne type "dataset"}}
-            {{#if has-corrections}}
+            {{#if hasCorrections}}
                 dataLayer[0]["corrections"] = "yes";
             {{else}}
                 dataLayer[0]["corrections"] = "no";


### PR DESCRIPTION
### What

Use slightly different variable names when assigning hasCorrections and hasAlerts to avoid conflicts with variable names in the alerts/corrections partials 

### How to review

Check that when adding corrections and notices to a page they appear correctly. This fixes the issues where correction would appear as if a blank correction had been added, view [Trello card](https://trello.com/c/BzmPw1Oc/3329-correction-and-notice-on-bulletin-page-cause-duplication-of-corrections-title) to see example.
Corrections and alerts should still show in the dataLayer for GTM. 

### Who can review

Anyone
