### PR TITLE
Expose babbage for access by search reindex script

### DIFF
--- a/scripts/codedeploy/application-start.sh
+++ b/scripts/codedeploy/application-start.sh
@@ -44,5 +44,6 @@ docker run -d                                                          \
   --env=REDIRECT_SECRET=$REDIRECT_SECRET                               \
   --name=babbage                                                       \
   --net=$DOCKER_NETWORK                                                \
+  --publish=10000:8080                                                 \
   --restart=always                                                     \
   $ECR_REPOSITORY_URI/babbage:$GIT_COMMIT


### PR DESCRIPTION
### What

The search reindex script runs outside the docker network so we need to
expose babbage on the host so we can trigger the reindex.

### How to review

Ensure the codedeploy scripts look reasonable.

### Who can review

Anyone but me.
