### PR TITLE
Added CORS for chart configs

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/filter/CorsFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/CorsFilter.java
@@ -14,7 +14,7 @@ public class CorsFilter implements Filter {
 
         String requestType = URIUtil.resolveRequestType(request.getRequestURI());
 
-        if (requestType.equals("data")) {
+        if (requestType.equals("data") || request.getRequestURI().contains("/chartconfig?uri=")) {
             response.addHeader("Access-Control-Allow-Origin", "*"); //request.getHeader("origin"));
             response.addHeader("Access-Control-Allow-Methods", "GET");
         }

--- a/src/main/java/com/github/onsdigital/babbage/api/filter/CorsFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/CorsFilter.java
@@ -14,7 +14,7 @@ public class CorsFilter implements Filter {
 
         String requestType = URIUtil.resolveRequestType(request.getRequestURI());
 
-        if (requestType.equals("data") || request.getRequestURI().contains("/chartconfig?uri=")) {
+        if (requestType.equals("data") || request.getRequestURI().equals("/chartconfig")) {
             response.addHeader("Access-Control-Allow-Origin", "*"); //request.getHeader("origin"));
             response.addHeader("Access-Control-Allow-Methods", "GET");
         }


### PR DESCRIPTION
### What

Allowed CORS GET requests for chart configs.

example chart config url:
https://www.ons.gov.uk/chartconfig?uri=peoplepopulationandcommunity/populationandmigration/populationestimates/bulletins/annualmidyearpopulationestimates/mid2017/ecf123e5

### How to review

Sanity check.

### Who can review

Anyone.
