### PR TITLE
Added GET cors for /chartconfig endpoint

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/filter/CorsFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/CorsFilter.java
@@ -14,7 +14,7 @@ public class CorsFilter implements Filter {
 
         String requestType = URIUtil.resolveRequestType(request.getRequestURI());
 
-        if (requestType.equals("data")) {
+        if (requestType.equals("data") || request.getRequestURI().equals("/chartconfig")) {
             response.addHeader("Access-Control-Allow-Origin", "*"); //request.getHeader("origin"));
             response.addHeader("Access-Control-Allow-Methods", "GET");
         }


### PR DESCRIPTION
### What

Allowed CORS for GET requests to /chartconfig endpoint.

example chartconfig url: https://www.ons.gov.uk/chartconfig?uri=peoplepopulationandcommunity/populationandmigration/populationestimates/bulletins/annualmidyearpopulationestimates/mid2017/ecf123e5

### How to review

Sanity check.

### Who can review

Anyone.
