### PR TITLE
Prevent publishing instances from using mount node

### DIFF
--- a/babbage.nomad
+++ b/babbage.nomad
@@ -7,11 +7,6 @@ job "babbage" {
     distinct_hosts = true
   }
 
-  constraint {
-    attribute = "${meta.has_disk}"
-    value     = true
-  }
-
   update {
     min_healthy_time = "30s"
     healthy_deadline = "2m"
@@ -102,7 +97,7 @@ job "babbage" {
 
     constraint {
       attribute = "${node.class}"
-      value     = "publishing-mount"
+      value     = "publishing"
     }
 
     restart {


### PR DESCRIPTION
### What

Prevent babbage-publishing from using the instance with the content
volume mount.  This also opens up the possibility of running two
babbage-publishing instances.

### How to review

Ensure the plan is valid.

### Who can review

Anyone but me.