### PR TITLE
fixed env config getter to use system and env vars

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/configuration/EnvVarUtils.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/EnvVarUtils.java
@@ -27,7 +27,7 @@ public class EnvVarUtils {
     }
 
     public static String getValueOrDefault(String key, String defaultVal) {
-        return StringUtils.defaultIfBlank(System.getProperty(key), defaultVal);
+        return StringUtils.defaultIfBlank(getValue(key), defaultVal);
     }
 
     public static Integer getNumberValue(String key) {


### PR DESCRIPTION
### What

Fix for config. App now checkout both `system` and `env` for config values before using the default
