### PR TITLE
Bug/port in rss link

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/builder/SyndEntryBuilder.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/builder/SyndEntryBuilder.java
@@ -60,7 +60,7 @@ public class SyndEntryBuilder {
 	}
 
 	private String getUri() {
-		return "http://" + ((Location) ThreadContext.getData(LOCATION_KEY)).getHost() + get(uri);
+		return "http://" + ((Location) ThreadContext.getData(LOCATION_KEY)).getHostname() + get(uri);
 	}
 
 	private String get(Field field) {

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/service/RssService.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/service/RssService.java
@@ -126,7 +126,7 @@ public class RssService {
 
 		return new SyndFeedBuilder()
 				.type(rssType)
-				.link(((Location) ThreadContext.getData(LOCATION_KEY)).getHost())
+				.link(((Location) ThreadContext.getData(LOCATION_KEY)).getHostname())
 				.category(title.toString())
 				.entries(searchResultsToSyndEntries(results))
 				.title(title.toString())
@@ -186,7 +186,7 @@ public class RssService {
 	private SyndFeed generateSyndFeed(Optional<SearchResult> results, RssSearchFilter filter) {
 		return new SyndFeedBuilder()
 				.type(rssType)
-				.link(((Location) ThreadContext.getData(LOCATION_KEY)).getHost())
+				.link(((Location) ThreadContext.getData(LOCATION_KEY)).getHostname())
 				.category(filter.getUri())
 				.entries(searchResultsToSyndEntries(results))
 				.title(filter)

--- a/src/test/java/com/github/onsdigital/babbage/api/endpoint/rss/builder/SyndEntryBuilderTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/api/endpoint/rss/builder/SyndEntryBuilderTest.java
@@ -42,7 +42,7 @@ public class SyndEntryBuilderTest {
 		masterMap = new HashMap<>();
 		description = new HashMap<>();
 		loc = new RequestUtil.Location();
-		loc.setHost("host");
+		loc.setHostname("host");
 		ThreadContext.addData(LOCATION_KEY, loc);
 	}
 
@@ -109,7 +109,7 @@ public class SyndEntryBuilderTest {
 		SyndEntry entry = builder.build(map(title, uri, metaDescription, releaseDate));
 
 		assertThat("SyndEntry.title not as expected.", entry.getTitle(), equalTo(TITLE));
-		assertThat("SyndEntry.link not as expected.", entry.getLink(), equalTo("http://" + loc.getHost() + URI));
+		assertThat("SyndEntry.link not as expected.", entry.getLink(), equalTo("http://" + loc.getHostname() + URI));
 		assertThat("SyndEntry.description.value not as expected.", entry.getDescription().getValue(), equalTo(META_DESC));
 		assertThat("SyndEntry.description.type not as expected.", entry.getDescription().getType(), equalTo("text/plain"));
 		assertThat("SyndEntry.publishedDate not as expected.", entry.getPublishedDate(),


### PR DESCRIPTION
### What

Babbage was including port number in links provided by the rss service. These were breaking functionality in some non-web browser use cases.

Changed it to build the uri's on .hostname rather than .host (which is literally hostname + port)

### How to review

Run tests. Sanity check.

### Who can review

Anyone.
