### PR TITLE
fix RSS links to use https scheme and to link back to the original pa…

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/builder/SyndEntryBuilder.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/builder/SyndEntryBuilder.java
@@ -28,6 +28,7 @@ public class SyndEntryBuilder {
 
     private static final DateFormat DATE_FORMAT = appConfig().contentAPI().defaultContentDateFormat();
     private static final String DESCRIPTION_TYPE = "text/plain";
+    static final String HTTPS_SCHEME = "https://";
 
     private Map<String, Object> map;
 
@@ -60,7 +61,7 @@ public class SyndEntryBuilder {
     }
 
     private String getUri() {
-        return "http://" + ((Location) ThreadContext.getData(LOCATION_KEY)).getHostname() + get(uri);
+        return HTTPS_SCHEME + ((Location) ThreadContext.getData(LOCATION_KEY)).getHostname() + get(uri);
     }
 
     private String get(Field field) {

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/service/RssService.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/service/RssService.java
@@ -126,7 +126,7 @@ public class RssService {
 
         return new SyndFeedBuilder()
                 .type(rssType)
-                .link(((Location) ThreadContext.getData(LOCATION_KEY)).getHostname())
+                .link(request.getRequestURL().toString())
                 .category(title.toString())
                 .entries(searchResultsToSyndEntries(results))
                 .title(title.toString())
@@ -186,7 +186,7 @@ public class RssService {
     private SyndFeed generateSyndFeed(Optional<SearchResult> results, RssSearchFilter filter) {
         return new SyndFeedBuilder()
                 .type(rssType)
-                .link(((Location) ThreadContext.getData(LOCATION_KEY)).getHostname())
+                .link(filter.getRequest().getRequestURL().toString())
                 .category(filter.getUri())
                 .entries(searchResultsToSyndEntries(results))
                 .title(filter)

--- a/src/test/java/com/github/onsdigital/babbage/api/endpoint/rss/builder/SyndEntryBuilderTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/api/endpoint/rss/builder/SyndEntryBuilderTest.java
@@ -11,6 +11,7 @@ import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.github.onsdigital.babbage.api.endpoint.rss.builder.SyndEntryBuilder.HTTPS_SCHEME;
 import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
 import static com.github.onsdigital.babbage.search.model.field.Field.metaDescription;
 import static com.github.onsdigital.babbage.search.model.field.Field.releaseDate;
@@ -109,7 +110,7 @@ public class SyndEntryBuilderTest {
         SyndEntry entry = builder.build(map(title, uri, metaDescription, releaseDate));
 
         assertThat("SyndEntry.title not as expected.", entry.getTitle(), equalTo(TITLE));
-        assertThat("SyndEntry.link not as expected.", entry.getLink(), equalTo("http://" + loc.getHostname() + URI));
+        assertThat("SyndEntry.link not as expected.", entry.getLink(), equalTo(HTTPS_SCHEME + loc.getHostname() + URI));
         assertThat("SyndEntry.description.value not as expected.", entry.getDescription().getValue(), equalTo(META_DESC));
         assertThat("SyndEntry.description.type not as expected.", entry.getDescription().getType(), equalTo("text/plain"));
         assertThat("SyndEntry.publishedDate not as expected.", entry.getPublishedDate(),


### PR DESCRIPTION
Minor fixes for RSS.
- item links now use `https://` scheme.
- Channel link is no the uri the RSS link was taken from instead of always the homepage.
