### PR TITLE
The bottom of a page now always has a margin

### DIFF
--- a/src/main/web/templates/handlebars/content/base/publication.handlebars
+++ b/src/main/web/templates/handlebars/content/base/publication.handlebars
@@ -14,7 +14,7 @@
 		<div class="hide--md margin-top-sm--1">{{> partials/related/new-data relatedUri=(concat uri "/relateddata") relatedTitle="self" }}</div>
 
         {{!-- Content --}}
-        <article class="col col--md-36 col--lg-39 page-content__main-content js-sticky-toc__trigger">
+        <article class="col col--md-36 col--lg-39 page-content__main-content padding-bottom: js-sticky-toc__trigger">
             {{#each sections}}
                 <div id="{{slugify title}}" class="section__content--markdown js-sticky-toc__section">
                     <section>
@@ -87,6 +87,10 @@
                             </section>
                         </div>
                     {{/if}}
+                </div>
+            {{else}}
+             <!-- Margin at bottom of article if no Accordion present -->
+                <div class="margin-bottom--4">
                 </div>
             {{/if_any}}
         </article>


### PR DESCRIPTION
### What

The bottom of a page now always has a margin

This is needed to add space at the bottom of a page. Previously this space was only present when an accordion was the last element. The actual aim was to have space under the final 'Back to Table of Contents' text and link.

### How to review

1. Check the branch feature/typography-revamp 
2. Open an article, compendium, bulletin and ensure that under the last 'Back to Table of Contents' text/link, that there is margin under before the footer element. It might be worth checking this for pages that have different elements at the bottom of the page.

### Who can review

Anyone except me

