### PR TITLE
Release date is now optionally not shown on neutral articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,11 @@
 {
-  "lockfileVersion": 1
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ember": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ember/-/ember-1.0.3.tgz",
+      "integrity": "sha512-+sZwA/QhOYnHbuSShSxy3EONx2rZteZrCyMOtns3703eJsHf6b8gEEjMKjYhMUb+CdPyAgr8K9bN00kQBjllRA=="
+    }
+  }
 }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/ConditionHelpers.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/ConditionHelpers.java
@@ -72,6 +72,20 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
 
     },
 
+        //evaluates existance
+        if_null {
+            @Override
+            public CharSequence apply(Object context, Options o) throws IOException {
+                return context == null ? o.fn() : o.inverse();
+            }
+    
+            @Override
+            public void register(Handlebars handlebars) {
+                handlebars.registerHelper(this.name(), this);
+            }
+    
+        },
+
     //Render block if all given params are ok(ok as in resolves as true in javascript)
     if_all {
         @Override

--- a/src/main/web/templates/handlebars/content/t4-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t4-3.handlebars
@@ -28,7 +28,11 @@
                                 <p class="page-neutral-intro__content">{{description._abstract}}</p>
                             {{/if}}
                             {{#if description.releaseDate}}
-                                <p class="page-neutral-intro__meta margin-top--0 margin-bottom--3">{{df description.releaseDate}}</p>
+                                {{#if isReleaseDateEnabled}}    {{!-- presence check ---}}
+                                    {{#if_ne isReleaseDateEnabled false}} {{!-- value check ---}}
+                                        <p class="page-neutral-intro__meta margin-top--0 margin-bottom--3">{{df description.releaseDate}}</p>
+                                    {{/if_ne}}
+                                {{/if}}
                             {{/if}}
                         </div>
                     {{/block}}

--- a/src/main/web/templates/handlebars/content/t4-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t4-3.handlebars
@@ -28,11 +28,12 @@
                                 <p class="page-neutral-intro__content">{{description._abstract}}</p>
                             {{/if}}
                             {{#if description.releaseDate}}
-                                {{#if isReleaseDateEnabled}}    {{!-- presence check ---}}
-                                    {{#if_ne isReleaseDateEnabled false}} {{!-- value check ---}}
-                                        <p class="page-neutral-intro__meta margin-top--0 margin-bottom--3">{{df description.releaseDate}}</p>
-                                    {{/if_ne}}
+                                {{#if isReleaseDateEnabled}} {{!-- Exists and is true--}}
+                                    <p class="page-neutral-intro__meta margin-top--0 margin-bottom--3">{{df description.releaseDate}}</p>
                                 {{/if}}
+                                {{#if_null isReleaseDateEnabled}} {{!-- Does not exists --}}
+                                    <p class="page-neutral-intro__meta margin-top--0 margin-bottom--3">{{df description.releaseDate}}</p>
+                                {{/if_null}}
                             {{/if}}
                         </div>
                     {{/block}}


### PR DESCRIPTION
### What

Release date is now optionally not shown on neutral articles

If a neutral article has isReleaseDateEnabled flag then if that is set to false it will not display the release date.

### How to review

1. Create a neutral article
2. Create a regular article
3. Checkout the following corresponding Florence branch to this PR: https://github.com/ONSdigital/florence/pull/353
4.  Make the following and check that the correct behaviour is followed:
* Neutral Article, release date enabled - release date should be displayed in the header
* Neutral Article, release date disabled - release date should not be visible
* Article (not neutral) - release date should be visible

5. Open the article in step 1 - release date should be visible
6. Open the neutral article in step 2 ensure that the release date is visible

For sanity, it may be worth checking a regular compendium or bulletin to ensure their release date information has not been changed.

### Who can review

Anyone except me