### PR TITLE
Fix for neutral article 'release date enabled' not present.

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/ConditionHelpers.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/ConditionHelpers.java
@@ -76,14 +76,13 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
         if_null {
             @Override
             public CharSequence apply(Object context, Options o) throws IOException {
-                return context == null ? o.fn() : o.inverse();
+                return ( context == null || "null".equals(String.valueOf(context)) ) ? o.fn() : o.inverse();
             }
     
             @Override
             public void register(Handlebars handlebars) {
                 handlebars.registerHelper(this.name(), this);
             }
-    
         },
 
     //Render block if all given params are ok(ok as in resolves as true in javascript)

--- a/src/main/web/package-lock.json
+++ b/src/main/web/package-lock.json
@@ -34,7 +34,7 @@
             "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.14.0"
             }
         },
         "aws-sign2": {
@@ -56,7 +56,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "bl": {
@@ -65,7 +65,7 @@
             "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.0.6"
+                "readable-stream": "~2.0.5"
             }
         },
         "boom": {
@@ -74,7 +74,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -83,7 +83,7 @@
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -99,11 +99,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "combined-stream": {
@@ -112,7 +112,7 @@
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -133,9 +133,9 @@
             "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6",
-                "typedarray": "0.0.6"
+                "inherits": "~2.0.1",
+                "readable-stream": "~2.0.0",
+                "typedarray": "~0.0.5"
             }
         },
         "core-util-is": {
@@ -150,7 +150,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "dashdash": {
@@ -159,7 +159,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -189,7 +189,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "escape-string-regexp": {
@@ -204,7 +204,7 @@
             "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
             "dev": true,
             "requires": {
-                "merge": "1.2.0"
+                "merge": "^1.1.3"
             }
         },
         "extend": {
@@ -237,7 +237,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "forever-agent": {
@@ -252,9 +252,9 @@
             "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
             "dev": true,
             "requires": {
-                "async": "2.6.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "async": "^2.0.1",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.11"
             }
         },
         "fs-extra": {
@@ -263,11 +263,11 @@
             "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0",
-                "klaw": "1.3.1",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
             }
         },
         "fs.realpath": {
@@ -288,7 +288,7 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "getpass": {
@@ -297,7 +297,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -314,12 +314,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -334,10 +334,10 @@
             "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.12.2",
-                "is-my-json-valid": "2.17.1",
-                "pinkie-promise": "2.0.1"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -346,7 +346,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "hasha": {
@@ -355,8 +355,8 @@
             "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "pinkie-promise": "2.0.1"
+                "is-stream": "^1.0.1",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "hawk": {
@@ -365,10 +365,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "hoek": {
@@ -383,9 +383,9 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -394,8 +394,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -410,10 +410,10 @@
             "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
             "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-property": {
@@ -477,7 +477,7 @@
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonpointer": {
@@ -518,7 +518,7 @@
             "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.9"
             }
         },
         "lodash": {
@@ -545,7 +545,7 @@
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "dev": true,
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
             }
         },
         "minimatch": {
@@ -554,7 +554,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -590,7 +590,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "path-is-absolute": {
@@ -611,14 +611,14 @@
             "integrity": "sha1-RCSsog4U0lXAsIia9va4lz2hDg0=",
             "dev": true,
             "requires": {
-                "extract-zip": "1.5.0",
-                "fs-extra": "0.26.7",
-                "hasha": "2.2.0",
-                "kew": "0.7.0",
-                "progress": "1.1.8",
-                "request": "2.67.0",
-                "request-progress": "2.0.1",
-                "which": "1.2.14"
+                "extract-zip": "~1.5.0",
+                "fs-extra": "~0.26.4",
+                "hasha": "^2.2.0",
+                "kew": "~0.7.0",
+                "progress": "~1.1.8",
+                "request": "~2.67.0",
+                "request-progress": "~2.0.1",
+                "which": "~1.2.2"
             }
         },
         "pinkie": {
@@ -633,7 +633,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "process-nextick-args": {
@@ -660,12 +660,12 @@
             "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
             }
         },
         "request": {
@@ -674,26 +674,26 @@
             "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.6.0",
-                "bl": "1.0.3",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "1.0.1",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "node-uuid": "1.4.8",
-                "oauth-sign": "0.8.2",
-                "qs": "5.2.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.2.2",
-                "tunnel-agent": "0.4.3"
+                "aws-sign2": "~0.6.0",
+                "bl": "~1.0.0",
+                "caseless": "~0.11.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~1.0.0-rc3",
+                "har-validator": "~2.0.2",
+                "hawk": "~3.1.0",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "node-uuid": "~1.4.7",
+                "oauth-sign": "~0.8.0",
+                "qs": "~5.2.0",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.2.0",
+                "tunnel-agent": "~0.4.1"
             }
         },
         "request-progress": {
@@ -702,7 +702,7 @@
             "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
             "dev": true,
             "requires": {
-                "throttleit": "1.0.0"
+                "throttleit": "^1.0.0"
             }
         },
         "rimraf": {
@@ -711,7 +711,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "sntp": {
@@ -720,7 +720,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "source-map": {
@@ -734,14 +734,14 @@
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -770,7 +770,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "supports-color": {
@@ -815,8 +815,8 @@
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.3.tgz",
             "integrity": "sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==",
             "requires": {
-                "commander": "2.19.0",
-                "source-map": "0.6.1"
+                "commander": "~2.19.0",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "commander": {
@@ -838,9 +838,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -857,8 +857,8 @@
             "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
             "dev": true,
             "requires": {
-                "exec-sh": "0.2.1",
-                "minimist": "1.2.0"
+                "exec-sh": "^0.2.0",
+                "minimist": "^1.2.0"
             },
             "dependencies": {
                 "minimist": {
@@ -875,7 +875,7 @@
             "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "wrappy": {
@@ -896,7 +896,7 @@
             "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
             "dev": true,
             "requires": {
-                "fd-slicer": "1.0.1"
+                "fd-slicer": "~1.0.1"
             }
         }
     }


### PR DESCRIPTION
### What

Our new Handlebars helper `if_null` was checking for reference null, but the type of the property it is trying to compare with is a `charSequence` and so the value is not a reference to `null` but has the value of 'null' instead.

### How to review

1. On Florence open an old neutral article (or make a normal article normal and save) 
The release date should be visible and changeable. Likewise, it should be visible on the preview.

2. Toggle isReleaseDateEnabled off and save ensure that the release date field in Florence is no longer visible.

3. Toggle isReleaseDateEnabled back on (note the underlining state is technically different to step 1, step 1 the property was null, now it is false) ensure everything is like it was in step 1.

4. Open a normal article (not neutral) ensure release date in Florence is visible and in the preview.

5. Change a neutral article to a normal article and ensure release date in Florence is visible and in the preview

### Who can review

Anyone except me.