### PR TITLE
Fix for more publications link not going to publications section

### DIFF
--- a/src/main/web/templates/handlebars/partials/t3/highlighted-content.handlebars
+++ b/src/main/web/templates/handlebars/partials/t3/highlighted-content.handlebars
@@ -47,9 +47,4 @@
             </a>
         </div>
 </div>
-{{#if_eq highlighted.type "bulletin"}}
-    <a href="#statistical-bulletins" class="btn btn--primary btn--full-width margin-top--2 js-scroll">{{labels.more-publications}}</a>
-{{/if_eq}}
-{{#if_eq highlighted.type "article"}}
-    <a href="#articles" class="btn btn--primary btn--full-width margin-top--2 js-scroll">More articles</a>
-{{/if_eq}}
+<a href="#publications" class="btn btn--primary btn--full-width margin-top--2 js-scroll">{{labels.more-publications}}</a>


### PR DESCRIPTION
### What

Fix for more publications link not going to the publications section; this affected t3 pages

### How to review

Checkout this branch go to a t3 page, e.g. `.../peoplepopulationandcommunity/populationandmigration/internationalmigration`
Click on the following buttons
<img width="989" alt="Screenshot 2019-06-20 at 13 31 18" src="https://user-images.githubusercontent.com/47502916/59849514-c3f06a80-935f-11e9-85a6-9e83858020fd.png">

Ensure that both take you to the publication sections

### Who can review
Anyone except me

Anyone except me