### PR TITLE
update logger version an get rid of all ex.printstacktrace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <handlebars-java-version>4.0.3</handlebars-java-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.5.6</powermock.version>
-        <dp-logging.version>release~1.1.0</dp-logging.version>
+        <dp-logging.version>release~1.3.0</dp-logging.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/Hash.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/Hash.java
@@ -5,7 +5,6 @@ import com.github.onsdigital.babbage.content.client.ContentClient;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
 import com.github.onsdigital.babbage.error.BabbageException;
-import com.github.onsdigital.babbage.publishing.PublishingManager;
 import com.github.onsdigital.babbage.response.util.CacheControlHelper;
 import org.apache.commons.io.IOUtils;
 
@@ -15,6 +14,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.core.Context;
 import java.io.IOException;
 
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
 /**
@@ -45,6 +45,6 @@ public class Hash {
     void handleError(@Context HttpServletResponse response, int statusCode, Throwable e) throws IOException {
         response.setStatus(statusCode);
         IOUtils.write("Failed reading content!", response.getOutputStream());
-        e.printStackTrace();
+        error().exception(e).log("api Hash: error getting resource from content API");
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/publishing/Upcoming.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/publishing/Upcoming.java
@@ -16,6 +16,8 @@ import javax.ws.rs.POST;
 import java.io.IOException;
 import java.util.List;
 
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+
 /**
  * Created by bren on 16/12/15.
  */
@@ -45,7 +47,7 @@ public class Upcoming {
             response.setStatus(e.getStatusCode());
             return new ResponseMessage(e.getMessage());
         } catch (Exception e) {
-            e.printStackTrace();
+            error().exception(e).log("api Upcoming: error handling POST request");
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return new ResponseMessage("Failed processing uri list publish dates");
         }

--- a/src/main/java/com/github/onsdigital/babbage/api/util/SearchUtils.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/util/SearchUtils.java
@@ -128,8 +128,7 @@ public class SearchUtils {
                 // Use external search client
                 return SearchClient.getInstance().search(request, listType);
             } catch (Exception e) {
-                // Print stack trace and fall back on internal search client
-                e.printStackTrace();
+                error().exception(e).log("SearchUtils.populateSerp encountered an unexpected error");
             }
         }
 
@@ -330,7 +329,7 @@ public class SearchUtils {
                 SearchResult result = searchReq.call();
                 results.put(SearchType.DEPARTMENTS.getResultKey(), result);
             } catch (Exception e) {
-                e.printStackTrace();
+                error().exception(e).log("SearchUtils.searchDeparments encountered an unexpected error");
             }
         }
 

--- a/src/main/java/com/github/onsdigital/babbage/pdf/ChartImageReplacedElementFactory.java
+++ b/src/main/java/com/github/onsdigital/babbage/pdf/ChartImageReplacedElementFactory.java
@@ -1,14 +1,11 @@
 package com.github.onsdigital.babbage.pdf;
 
 import com.github.onsdigital.babbage.content.client.ContentClient;
-import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
 import com.github.onsdigital.babbage.highcharts.HighChartsExportClient;
 import com.github.onsdigital.babbage.template.TemplateService;
-import com.lowagie.text.BadElementException;
 import com.lowagie.text.Image;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.w3c.dom.Element;
 import org.xhtmlrenderer.extend.ReplacedElement;
 import org.xhtmlrenderer.extend.ReplacedElementFactory;
@@ -19,9 +16,10 @@ import org.xhtmlrenderer.pdf.ITextImageElement;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedHashMap;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 
 public class ChartImageReplacedElementFactory implements ReplacedElementFactory {
 
@@ -56,7 +54,7 @@ public class ChartImageReplacedElementFactory implements ReplacedElementFactory 
 
                 // The highcharts configuration is generated from a handlebars template with the chart JSON as input.
                 LinkedHashMap<String, Object> additionalData = new LinkedHashMap<>();
-                additionalData.put("width",600);
+                additionalData.put("width", 600);
                 String chartConfig = TemplateService.getInstance().renderChartConfiguration(contentResponse.getDataStream(),
                         additionalData);
 
@@ -74,10 +72,9 @@ public class ChartImageReplacedElementFactory implements ReplacedElementFactory 
                     }
                     return new ITextImageElement(fsImage);
                 }
-            } catch (IOException | BadElementException e) {
-                ExceptionUtils.getStackTrace(e);
-            } catch (ContentReadException e) {
-                e.printStackTrace();
+            } catch (Exception ex) {
+                error().exception(ex)
+                        .log("ChartImageReplacedElementFactory.createReplacedElement encountered an unexpected error");
             } finally {
                 IOUtils.closeQuietly(input);
             }

--- a/src/main/java/com/github/onsdigital/babbage/pdf/PDFGenerator.java
+++ b/src/main/java/com/github/onsdigital/babbage/pdf/PDFGenerator.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 
 /**
@@ -67,7 +68,10 @@ public class PDFGenerator {
 
             return pdfFile;
         } catch (Exception ex) {
-            ex.printStackTrace();
+            error().exception(ex)
+                    .data("uri", uri)
+                    .data("filename", fileName)
+                    .log("error generating PDF for uri");
             throw new RuntimeException("Failed generating pdf", ex);
         }
     }
@@ -96,6 +100,13 @@ public class PDFGenerator {
 
             os.close();
             os = null;
+
+        } catch (Exception ex) {
+            error().exception(ex)
+                    .data("url", url)
+                    .data("outputFile", outputFile)
+                    .log("error creating PDF");
+            throw ex;
         } finally {
             if (os != null) {
                 try {

--- a/src/main/java/com/github/onsdigital/babbage/pdf/PdfGeneratorLegacy.java
+++ b/src/main/java/com/github/onsdigital/babbage/pdf/PdfGeneratorLegacy.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 
 public class PdfGeneratorLegacy {
@@ -54,7 +55,10 @@ public class PdfGeneratorLegacy {
 
             return pdfFile;
         } catch (Exception ex) {
-            ex.printStackTrace();
+            error().exception(ex)
+                    .data("uri", uri)
+                    .data("fileName", fileName)
+                    .log("error generating legacy PDF");
             throw new RuntimeException("Failed generating pdf", ex);
         }
     }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/content/DataRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/content/DataRequestHandler.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.github.onsdigital.babbage.util.RequestUtil.getQueryParameters;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 
 /**
@@ -74,10 +75,9 @@ public class DataRequestHandler extends BaseRequestHandler {
                     .map((e) -> e.getValue().getClass().getName()).toArray()))
                     .log("registered list page request handlers");
 
-        } catch (Exception e) {
-            System.err.println("Failed initializing request handlers");
-            e.printStackTrace();
-            throw new RuntimeException(e);
+        } catch (Exception ex) {
+            error().exception(ex).log("error failed to initialize request handler");
+            throw new RuntimeException(ex);
         }
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageRssResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageRssResponse.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static java.util.Objects.requireNonNull;
 
 public class BabbageRssResponse extends BabbageResponse {
@@ -36,8 +37,7 @@ public class BabbageRssResponse extends BabbageResponse {
         try {
             new SyndFeedOutput().output(this.rssFeed, response.getWriter());
         } catch (FeedException ex) {
-            // TODO fix this.
-            ex.printStackTrace();
+            error().exception(ex).log("error creating RSS SyndFeedOutput for request");
         }
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpers.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpers.java
@@ -266,9 +266,8 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
                 ContentResponse stream = ContentClient.getInstance().getFileSize(uriString);
                 Map<String, Object> size = toMap(stream.getDataStream());
                 return humanReadableByteCount(((Number) size.get("fileSize")).longValue(), true);
-            } catch (Exception e) {
-                System.err.printf("Failed reading file size from content service, uri: %s cause: %s", uri, e.getMessage());
-                e.printStackTrace();
+            } catch (Exception ex) {
+                error().exception(ex).data("uri", uri).log("failed reading file size from content service");
                 return null;
             }
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/util/HelperUtils.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/util/HelperUtils.java
@@ -1,10 +1,11 @@
 package com.github.onsdigital.babbage.template.handlebars.helpers.util;
 
-import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Handlebars.Utils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 
 /**
  * Created by bren on 06/07/15.
@@ -65,8 +66,8 @@ public class HelperUtils {
             if (StringUtils.isNotEmpty(numberString)) {
                 try {
                     return Double.valueOf(numberString);
-                } catch (NumberFormatException e) {
-                    System.err.println(object + " is not a number!!");
+                } catch (NumberFormatException ex) {
+                    error().exception(ex).data("value", object).log("error converting value to number");
                     return null;
                 }
             }

--- a/src/test/java/com/github/onsdigital/babbage/util/TestsUtil.java
+++ b/src/test/java/com/github/onsdigital/babbage/util/TestsUtil.java
@@ -5,44 +5,47 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
+
 public class TestsUtil {
 
-	/**
-	 * Test helper method to set private field values on the class under test - i.e. mocked classes.
-	 */
-	public static void setPrivateField(Object target, String fieldName, Object newValue) throws NoSuchFieldException,
-			IllegalAccessException {
-		Field field = null;
-		Class clazz = target.getClass();
-		boolean hasParent = true;
+    /**
+     * Test helper method to set private field values on the class under test - i.e. mocked classes.
+     */
+    public static void setPrivateField(Object target, String fieldName, Object newValue) throws NoSuchFieldException,
+            IllegalAccessException {
+        Field field = null;
+        Class clazz = target.getClass();
+        boolean hasParent = true;
 
-		while (hasParent) {
-			try {
-				field = clazz.getDeclaredField(fieldName);
-				break;
-			} catch (NoSuchFieldException ex) {
-				if (clazz.getSuperclass().equals(Object.class)) {
-					hasParent = false;
-					String message = "Could not find field '%s' in class '%s' or any of super classes. Setting null";
-					System.out.println(String.format(message, fieldName, target.getClass().getSimpleName()));
-				} else {
-					clazz = clazz.getSuperclass();
-				}
-			}
-		}
-		FieldUtils.writeField(field, target, newValue, true);
-	}
+        while (hasParent) {
+            try {
+                field = clazz.getDeclaredField(fieldName);
+                break;
+            } catch (NoSuchFieldException ex) {
+                if (clazz.getSuperclass().equals(Object.class)) {
+                    hasParent = false;
+                    warn().data("field", fieldName)
+                            .data("class", target.getClass().getSimpleName())
+                            .log("Could not find field in class or any of super classes setting to null");
+                } else {
+                    clazz = clazz.getSuperclass();
+                }
+            }
+        }
+        FieldUtils.writeField(field, target, newValue, true);
+    }
 
-	/**
-	 * Test helper method to set private static field values on the class under test - i.e. mocked classes.
-	 */
-	public static void setPrivateStaticField(Object target, String fieldName, Object newValue) throws NoSuchFieldException,
-			IllegalAccessException {
-		Field field = target.getClass().getDeclaredField(fieldName);
-		field.setAccessible(true);
-		Field modifiersField = Field.class.getDeclaredField("modifiers");
-		modifiersField.setAccessible(true);
-		modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-		field.set(null, newValue);
-	}
+    /**
+     * Test helper method to set private static field values on the class under test - i.e. mocked classes.
+     */
+    public static void setPrivateStaticField(Object target, String fieldName, Object newValue) throws NoSuchFieldException,
+            IllegalAccessException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, newValue);
+    }
 }


### PR DESCRIPTION
### What
 - Updated dp-logging version to latest.
 - Replaced all uses of `ex.printStackTrac()` with call to logger.
 - Added _some_ better / missing logging to some obvious places.
