### PR TITLE
Loop 11 feature flag/config has been added

### DIFF
--- a/run-publishing.sh
+++ b/run-publishing.sh
@@ -22,6 +22,7 @@ export DEV_ENVIRONMENT="Y"
 export IS_PUBLISHING="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
+export ENABLE_LOOP11="N"
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/run-publishing.sh
+++ b/run-publishing.sh
@@ -22,7 +22,7 @@ export DEV_ENVIRONMENT="Y"
 export IS_PUBLISHING="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
-export ENABLE_LOOP11="N"
+export ENABLE_LOOP11=false
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,8 @@ export DP_LOGGING_FORMAT=pretty_json
 export DEV_ENVIRONMENT="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
+export ENABLE_LOOP11="N"
+
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,6 @@ export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
 export ENABLE_LOOP11="N"
 
-
 # Development: reloadable
 java $JAVA_OPTS \
  -Drestolino.realm=$REALM \

--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@ export DP_LOGGING_FORMAT=pretty_json
 export DEV_ENVIRONMENT="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
-export ENABLE_LOOP11="N"
+export ENABLE_LOOP11=false
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
@@ -36,7 +36,6 @@ public class Handlebars implements AppConfig {
     }
 
     private Handlebars() {
-
         defaultHandlebarsDatePattern = "d MMMM yyyy";
         mainContentTemplateName = "main";
         mainChartConfigTemplateName = "chart-config";
@@ -47,7 +46,6 @@ public class Handlebars implements AppConfig {
         enableLoop11 = getStringAsBool(ENABLE_LOOP11, "N");
         System.out.println("ENABLE_LOOP11");
         System.out.println(enableLoop11);
-
     }
 
     public String getHandlebarsDatePattern() {

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import static com.github.onsdigital.babbage.configuration.EnvVarUtils.getStringAsBool;
 import static com.github.onsdigital.babbage.configuration.EnvVarUtils.getValueOrDefault;
+import static com.github.onsdigital.babbage.configuration.EnvVarUtils.getValue;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 
 public class Handlebars implements AppConfig {
@@ -43,7 +44,7 @@ public class Handlebars implements AppConfig {
         templatesDir = getValueOrDefault(TEMPLATES_DIR_KEY, "target/web/templates/handlebars");
         templatesSuffix = getValueOrDefault(TEMPLATES_SUFFIX_KEY, ".handlebars");
         reloadTemplateChanges = getStringAsBool(RELOAD_TEMPLATES_KEY, "N");
-        enableLoop11 = getStringAsBool(ENABLE_LOOP11, "N");
+        enableLoop11 = Boolean.parseBoolean(getValue(ENABLE_LOOP11));
     }
 
     public String getHandlebarsDatePattern() {

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
@@ -44,8 +44,6 @@ public class Handlebars implements AppConfig {
         templatesSuffix = getValueOrDefault(TEMPLATES_SUFFIX_KEY, ".handlebars");
         reloadTemplateChanges = getStringAsBool(RELOAD_TEMPLATES_KEY, "N");
         enableLoop11 = getStringAsBool(ENABLE_LOOP11, "N");
-        System.out.println("ENABLE_LOOP11");
-        System.out.println(enableLoop11);
     }
 
     public String getHandlebarsDatePattern() {

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
@@ -71,7 +71,7 @@ public class Handlebars implements AppConfig {
         return reloadTemplateChanges;
     }
 
-    public boolean getEnableLoop11() {
+    public boolean isEnableLoop11() {
         return enableLoop11;
     }
 

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
@@ -14,6 +14,7 @@ public class Handlebars implements AppConfig {
     private static final String TEMPLATES_DIR_KEY = "TEMPLATES_DIR";
     private static final String TEMPLATES_SUFFIX_KEY = "TEMPLATES_SUFFIX";
     private static final String RELOAD_TEMPLATES_KEY = "RELOAD_TEMPLATES";
+    private static final String ENABLE_LOOP11 = "ENABLE_LOOP11";
 
     private final String defaultHandlebarsDatePattern;
     private final String mainContentTemplateName;
@@ -21,6 +22,7 @@ public class Handlebars implements AppConfig {
     private final String templatesDir;
     private final String templatesSuffix;
     private final boolean reloadTemplateChanges;
+    private final boolean enableLoop11;
 
     static Handlebars getInstance() {
         if (INSTANCE == null) {
@@ -34,6 +36,7 @@ public class Handlebars implements AppConfig {
     }
 
     private Handlebars() {
+
         defaultHandlebarsDatePattern = "d MMMM yyyy";
         mainContentTemplateName = "main";
         mainChartConfigTemplateName = "chart-config";
@@ -41,6 +44,10 @@ public class Handlebars implements AppConfig {
         templatesDir = getValueOrDefault(TEMPLATES_DIR_KEY, "target/web/templates/handlebars");
         templatesSuffix = getValueOrDefault(TEMPLATES_SUFFIX_KEY, ".handlebars");
         reloadTemplateChanges = getStringAsBool(RELOAD_TEMPLATES_KEY, "N");
+        enableLoop11 = getStringAsBool(ENABLE_LOOP11, "N");
+        System.out.println("ENABLE_LOOP11");
+        System.out.println(enableLoop11);
+
     }
 
     public String getHandlebarsDatePattern() {
@@ -67,6 +74,10 @@ public class Handlebars implements AppConfig {
         return reloadTemplateChanges;
     }
 
+    public boolean getEnableLoop11() {
+        return enableLoop11;
+    }
+
     @Override
     public Map<String, Object> getConfig() {
         Map<String, Object> config = new HashMap<>();
@@ -76,6 +87,7 @@ public class Handlebars implements AppConfig {
         config.put("templatesDir", templatesDir);
         config.put("templatesSuffix", templatesSuffix);
         config.put("reloadTemplateChanges", reloadTemplateChanges);
+        config.put("enableLoop11", enableLoop11);
         return config;
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -16,6 +16,8 @@ import java.util.LinkedHashMap;
 
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 
+import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
+
 /**
  * Created by bren on 28/05/15.
  * <p>
@@ -37,6 +39,7 @@ public class PageRequestHandler extends BaseRequestHandler {
             if(RequestUtil.getQueryParameters(request).containsKey("pdf")) {
                 additionalData.put("pdf_style", true);
             }
+            additionalData.put("EnableLoop11", appConfig().handlebars().getEnableLoop11());
             String html = TemplateService.getInstance().renderContent(dataStream, additionalData);
             return new BabbageContentBasedStringResponse(contentResponse,html, TEXT_HTML);
         }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -39,7 +39,7 @@ public class PageRequestHandler extends BaseRequestHandler {
             if(RequestUtil.getQueryParameters(request).containsKey("pdf")) {
                 additionalData.put("pdf_style", true);
             }
-            additionalData.put("EnableLoop11", appConfig().handlebars().getEnableLoop11());
+            additionalData.put("EnableLoop11", appConfig().handlebars().isEnableLoop11());
             String html = TemplateService.getInstance().renderContent(dataStream, additionalData);
             return new BabbageContentBasedStringResponse(contentResponse,html, TEXT_HTML);
         }

--- a/src/main/web/templates/handlebars/base/base.handlebars
+++ b/src/main/web/templates/handlebars/base/base.handlebars
@@ -16,4 +16,6 @@
 {{#block "block-footer"}}
 	{{> partials/footer}}
 {{/block}}
-<script src="//cdn.loop11.com/embed.js" type="text/javascript" async="async"></script>
+{{#if EnableLoop11}}
+    <script src="//cdn.loop11.com/embed.js" type="text/javascript" async="async"></script>
+{{/if}}


### PR DESCRIPTION
### What

- Template files have been updated to only allow  loop11 if set to enabled
- Loop 11 configuration/feature flag has been added to the run.sh and run-publishing shell commands.
- Loop 11 configuration read in from a new env var.

### How to review

Test loop11 by enabling it and disabling it, have tested locally and the following happens.
`ENABLE_LOOP11=true` :
<img width="1680" alt="Screenshot 2020-01-27 at 11 08 22" src="https://user-images.githubusercontent.com/47502916/73171157-f9c8af00-40f7-11ea-82ff-ee344835c0e9.png">


`ENABLE_LOOP11=false`:
<img width="1680" alt="Screenshot 2020-01-27 at 11 09 29" src="https://user-images.githubusercontent.com/47502916/73171167-00572680-40f8-11ea-8b20-5bed7517c1c5.png">


Note initially this config was Y/N as per pictures. If not set it defaults to false.
Ensure that the 'Java' is correct in terms of following our design patterns and principles.

### Who can review

Anyone except me
