### PR TITLE
change banner markup from one-col to two-col setup

### DIFF
--- a/src/main/web/templates/handlebars/partials/banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/banner.handlebars
@@ -1,16 +1,18 @@
 {{#resolve "/"}}
-		{{#if serviceMessage}}
-			<div class="banner">
-				<div class="wrapper banner--bottom-border">
-					<div class="col-wrap">
-						<div class="col">
-							<span class="banner__icon icon icon-info"></span>
-							<div class="banner__body">
-								{{md serviceMessage}}
-							</div>
+	{{#if serviceMessage}}
+		<div class="banner">
+			<div class="wrapper banner--bottom-border">
+				<div class="banner__container col-wrap">
+					<div class="col col--md-2 col--lg-2">
+						<span class="banner__icon icon icon-info"></span>
+					</div>
+					<div class="col col--md-45 col--lg-55">
+						<div class="banner__body">
+							{{md serviceMessage}}
 						</div>
 					</div>
 				</div>
 			</div>
-		{{/if}}
-	{{/resolve}}
+		</div>
+	{{/if}}
+{{/resolve}}


### PR DESCRIPTION
### What

Issue: Service message 'i' icon would be displaced and float away in medium sized viewports. The service message banner has subsequently been updated to be a two-column setup rather than one in order to align the icon with the service message in different contexts.

### How to review

Check changes to markup and review service message banner across various browsers and widths (can be found on the ONS homepage)

### Who can review

Anyone bar me.
