### PR TITLE
Feature/cookies banner

### DIFF
--- a/run-publishing.sh
+++ b/run-publishing.sh
@@ -23,7 +23,7 @@ export IS_PUBLISHING="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
 export ENABLE_LOOP11=false
-export ENABLE_COOKIES_CONTROL=true
+export ENABLE_COOKIES_CONTROL=false
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/run-publishing.sh
+++ b/run-publishing.sh
@@ -23,6 +23,7 @@ export IS_PUBLISHING="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
 export ENABLE_LOOP11=false
+export ENABLE_COOKIES_CONTROL=true
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/run.sh
+++ b/run.sh
@@ -22,6 +22,7 @@ export DEV_ENVIRONMENT="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
 export ENABLE_LOOP11=false
+export ENABLE_COOKIES_CONTROL=false
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
@@ -16,6 +16,7 @@ public class Handlebars implements AppConfig {
     private static final String TEMPLATES_SUFFIX_KEY = "TEMPLATES_SUFFIX";
     private static final String RELOAD_TEMPLATES_KEY = "RELOAD_TEMPLATES";
     private static final String ENABLE_LOOP11 = "ENABLE_LOOP11";
+    private static final String ENABLE_COOKIES_CONTROL = "ENABLE_COOKIES_CONTROL";
 
     private final String defaultHandlebarsDatePattern;
     private final String mainContentTemplateName;
@@ -24,6 +25,7 @@ public class Handlebars implements AppConfig {
     private final String templatesSuffix;
     private final boolean reloadTemplateChanges;
     private final boolean enableLoop11;
+    private final boolean enableCookiesControl;
 
     static Handlebars getInstance() {
         if (INSTANCE == null) {
@@ -45,6 +47,7 @@ public class Handlebars implements AppConfig {
         templatesSuffix = getValueOrDefault(TEMPLATES_SUFFIX_KEY, ".handlebars");
         reloadTemplateChanges = getStringAsBool(RELOAD_TEMPLATES_KEY, "N");
         enableLoop11 = Boolean.parseBoolean(getValue(ENABLE_LOOP11));
+        enableCookiesControl = Boolean.parseBoolean(getValue(ENABLE_COOKIES_CONTROL));
     }
 
     public String getHandlebarsDatePattern() {
@@ -75,6 +78,10 @@ public class Handlebars implements AppConfig {
         return enableLoop11;
     }
 
+    public boolean isEnableCookiesControl() {
+        return enableCookiesControl;
+    }
+
     @Override
     public Map<String, Object> getConfig() {
         Map<String, Object> config = new HashMap<>();
@@ -85,6 +92,7 @@ public class Handlebars implements AppConfig {
         config.put("templatesSuffix", templatesSuffix);
         config.put("reloadTemplateChanges", reloadTemplateChanges);
         config.put("enableLoop11", enableLoop11);
+        config.put("enableCookiesControl", enableCookiesControl);
         return config;
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -9,14 +9,14 @@ import com.github.onsdigital.babbage.response.base.BabbageResponse;
 import com.github.onsdigital.babbage.template.TemplateService;
 import com.github.onsdigital.babbage.util.RequestUtil;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedHashMap;
 
-import static javax.ws.rs.core.MediaType.TEXT_HTML;
-
 import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
+import static javax.ws.rs.core.MediaType.TEXT_HTML;
 
 /**
  * Created by bren on 28/05/15.
@@ -26,6 +26,7 @@ import static com.github.onsdigital.babbage.configuration.ApplicationConfigurati
 public class PageRequestHandler extends BaseRequestHandler {
 
     private static final String REQUEST_TYPE = "/";
+    private static final String COOKIES_PREFERENCES_SET_NAME = "cookies_preferences_set";
 
     @Override
     public BabbageResponse get(String uri, HttpServletRequest request) throws IOException, ContentReadException {
@@ -34,19 +35,37 @@ public class PageRequestHandler extends BaseRequestHandler {
 
     public static BabbageResponse getPage(String uri, HttpServletRequest request) throws ContentReadException, IOException {
         ContentResponse contentResponse = ContentClient.getInstance().getContent(uri);
-        try (InputStream dataStream = contentResponse.getDataStream()){
+        try (InputStream dataStream = contentResponse.getDataStream()) {
             LinkedHashMap<String, Object> additionalData = new LinkedHashMap<>();
-            if(RequestUtil.getQueryParameters(request).containsKey("pdf")) {
+            if (RequestUtil.getQueryParameters(request).containsKey("pdf")) {
                 additionalData.put("pdf_style", true);
             }
             additionalData.put("EnableLoop11", appConfig().handlebars().isEnableLoop11());
+            additionalData.put("EnableCookiesControl", appConfig().handlebars().isEnableCookiesControl());
+            additionalData.put("CookiesPreferencesSet", isCookiesPreferenceSet(request));
             String html = TemplateService.getInstance().renderContent(dataStream, additionalData);
-            return new BabbageContentBasedStringResponse(contentResponse,html, TEXT_HTML);
+            return new BabbageContentBasedStringResponse(contentResponse, html, TEXT_HTML);
         }
     }
 
     @Override
     public String getRequestType() {
         return REQUEST_TYPE;
+    }
+
+    static boolean isCookiesPreferenceSet(HttpServletRequest request) {
+        if (request == null) {
+            return false;
+        }
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return false;
+        }
+        for (int i = 0; i < cookies.length; i++) {
+            if (COOKIES_PREFERENCES_SET_NAME.equals(cookies[i].getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -26,7 +26,13 @@ import static javax.ws.rs.core.MediaType.TEXT_HTML;
 public class PageRequestHandler extends BaseRequestHandler {
 
     private static final String REQUEST_TYPE = "/";
+    private static final String PDF = "pdf";
+    private static final String PDF_STYLE = "pdf_style";
+    private static final String ENABLE_LOOP11 = "EnableLoop11";
+    private static final String ENABLE_COOKIES_CONTROL = "EnableCookiesControl";
     private static final String COOKIES_PREFERENCES_SET_NAME = "cookies_preferences_set";
+    private static final String COOKIES_PREFERENCES_SET = "CookiesPreferencesSet";
+  
 
     @Override
     public BabbageResponse get(String uri, HttpServletRequest request) throws IOException, ContentReadException {
@@ -37,12 +43,12 @@ public class PageRequestHandler extends BaseRequestHandler {
         ContentResponse contentResponse = ContentClient.getInstance().getContent(uri);
         try (InputStream dataStream = contentResponse.getDataStream()) {
             LinkedHashMap<String, Object> additionalData = new LinkedHashMap<>();
-            if (RequestUtil.getQueryParameters(request).containsKey("pdf")) {
-                additionalData.put("pdf_style", true);
+            if (RequestUtil.getQueryParameters(request).containsKey(PDF)) {
+                additionalData.put(PDF_STYLE, true);
             }
-            additionalData.put("EnableLoop11", appConfig().handlebars().isEnableLoop11());
-            additionalData.put("EnableCookiesControl", appConfig().handlebars().isEnableCookiesControl());
-            additionalData.put("CookiesPreferencesSet", isCookiesPreferenceSet(request));
+            additionalData.put(ENABLE_LOOP11, appConfig().handlebars().isEnableLoop11());
+            additionalData.put(ENABLE_COOKIES_CONTROL, appConfig().handlebars().isEnableCookiesControl());
+            additionalData.put(COOKIES_PREFERENCES_SET, isCookiesPreferenceSet(request));
             String html = TemplateService.getInstance().renderContent(dataStream, additionalData);
             return new BabbageContentBasedStringResponse(contentResponse, html, TEXT_HTML);
         }

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -472,3 +472,12 @@ search-try-other=You could try one of the following:
 search-diff-words=search again using different words
 search-remove-filters=remove any filters selected
 a-z-of-statistical-bulletins=A to Z of statistical bulletins
+
+# Cookies Banner
+cookies-banner-title=Tell us whether you accept cookies
+cookies-banner-info=We would like to <a href="/cookies-preferences">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
+cookies-banner-why-we-use=We use this information to make the website work as well as possible and improve our services.
+cookies-banner-accept-action=Accept all cookies
+cookies-banner-set-preferences-action=Set Cookie preferences
+cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies-preferences">change your cookie settings</a> at any time.
+cookies-banner-hide-action=Hide

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -475,9 +475,9 @@ a-z-of-statistical-bulletins=A to Z of statistical bulletins
 
 # Cookies Banner
 cookies-banner-title=Tell us whether you accept cookies
-cookies-banner-info=We would like to <a href="/cookies/edit">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
+cookies-banner-info=We would like to <a href="/cookies">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
 cookies-banner-why-we-use=We use this information to make the website work as well as possible and improve our services.
 cookies-banner-accept-action=Accept all cookies
 cookies-banner-set-preferences-action=Set Cookie preferences
-cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies/edit">change your cookie settings</a> at any time.
+cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies">change your cookie settings</a> at any time.
 cookies-banner-hide-action=Hide

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -475,9 +475,9 @@ a-z-of-statistical-bulletins=A to Z of statistical bulletins
 
 # Cookies Banner
 cookies-banner-title=Tell us whether you accept cookies
-cookies-banner-info=We would like to <a href="/cookies-preferences">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
+cookies-banner-info=We would like to <a href="/cookies/edit">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
 cookies-banner-why-we-use=We use this information to make the website work as well as possible and improve our services.
 cookies-banner-accept-action=Accept all cookies
 cookies-banner-set-preferences-action=Set Cookie preferences
-cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies-preferences">change your cookie settings</a> at any time.
+cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies/edit">change your cookie settings</a> at any time.
 cookies-banner-hide-action=Hide

--- a/src/main/resources/LabelsBundle_cy.properties
+++ b/src/main/resources/LabelsBundle_cy.properties
@@ -470,9 +470,9 @@ a-z-of-statistical-bulletins=A to Z of statistical bulletins
 
 # Cookies Banner
 cookies-banner-title=Tell us whether you accept cookies
-cookies-banner-info=We would like to <a href="/cookies/edit">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
+cookies-banner-info=We would like to <a href="/cookies">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
 cookies-banner-why-we-use=We use this information to make the website work as well as possible and improve our services.
 cookies-banner-accept-action=Accept all cookies
 cookies-banner-set-preferences-action=Set Cookie preferences
-cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies/edit">change your cookie settings</a> at any time.
+cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies">change your cookie settings</a> at any time.
 cookies-banner-hide-action=Hide

--- a/src/main/resources/LabelsBundle_cy.properties
+++ b/src/main/resources/LabelsBundle_cy.properties
@@ -467,3 +467,12 @@ search-try-other=You could try one of the following
 search-diff-words=search again using different words
 search-remove-filters=remove any filters selected
 a-z-of-statistical-bulletins=A to Z of statistical bulletins
+
+# Cookies Banner
+cookies-banner-title=Tell us whether you accept cookies
+cookies-banner-info=We would like to <a href="/cookies-preferences">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
+cookies-banner-why-we-use=We use this information to make the website work as well as possible and improve our services.
+cookies-banner-accept-action=Accept all cookies
+cookies-banner-set-preferences-action=Set Cookie preferences
+cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies-preferences">change your cookie settings</a> at any time.
+cookies-banner-hide-action=Hide

--- a/src/main/resources/LabelsBundle_cy.properties
+++ b/src/main/resources/LabelsBundle_cy.properties
@@ -470,9 +470,9 @@ a-z-of-statistical-bulletins=A to Z of statistical bulletins
 
 # Cookies Banner
 cookies-banner-title=Tell us whether you accept cookies
-cookies-banner-info=We would like to <a href="/cookies-preferences">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
+cookies-banner-info=We would like to <a href="/cookies/edit">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>.</p>
 cookies-banner-why-we-use=We use this information to make the website work as well as possible and improve our services.
 cookies-banner-accept-action=Accept all cookies
 cookies-banner-set-preferences-action=Set Cookie preferences
-cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies-preferences">change your cookie settings</a> at any time.
+cookies-banner-success=You’ve accepted all cookies. You can <a href="/cookies/edit">change your cookie settings</a> at any time.
 cookies-banner-hide-action=Hide

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -23,7 +23,7 @@
                 <div class="cookies-banner__message">
                     <p class="cookies-banner__confirmation-message">
                         {{{labels.cookies-banner-success}}}
-                        <button type="button" class="cookie-banner__hide-button js-hide-cookies-banner">{{labels.cookies-banner-hide-action}}</button>
+                        <button type="button" class="cookies-banner__button--hide js-hide-cookies-banner">{{labels.cookies-banner-hide-action}}</button>
                     </p>
                 </div>
             </div>

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -1,0 +1,33 @@
+<form action="/cookies/accept-all" method="POST" id="global-cookie-message" class="cookies-banner js-cookies-banner-form clearfix"
+        aria-label="cookie banner" style="display: block;">
+    <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
+        <div class="col col--md-two-thirds col--lg-two-thirds">
+            <div class="cookies-banner__message">
+                <h3 class="cookies-banner__heading">Tell us whether you accept cookies</h3>
+                <p class="cookies-banner__body">We would like to <a href="/help/cookies">use cookies to collect
+                            information</a> about how you use <strong>ons.gov.uk</strong>.</p>
+                <p class="cookies-banner__body">We use this information to make the website work as well as possible and improve our services.</p>
+            </div>
+            <div class="cookies-banner__buttons">
+                <div class="cookies-banner__button cookies-banner__button--accept">
+                    <button class="btn btn--primary btn--full-width js-accept-cookies" type="submit">Accept all cookies</button>
+                </div>
+                <div class="cookies-banner__button">
+                    <a role="button" href="/help/cookiesandprivacy" class="btn btn--primary btn--full-width">Set Cookie Preferences</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="cookies-banner__confirmation cookies-banner hidden js-cookies-banner-confirmation" tabindex="-1">
+        <div class="cookies-banner__wrapper wrapper">
+            <div class="col">
+                <div class="cookies-banner__message">
+                    <p class="cookies-banner__confirmation-message">
+                        You’ve accepted all cookies. You can <a class="govuk-link" href="/help/cookies">change your cookie settings</a> at any time.
+                        <button type="button" class="cookie-banner__hide-button js-hide-cookies-banner">Hide</button>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -1,5 +1,5 @@
 {{#unless CookiesPreferencesSet}}
-    <form action="/cookie/accept-all" method="GET" id="global-cookie-message" class="cookies-banner js-cookies-banner-form clearfix"
+    <form action="/cookies/accept-all" method="GET" id="global-cookie-message" class="cookies-banner js-cookies-banner-form clearfix"
             aria-label="cookie banner" style="display: block;">
         <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
             <div class="col col--md-two-thirds col--lg-two-thirds">

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -13,7 +13,7 @@
                         <button class="btn btn--primary btn--full-width js-accept-cookies" type="submit">{{labels.cookies-banner-accept-action}}</button>
                     </div>
                     <div class="cookies-banner__button">
-                        <a role="button" href="/cookies/edit" class="btn btn--primary btn--full-width">{{labels.cookies-banner-set-preferences-action}}</a>
+                        <a role="button" href="/cookies" class="btn btn--primary btn--full-width">{{labels.cookies-banner-set-preferences-action}}</a>
                     </div>
                 </div>
             </div>

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -13,7 +13,7 @@
                         <button class="btn btn--primary btn--full-width js-accept-cookies" type="submit">{{labels.cookies-banner-accept-action}}</button>
                     </div>
                     <div class="cookies-banner__button">
-                        <a role="button" href="/cookies-preferences" class="btn btn--primary btn--full-width">{{labels.cookies-banner-set-preferences-action}}</a>
+                        <a role="button" href="/cookies/edit" class="btn btn--primary btn--full-width">{{labels.cookies-banner-set-preferences-action}}</a>
                     </div>
                 </div>
             </div>

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -3,17 +3,16 @@
     <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
         <div class="col col--md-two-thirds col--lg-two-thirds">
             <div class="cookies-banner__message">
-                <h3 class="cookies-banner__heading">Tell us whether you accept cookies</h3>
-                <p class="cookies-banner__body">We would like to <a href="/help/cookies">use cookies to collect
-                            information</a> about how you use <strong>ons.gov.uk</strong>.</p>
-                <p class="cookies-banner__body">We use this information to make the website work as well as possible and improve our services.</p>
+                <h3 class="cookies-banner__heading">{{labels.cookies-banner-title}}</h3>
+                <p class="cookies-banner__body">{{{labels.cookies-banner-info}}}</p>
+                <p class="cookies-banner__body">{{labels.cookies-banner-why-we-use}}</p>
             </div>
             <div class="cookies-banner__buttons">
                 <div class="cookies-banner__button cookies-banner__button--accept">
-                    <button class="btn btn--primary btn--full-width js-accept-cookies" type="submit">Accept all cookies</button>
+                    <button class="btn btn--primary btn--full-width js-accept-cookies" type="submit">{{labels.cookies-banner-accept-action}}</button>
                 </div>
                 <div class="cookies-banner__button">
-                    <a role="button" href="/help/cookiesandprivacy" class="btn btn--primary btn--full-width">Set Cookie Preferences</a>
+                    <a role="button" href="/cookies-preferences" class="btn btn--primary btn--full-width">{{labels.cookies-banner-set-preferences-action}}</a>
                 </div>
             </div>
         </div>
@@ -23,8 +22,8 @@
             <div class="col">
                 <div class="cookies-banner__message">
                     <p class="cookies-banner__confirmation-message">
-                        You’ve accepted all cookies. You can <a class="govuk-link" href="/help/cookies">change your cookie settings</a> at any time.
-                        <button type="button" class="cookie-banner__hide-button js-hide-cookies-banner">Hide</button>
+                        {{{labels.cookies-banner-success}}}
+                        <button type="button" class="cookie-banner__hide-button js-hide-cookies-banner">{{labels.cookies-banner-hide-action}}</button>
                     </p>
                 </div>
             </div>

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -2,7 +2,7 @@
     <form action="/cookies/accept-all" method="GET" id="global-cookie-message" class="cookies-banner js-cookies-banner-form clearfix"
             aria-label="cookie banner" style="display: block;">
         <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
-            <div class="col col--md-two-thirds col--lg-two-thirds">
+            <div>
                 <div class="cookies-banner__message">
                     <h3 class="cookies-banner__heading">{{labels.cookies-banner-title}}</h3>
                     <p class="cookies-banner__body">{{{labels.cookies-banner-info}}}</p>

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -1,32 +1,34 @@
-<form action="/cookie/accept-all" method="GET" id="global-cookie-message" class="cookies-banner js-cookies-banner-form clearfix"
-        aria-label="cookie banner" style="display: block;">
-    <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
-        <div class="col col--md-two-thirds col--lg-two-thirds">
-            <div class="cookies-banner__message">
-                <h3 class="cookies-banner__heading">{{labels.cookies-banner-title}}</h3>
-                <p class="cookies-banner__body">{{{labels.cookies-banner-info}}}</p>
-                <p class="cookies-banner__body">{{labels.cookies-banner-why-we-use}}</p>
-            </div>
-            <div class="cookies-banner__buttons">
-                <div class="cookies-banner__button cookies-banner__button--accept">
-                    <button class="btn btn--primary btn--full-width js-accept-cookies" type="submit">{{labels.cookies-banner-accept-action}}</button>
-                </div>
-                <div class="cookies-banner__button">
-                    <a role="button" href="/cookies-preferences" class="btn btn--primary btn--full-width">{{labels.cookies-banner-set-preferences-action}}</a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="cookies-banner__confirmation cookies-banner hidden js-cookies-banner-confirmation" tabindex="-1">
-        <div class="cookies-banner__wrapper wrapper">
-            <div class="col">
+{{#unless CookiesPreferencesSet}}
+    <form action="/cookie/accept-all" method="GET" id="global-cookie-message" class="cookies-banner js-cookies-banner-form clearfix"
+            aria-label="cookie banner" style="display: block;">
+        <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
+            <div class="col col--md-two-thirds col--lg-two-thirds">
                 <div class="cookies-banner__message">
-                    <p class="cookies-banner__confirmation-message">
-                        {{{labels.cookies-banner-success}}}
-                        <button type="button" class="cookies-banner__button--hide js-hide-cookies-banner">{{labels.cookies-banner-hide-action}}</button>
-                    </p>
+                    <h3 class="cookies-banner__heading">{{labels.cookies-banner-title}}</h3>
+                    <p class="cookies-banner__body">{{{labels.cookies-banner-info}}}</p>
+                    <p class="cookies-banner__body">{{labels.cookies-banner-why-we-use}}</p>
+                </div>
+                <div class="cookies-banner__buttons">
+                    <div class="cookies-banner__button cookies-banner__button--accept">
+                        <button class="btn btn--primary btn--full-width js-accept-cookies" type="submit">{{labels.cookies-banner-accept-action}}</button>
+                    </div>
+                    <div class="cookies-banner__button">
+                        <a role="button" href="/cookies-preferences" class="btn btn--primary btn--full-width">{{labels.cookies-banner-set-preferences-action}}</a>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-</form>
+        <div class="cookies-banner__confirmation cookies-banner hidden js-cookies-banner-confirmation" tabindex="-1">
+            <div class="cookies-banner__wrapper wrapper">
+                <div class="col">
+                    <div class="cookies-banner__message">
+                        <p class="cookies-banner__confirmation-message">
+                            {{{labels.cookies-banner-success}}}
+                            <button type="button" class="cookies-banner__button--hide js-hide-cookies-banner">{{labels.cookies-banner-hide-action}}</button>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+{{/unless}}

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -1,4 +1,4 @@
-<form action="/cookies/accept-all" method="POST" id="global-cookie-message" class="cookies-banner js-cookies-banner-form clearfix"
+<form action="/cookie/accept-all" method="GET" id="global-cookie-message" class="cookies-banner js-cookies-banner-form clearfix"
         aria-label="cookie banner" style="display: block;">
     <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
         <div class="col col--md-two-thirds col--lg-two-thirds">

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -3,7 +3,9 @@
     <a class="skiplink" href="#main" tabindex="0">
         Skip to main content
     </a>
-	{{> partials/cookies-banner}}
+	{{#if EnableCookiesControl}}
+		{{> partials/cookies-banner}}
+	{{/if}}
 	{{!-- produced for download analytics function --}}
 	<div id="pagePath" class="hide">{{uri}}</div>
 	{{!-- LANGUAGE TOGGLE AND SECONDARY NAV - DESKTOP --}}

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -3,6 +3,7 @@
     <a class="skiplink" href="#main" tabindex="0">
         Skip to main content
     </a>
+	{{> partials/cookies-banner}}
 	{{!-- produced for download analytics function --}}
 	<div id="pagePath" class="hide">{{uri}}</div>
 	{{!-- LANGUAGE TOGGLE AND SECONDARY NAV - DESKTOP --}}

--- a/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
@@ -40,6 +40,14 @@ public class PageRequestHandlerTest {
     }
 
     @Test
+    public void isCookiesPreference_CookiesIsEmptyArray_ReturnsFalse() {
+        Cookie[] cookies = new Cookie[]{};
+        when(request.getCookies()).thenReturn(cookies);
+        boolean result = isCookiesPreferenceSet(request);
+        assertFalse(result);
+    }
+
+    @Test
     public void isCookiesPreference_CookieNotExist_ReturnsFalse() {
         Cookie[] cookies = new Cookie[]{cookie};
         when(cookie.getName()).thenReturn("test_cookie");

--- a/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
@@ -1,0 +1,63 @@
+package com.github.onsdigital.babbage.request.handler;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import static com.github.onsdigital.babbage.request.handler.PageRequestHandler.isCookiesPreferenceSet;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class PageRequestHandlerTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private Cookie cookie;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void isCookiesPreferenceSet_RequestIsNull_ReturnsFalse() {
+        boolean result = isCookiesPreferenceSet(null);
+        assertFalse(result);
+    }
+
+    @Test
+    public void isCookiesPreference_CookiesIsNull_ReturnsFalse() {
+        when(request.getCookies()).thenReturn(null);
+        boolean result = isCookiesPreferenceSet(request);
+        assertFalse(result);
+    }
+
+    @Test
+    public void isCookiesPreference_CookieNotExist_ReturnsFalse() {
+        Cookie[] cookies = new Cookie[]{cookie};
+        when(cookie.getName()).thenReturn("test_cookie");
+        when(request.getCookies()).thenReturn(cookies);
+
+        boolean result = isCookiesPreferenceSet(request);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void isCookiesPreference_CookieExists_ReturnsTrue() {
+        Cookie[] cookies = new Cookie[]{cookie};
+        when(cookie.getName()).thenReturn("cookies_preferences_set");
+        when(request.getCookies()).thenReturn(cookies);
+
+        boolean result = isCookiesPreferenceSet(request);
+
+        assertTrue(result);
+    }
+}


### PR DESCRIPTION
### What

- Added markup for cookies banner
- Added localisation setup for cookies banner
- Conditional rendering logic for the cookies banne. A feature flag, `EnableCookiesControl` and `CookiesPreferencesSet` property.
- Updated `PageRequestHandler` to send `CookiesPreferencesSet` property. Added `PageRequestHandlerTest` suite.

### How to review

- Check that localisation tags are clear and make sense
- Check that localisation copy aligns with prototype
- Check that markup aligns with requirements
- Check Java code follows best practices

**To test in the browser**
1a. Pull `dp-frontend-dataset-controller` and checkout `feature/flag-cookie-controller`
1b. Pull `sixteens` and checkout `feature/cookies-banner-styling` and run
2. Run the dataset controller. Do so with the flag, `ENABLE_COOKIES_CONTROL=true`, to have the cookies banner render
3. View cookies banner on a Babbage served page - i.e., the homepage
4. Testing the 'Accept all' button would need the `dp-frontend-cookies-controller` running, specifically on the `feature/populate-controller` branch. The route should be `/cookie/accept-all`
5. Set Cookies Preferences button should route to the `/cookies` page (currently pending)

### Who can review

Anyone bar me
