### PR TITLE
removed margin-top class from cookies banner buttons

### DIFF
--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -10,10 +10,10 @@
                 </div>
                 <div class="cookies-banner__buttons">
                     <div class="cookies-banner__button cookies-banner__button--accept">
-                        <button class="btn btn--full-width btn--primary btn--focus margin-top--2 margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" type="submit">{{labels.cookies-banner-accept-action}}</button>
+                        <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" type="submit">{{labels.cookies-banner-accept-action}}</button>
                     </div>
                     <div class="cookies-banner__button">
-                        <a role="button" href="/cookies" class="btn btn--full-width btn--primary btn--focus margin-top--2 margin-right--2 font-weight-700 font-size--17 text-wrap">{{labels.cookies-banner-set-preferences-action}}</a>
+                        <a role="button" href="/cookies" class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap">{{labels.cookies-banner-set-preferences-action}}</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### What

Removed `margin-top` from buttons in the cookies banner so the top and bottom spacing is even

### How to review

Check banner spacing is even

### Who can review

Anyone bar me
