### PR TITLE
added nojs class to cookies banner accept all button

### DIFF
--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -9,7 +9,7 @@
                     <p class="cookies-banner__body">{{labels.cookies-banner-why-we-use}}</p>
                 </div>
                 <div class="cookies-banner__buttons">
-                    <div class="cookies-banner__button cookies-banner__button--accept">
+                    <div class="nojs--hide cookies-banner__button cookies-banner__button--accept">
                         <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" type="submit">{{labels.cookies-banner-accept-action}}</button>
                     </div>
                     <div class="cookies-banner__button">


### PR DESCRIPTION
### What

Added a `nojs` class to the Accept All button of the cookies banner. This means that the button will not be displayed on browsers where the user has JS disabled

### How to review

Run site with cookies functionality enabled locally and check that the Accept All button is only displayed when JS is enabled

### Who can review

Anyone but me
