### PR TITLE
Fix the version of restolino to a specific commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>restolino</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>6cf0bd10f3b30a2bde866beaf0a75c7f2f74f6a1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>restolino</artifactId>
-            <version>6cf0bd10f3b30a2bde866beaf0a75c7f2f74f6a1</version>
+            <version>v0.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What

Fixed the version of restolino being used instead of tracking the master branch. This means that any new changes to the restolino library don't unexpectedly impact on babbage.

### How to review

Rebuild and ensure that nothing has changed. The version being imported should be identical it's just how it's referenced that is changing.

### Who can review

Anyone but me.