### PR TITLE
Add JSON-LD rendering to templates (instead of via GTM)

### DIFF
--- a/run-publishing.sh
+++ b/run-publishing.sh
@@ -24,6 +24,7 @@ export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
 export ENABLE_COOKIES_CONTROL=false
 export ENABLE_COVID19_FEATURE=false
+export ENABLE_JSONLD_CONTROL=false
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,7 @@ export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
 export ENABLE_COOKIES_CONTROL=false
 export ENABLE_COVID19_FEATURE=false
+export ENABLE_JSONLD_CONTROL=false
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
@@ -17,6 +17,7 @@ public class Handlebars implements AppConfig {
     private static final String RELOAD_TEMPLATES_KEY = "RELOAD_TEMPLATES";
     private static final String ENABLE_COVID19_FEATURE = "ENABLE_COVID19_FEATURE";
     private static final String ENABLE_COOKIES_CONTROL = "ENABLE_COOKIES_CONTROL";
+    private static final String ENABLE_JSONLD_CONTROL = "ENABLE_JSONLD_CONTROL";
 
     private final String defaultHandlebarsDatePattern;
     private final String mainContentTemplateName;
@@ -26,6 +27,7 @@ public class Handlebars implements AppConfig {
     private final boolean reloadTemplateChanges;
     private final boolean enableCovid19Feature;
     private final boolean enableCookiesControl;
+    private final boolean enableJSONLDControl;
 
     static Handlebars getInstance() {
         if (INSTANCE == null) {
@@ -48,6 +50,7 @@ public class Handlebars implements AppConfig {
         reloadTemplateChanges = getStringAsBool(RELOAD_TEMPLATES_KEY, "N");
         enableCovid19Feature = Boolean.parseBoolean(getValue(ENABLE_COVID19_FEATURE));
         enableCookiesControl = Boolean.parseBoolean(getValue(ENABLE_COOKIES_CONTROL));
+        enableJSONLDControl = Boolean.parseBoolean(getValue(ENABLE_JSONLD_CONTROL));
     }
 
     public String getHandlebarsDatePattern() {
@@ -82,6 +85,10 @@ public class Handlebars implements AppConfig {
         return enableCovid19Feature;
     }
 
+    public boolean isEnableJSONLDControl() {
+        return enableJSONLDControl;
+    }
+
     @Override
     public Map<String, Object> getConfig() {
         Map<String, Object> config = new HashMap<>();
@@ -93,6 +100,7 @@ public class Handlebars implements AppConfig {
         config.put("reloadTemplateChanges", reloadTemplateChanges);
         config.put("enableCovid19Feature", enableCovid19Feature);
         config.put("enableCookiesControl", enableCookiesControl);
+        config.put("enableJSONLDControl", enableJSONLDControl);
         return config;
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -30,7 +30,7 @@ public class PageRequestHandler extends BaseRequestHandler {
     private static final String PDF_STYLE = "pdf_style";
     private static final String ENABLE_COOKIES_CONTROL = "EnableCookiesControl";
     private static final String ENABLE_COVID19_FEATURE = "EnableCovid19Feature";
-
+    private static final String ENABLE_JSONLD_CONTROL = "EnableJSONLDControl";
 
     @Override
     public BabbageResponse get(String uri, HttpServletRequest request) throws IOException, ContentReadException {
@@ -46,6 +46,7 @@ public class PageRequestHandler extends BaseRequestHandler {
             }
             additionalData.put(ENABLE_COVID19_FEATURE, appConfig().handlebars().isEnableCovid19Feature());
             additionalData.put(ENABLE_COOKIES_CONTROL, appConfig().handlebars().isEnableCookiesControl());
+            additionalData.put(ENABLE_JSONLD_CONTROL, appConfig().handlebars().isEnableJSONLDControl());
             String html = TemplateService.getInstance().renderContent(dataStream, additionalData);
             return new BabbageContentBasedStringResponse(contentResponse, html, TEXT_HTML);
         }

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -42,9 +42,9 @@
         })(window,document,'script','dataLayer','GTM-MBCBVQS');</script>
         <!-- End Google Tag Manager -->
 
-		{{#if EnableJSONLDControl}}
-			{{> partials/json-ld/base }}
-		{{/if}}
+        {{#if EnableJSONLDControl}}
+            {{> partials/json-ld/base }}
+        {{/if}}
 
 	</head>
 	<body class="{{type}}">

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -42,6 +42,8 @@
         })(window,document,'script','dataLayer','GTM-MBCBVQS');</script>
         <!-- End Google Tag Manager -->
 
+		{{> partials/json-ld/base }}
+
 	</head>
 	<body class="{{type}}">
 

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -42,7 +42,9 @@
         })(window,document,'script','dataLayer','GTM-MBCBVQS');</script>
         <!-- End Google Tag Manager -->
 
-		{{> partials/json-ld/base }}
+		{{#if EnableJSONLDControl}}
+			{{> partials/json-ld/base }}
+		{{/if}}
 
 	</head>
 	<body class="{{type}}">

--- a/src/main/web/templates/handlebars/partials/json-ld/adhoc.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/adhoc.handlebars
@@ -6,6 +6,6 @@
     {
         "@type":"DataDownload",
         "encodingFormat":"{{fe downloads.0.uri}}",
-        "contentUrl": "{{location.protocol}}{{location.hostname}}/file?uri={{downloads.0.uri}}"
+        "contentUrl": "{{location.hostname}}/file?uri={{downloads.0.uri}}"
     }
 ]

--- a/src/main/web/templates/handlebars/partials/json-ld/adhoc.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/adhoc.handlebars
@@ -1,0 +1,11 @@
+"@type": "Dataset",
+"datePublished": "{{description.releaseDate}}",
+{{> partials/json-ld/publisher }}
+{{#if downloads.0}}
+"distribution":[
+    {
+        "@type":"DataDownload",
+        "encodingFormat":"{{fe downloads.0.uri}}",
+        "contentUrl": "{{location.protocol}}{{location.hostname}}/file?uri={{downloads.0.uri}}"
+    }
+]

--- a/src/main/web/templates/handlebars/partials/json-ld/author.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/author.handlebars
@@ -1,0 +1,4 @@
+"author": {
+    "@type": "Person",
+    "name": "{{description.contact.name}}",
+}

--- a/src/main/web/templates/handlebars/partials/json-ld/author.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/author.handlebars
@@ -1,4 +1,4 @@
 "author": {
     "@type": "Person",
-    "name": "{{description.contact.name}}",
-}
+    "name": "{{description.contact.name}}"
+},

--- a/src/main/web/templates/handlebars/partials/json-ld/base.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/base.handlebars
@@ -1,14 +1,14 @@
-{{#if_any (eq type "home_page") (eq type "timeseries") (eq type "bulletin") (eq type "static_adhoc")}}
+{{#if_any (eq type "home_page") (eq type "timeseries") (eq type "bulletin") (eq type "article") (eq type "static_adhoc")}}
     <script type="application/ld+json">
         {
             "@context": "http://schema.org",
             "name": "{{description.title}}",
-            "description": "{{description.summary}}",
+            "description": {{#if description._abstract}}"{{description._abstract}}"{{else}}"{{description.summary}}"{{/if}},
             {{#if_eq type "home_page"}} {{> partials/json-ld/homepage }} {{/if_eq}}
             {{#if_eq type "timeseries"}} {{> partials/json-ld/timeseries }} {{/if_eq}}
             {{#if_eq type "bulletin"}} {{> partials/json-ld/bulletin }} {{/if_eq}}
             {{#if_eq type "static_adhoc"}} {{> partials/json-ld/adhoc }} {{/if_eq}}
-            "url": {{location.protocol}}{{location.hostname}}{{uri}},
+            "url": "{{location.protocol}}{{location.hostname}}{{uri}}",
             "license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
         }
     </script>

--- a/src/main/web/templates/handlebars/partials/json-ld/base.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/base.handlebars
@@ -9,7 +9,7 @@
             {{#if_eq type "bulletin"}} {{> partials/json-ld/bulletin }} {{/if_eq}}
             {{#if_eq type "static_adhoc"}} {{> partials/json-ld/adhoc }} {{/if_eq}}
             "url": "{{location.hostname}}{{uri}}",
-            "license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+            "license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
         }
     </script>
 {{/if_any}}

--- a/src/main/web/templates/handlebars/partials/json-ld/base.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/base.handlebars
@@ -1,0 +1,15 @@
+{{#if_any (eq type "home_page") (eq type "timeseries") (eq type "bulletin") (eq type "static_adhoc")}}
+    <script type="application/ld+json">
+        {
+            "@context": "http://schema.org",
+            "name": "{{description.title}}",
+            "description": "{{description.summary}}",
+            {{#if_eq type "home_page"}} {{> partials/json-ld/homepage }} {{/if_eq}}
+            {{#if_eq type "timeseries"}} {{> partials/json-ld/timeseries }} {{/if_eq}}
+            {{#if_eq type "bulletin"}} {{> partials/json-ld/bulletin }} {{/if_eq}}
+            {{#if_eq type "static_adhoc"}} {{> partials/json-ld/adhoc }} {{/if_eq}}
+            "url": {{location.protocol}}{{location.hostname}}{{uri}},
+            "license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+        }
+    </script>
+{{/if_any}}

--- a/src/main/web/templates/handlebars/partials/json-ld/base.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/base.handlebars
@@ -8,7 +8,7 @@
             {{#if_eq type "timeseries"}} {{> partials/json-ld/timeseries }} {{/if_eq}}
             {{#if_eq type "bulletin"}} {{> partials/json-ld/bulletin }} {{/if_eq}}
             {{#if_eq type "static_adhoc"}} {{> partials/json-ld/adhoc }} {{/if_eq}}
-            "url": "{{location.protocol}}{{location.hostname}}{{uri}}",
+            "url": "{{location.hostname}}{{uri}}",
             "license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
         }
     </script>

--- a/src/main/web/templates/handlebars/partials/json-ld/bulletin.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/bulletin.handlebars
@@ -4,7 +4,7 @@
 "dateModified": "{{description.releaseDate}}",
 {{> partials/json-ld/author }}
 {{#if charts.0}}
-"image": "{{location.protocol}}{{location.hostname}}/chartimage?uri={{charts.0.uri}}",
+"image": "{{location.hostname}}/chartimage?uri={{charts.0.uri}}",
 {{/if}}
 "mainEntityOfPage": "{{uri}}",
 {{> partials/json-ld/publisher }}

--- a/src/main/web/templates/handlebars/partials/json-ld/bulletin.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/bulletin.handlebars
@@ -1,0 +1,10 @@
+"@type": "Article",
+"headLine": "{{description.title}}",
+"datePublished": "{{description.releaseDate}}",
+"dateModified": "{{description.releaseDate}}",
+{{> partials/json-ld/author }}
+{{#if charts.0}}
+"image": "{{location.protocol}}{{location.hostname}}/chartimage?uri={{charts.0.uri}}",
+{{/if}}
+"mainEntityOfPage": "{{uri}}",
+{{> partials/json-ld/publisher }}

--- a/src/main/web/templates/handlebars/partials/json-ld/homepage.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/homepage.handlebars
@@ -1,4 +1,4 @@
-"@type": "Organization",
+"@type": "GovernmentOrganization",
 "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png",
 "name": "Office for National Statistics",
 "sameAs": [

--- a/src/main/web/templates/handlebars/partials/json-ld/homepage.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/homepage.handlebars
@@ -1,0 +1,8 @@
+"@type": "Organization",
+"logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png",
+"name": "Office for National Statistics",
+"sameAs": [
+    "https://twitter.com/ONS",
+    "https://www.facebook.com/ONS",
+    "https://www.linkedin.com/company/office-for-national-statistics/"
+]

--- a/src/main/web/templates/handlebars/partials/json-ld/publisher.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/publisher.handlebars
@@ -1,0 +1,5 @@
+"publisher": {
+    "@type": "Organization",
+    "name": "Office for National Statistics",  
+    "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png"
+},

--- a/src/main/web/templates/handlebars/partials/json-ld/publisher.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/publisher.handlebars
@@ -1,5 +1,5 @@
 "publisher": {
-    "@type": "Organization",
+    "@type": "GovernmentOrganization",
     "name": "Office for National Statistics",  
     "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png"
 },

--- a/src/main/web/templates/handlebars/partials/json-ld/timeseries.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/timeseries.handlebars
@@ -1,0 +1,21 @@
+"@type": "Dataset",
+{{> partials/json-ld/author }}
+"headline": "{{description.title}}",
+"datePublished": "{{description.releaseDate}}",
+"dateModified": "{{description.releaseDate}}",
+"discussionURL": "{{location.protocol}}{{location.hostname}}{{relatedDocuments.0.uri}}",
+"keywords": ["{{description.cdid}}", "{{description.datasetId}}"],
+{{> partials/json-ld/publisher }}
+"image": "{{location.protocol}}{{location.hostname}}{{uri}}/linechartimage",  
+"distribution":[
+    {
+        "@type":"DataDownload",
+        "encodingFormat":"XLS",
+        "contentUrl": "{{location.protocol}}{{location.hostname}}/generator?format=xls&uri={{uri}}"
+    },
+    {
+        "@type":"DataDownload",
+        "encodingFormat":"CSV",
+        "contentUrl": "{{location.protocol}}{{location.hostname}}/generator?format=csv&uri={{uri}}"
+    }
+]

--- a/src/main/web/templates/handlebars/partials/json-ld/timeseries.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/timeseries.handlebars
@@ -3,19 +3,19 @@
 "headline": "{{description.title}}",
 "datePublished": "{{description.releaseDate}}",
 "dateModified": "{{description.releaseDate}}",
-"discussionURL": "{{location.protocol}}{{location.hostname}}{{relatedDocuments.0.uri}}",
+"discussionURL": "{{location.hostname}}{{relatedDocuments.0.uri}}",
 "keywords": ["{{description.cdid}}", "{{description.datasetId}}"],
 {{> partials/json-ld/publisher }}
-"image": "{{location.protocol}}{{location.hostname}}{{uri}}/linechartimage",  
+"image": "{{location.hostname}}{{uri}}/linechartimage",  
 "distribution":[
     {
         "@type":"DataDownload",
         "encodingFormat":"XLS",
-        "contentUrl": "{{location.protocol}}{{location.hostname}}/generator?format=xls&uri={{uri}}"
+        "contentUrl": "{{location.hostname}}/generator?format=xls&uri={{uri}}"
     },
     {
         "@type":"DataDownload",
         "encodingFormat":"CSV",
-        "contentUrl": "{{location.protocol}}{{location.hostname}}/generator?format=csv&uri={{uri}}"
+        "contentUrl": "{{location.hostname}}/generator?format=csv&uri={{uri}}"
     }
 ]


### PR DESCRIPTION
### What

- Added JSON-LD rendering to templates

### How to review

- Run babbage with `ENABLE_JSONLD_CONTROL=true`
- Check that JSON-LD is only rendered on correct pages (home page, timeseries, bulletins, articles and adhocs) and that it matches what is currently added to the pages via GTM. 

_Notes: GTM doesn't add it to articles but as art of this we've added it to articles. Articles and bulletins don't have word count attribute this has been raised and will be done as a separate task._

### Who can review

Anyone
