### PR TITLE
introduce new 'show-corrections' argument 

### DIFF
--- a/src/main/web/templates/handlebars/partials/alert.handlebars
+++ b/src/main/web/templates/handlebars/partials/alert.handlebars
@@ -1,8 +1,9 @@
+{{!-- TODO refactor the whole alert system (notices & corrections) it is a major mess. --}}
 {{!-- Unique alerts/corrections system for dataset landing page - only shown when no-versions=true --}}
 {{#if no-versions}}
 
 	{{!-- Store whether dataset has correction and/or alerts --}}
-	{{#each alerts}}
+    {{#each alerts}}
 		{{#if_eq type "correction"}}
 			{{#assign "has-corrections"}}
 				true
@@ -15,7 +16,11 @@
 			{{/assign}}
 		{{/if_eq}}
 	{{/each}}
-
+    {{#if has-correction}}
+        {{#assign "show-corrections"}}
+            true
+        {{/assign}}
+    {{/if}}
 	{{!-- Show those alerts/corrections --}}
 	{{#if alerts}}
 		<div class="alert">
@@ -98,6 +103,13 @@
 
 		{{else}}
 
+            {{#each alerts}}
+                {{#if_eq type "alert"}}
+                    {{#assign "has-alerts"}}
+                        true
+                    {{/assign}}
+                {{/if_eq}}
+            {{/each}}
 			{{!-- Set whether there are any corrections --}}
 			{{#each versions}}
 				{{#if correctionNotice}}
@@ -120,7 +132,6 @@
                                         <a class="alert__link js-scroll" href="#othertimeseries">View other variations of this time series</a>
                                     {{/if_ne}}
                                 {{/resolveTimeSeriesList}}
-
                                 {{#if alerts}}
                                     <div class="show-hide show-hide--dark info-box margin-top-sm--3 margin-top-md--3 js-show-hide">
                                         <div class="js-show-hide__title">

--- a/src/main/web/templates/handlebars/partials/notice.handlebars
+++ b/src/main/web/templates/handlebars/partials/notice.handlebars
@@ -2,7 +2,7 @@
 
 	{{!-- For dataset pages that have 'correction alerts' instead of versions and 'alert alerts' for normal alerts --}}
 	{{#if_any has-corrections has-alerts}}
-		{{#if has-corrections}}
+        {{#if_all has-corrections show-corrections}}
 			<div class="show-hide__content alert--warning__content section__content--markdown">
 				<section>
 					{{#if_all has-corrections has-alerts}}
@@ -16,11 +16,11 @@
 					{{/loop}}
 				</section>
 			</div>
-		{{/if}}
+		{{/if_all}}
 		{{#if has-alerts}}
 			<div class="show-hide__content alert--warning__content section__content--markdown">
 				<section>
-					{{#if_all has-corrections has-alerts}}
+					{{#if_all show-corrections has-corrections has-alerts}}
 						<h3 class="alert--notice__title">{{labels.notices}}</h3>
 					{{/if_all}}
 					{{#loop alerts orderBy="date" reverse=true}}


### PR DESCRIPTION
### What

#### Issue 
On time-series pages the notice banner has no content e.g. https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/bluu/lms

#### Issue cause
The template files for alerts (which are the notices and corrections) is a mess - it looks like some previous technical debt between 2015-2017 has come back to haunt us and these files have just been expanded on time and time again to get even messier.

- alert.handlebars has many different forks in logic for a template file that is supposed to just handle whether or not to add a sub partial for showing corrections and notices

    - 26 if statements 13 else statements … trying to fix this is a bit like walking on eggshells.

- To add to the fun - There are then 2 sub partials for the banner, ‘notice’ and ‘corrections’… you would think one was for just for the `corrections` banner and one was for just the `notices` banner, but no.
	- `Corrections` is just for a single show hide banner that contains `corrections` as you would expect
	- `Notices` is for a single show and hide banner that contains two headings Notices and corrections - this is also the opposite order to the time series page currently.
- But hey that’s not all Timeseries page has extra funky logic to add to the mix 
	- It uses the ‘notices’ partial (so corrections and notices in the same show and hide - but never sets a variable to say it has notices so that section of the banner is always hidden. 
	- So where is notice section we see on the page coming from well this comes from a random block of templating which isn’t in either of the notices or corrections template files but floats around at the bottom of the alerts template file and is only hit on timeseries pages.
	- Because of all this fun if you say it has both corrections and notices on a time series page it will duplicate the corrections section - one in the corrections banner and another in the notices banner under the corrections 

#### Possible fix options:
1. Duplicate the code for the notices partial as is already done for corrections but change it for time series alert to fix the issue 

- even more code = more mess + WET

2. Change `has corrections` when showing the notice banner (stops the corrections title from showing)
 - misuse of a variable; it no longer represents that it has-corrections as its name implies

3. introduce new var `show-corrections` set to true when wanting to show corrections in the notice banner. Then set `has-alerts` to true to show the notices
 - More code to add to the mess but not as much as other options
 - Slightly harder to follow the code as selection statements are slightly longer

4.  Rewrite the whole thing 
 - long time
 - lots could go wrong 
 - lots of testing needed too
 - everything is being moved to the renderer so this would be fixing a legacy system which is scheduled to be replaced (waste of time in the long run).

5. If time series page then don’t show corrections in a notice banner ever ( logic in notice.handlebars )
 - exception logic like this is more technical debt
 - much harder to maintain in the future (logic would flow like so: if time-series then use this component but if time-series then don't use this part of that component) 🔥 

#### Fix option chosen 
Option 3 as the downfalls are minimal compared to the other options.

Pages have been tested locally as per below results:
1. Timeseries page
![Screenshot 2020-04-08 at 11 33 30](https://user-images.githubusercontent.com/47502916/78776968-a644ce00-7990-11ea-9ae2-c35a07d176a6.png)

2. Dataset page
<img width="1680" alt="Screenshot 2020-04-08 at 11 32 00" src="https://user-images.githubusercontent.com/47502916/78776942-99c07580-7990-11ea-8f7d-191508471309.png">

3. Article
![Screenshot 2020-04-08 at 11 34 33](https://user-images.githubusercontent.com/47502916/78776979-a9d85500-7990-11ea-9855-b3a9844539e4.png)

### How to review

- Ensure that the chosen fix is a good fix to have chosen
- Ensure the fix was implemented in the cleanest way possible without having further negative effects
- Test alerts and corrections on different page types with different options selected for alert and correction combos
Describe the steps required to test the changes.

### Who can review

Anyone except me
