### PR TITLE
Fix download link in adhoc JSON-LD to use correct property

### DIFF
--- a/src/main/web/templates/handlebars/partials/json-ld/adhoc.handlebars
+++ b/src/main/web/templates/handlebars/partials/json-ld/adhoc.handlebars
@@ -5,8 +5,8 @@
 "distribution":[
     {
         "@type":"DataDownload",
-        "encodingFormat":"{{fe downloads.0.uri}}",
-        "contentUrl": "https://{{location.hostname}}/file?uri={{downloads.0.uri}}"
+        "encodingFormat":"{{fe downloads.0.file}}",
+        "contentUrl": "https://{{location.hostname}}/file?uri={{downloads.0.file}}"
     }
 ],
 {{/if}}


### PR DESCRIPTION
### What

Fix download link in adhoc JSON-LD to use correct property

### Who can review

Anyone
