### PR TITLE
update to use new OGL logo in footer

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -22,14 +22,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/a9d11c6{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/a9d11c6{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/a9d11c6{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/a9d11c6{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
         {{> partials/gtm-data-layer }}
@@ -141,7 +141,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/a9d11c6{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/footer.handlebars
+++ b/src/main/web/templates/handlebars/partials/footer.handlebars
@@ -66,7 +66,7 @@
 		</div>
 		<div class="wrapper">
 			<div class="footer-license">
-				<img class="footer-license__img" alt="OGL" width="60" src="/img/ogl.png">
+				<img class="footer-license__img" alt="OGL" width="60" src="https://cdn.ons.gov.uk/assets/images/logo-ogl-footer.svg">
 				<p class="footer-license__text margin-left-sm--0">
 					{{{labels.ogl}}}
 				</p>

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,7 +51,7 @@ The commented code below is what needs to go in the parent.
     {{/if}}
   {{/if}}
 
-  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/a9d11c6{{/if}}/js/main.js"></script>
+  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/js/main.js"></script>
   <script type="text/javascript" src="/js/app.js"></script>
 
   <script type="text/javascript" src="//pym.nprapps.org/pym.v1.min.js"></script>

--- a/src/main/web/templates/html/404.html
+++ b/src/main/web/templates/html/404.html
@@ -325,7 +325,7 @@
       <div class="slate--mid-grey">
         <div class="wrapper">
           <div class="footer__license">
-            <img class="footer__license__img" alt="OGL" width="60" src="/node_modules/ONS-Pattern-Library/ui/img/ogl.png">
+            <img class="footer__license__img" alt="OGL" width="60" src="https://cdn.ons.gov.uk/assets/images/logo-ogl-footer.svg">
             <p class="footer__license__body">
               All content is available under the Open Government Licence v2.0, except where otherwise stated
             </p>

--- a/src/main/web/templates/html/500.html
+++ b/src/main/web/templates/html/500.html
@@ -322,7 +322,7 @@
             <div class="slate--mid-grey">
                 <div class="wrapper">
                     <div class="footer__license">
-                        <img class="footer__license__img" alt="OGL" width="60" src="/node_modules/ONS-Pattern-Library/ui/img/ogl.png">
+                        <img class="footer__license__img" alt="OGL" width="60" src="https://cdn.ons.gov.uk/assets/images/logo-ogl-footer.svg">
                         <p class="footer__license__body">
                             All content is available under the Open Government Licence v2.0, except where otherwise stated
                         </p>


### PR DESCRIPTION
### What

The Open Government License (OGL) logo has been updated to match with the new footer typography. We now use an SVG and it is filled with `grey4` - `e2e2e3`

### How to review

Check that the new OGL logo is present in the footer

### Who can review

Anyone but me 
