### PR TITLE
Add java dependency auditing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,20 @@
 all: audit test build
 
 .PHONY: audit
-audit:
-	pushd src/main/web && npm audit --audit-level=high && popd
+audit : audit-java audit-js
+
+.PHONY: audit-java
+audit-java:
+	mvn ossindex:audit
+
+.PHONY: audit-js
+audit-js:
+	npm audit --prefix src/main/web --audit-level=high
 
 .PHONY: build
 build:
 	npm install --prefix src/main/web --unsafe-perm
-	mvn -Dmaven.test.skip clean package dependency:copy-dependencies
+	mvn -Dmaven.test.skip -Dossindex.skip=true clean package dependency:copy-dependencies
 
 .PHONY: debug-web
 debug-web:
@@ -20,4 +27,4 @@ debug-publishing:
 
 .PHONY: test
 test:
-	mvn test
+	mvn -Dossindex.skip=true test

--- a/build-api.sh
+++ b/build-api.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mvn clean compile dependency:copy-dependencies
+mvn -Dossindex.skip=true clean compile dependency:copy-dependencies
 
  if [ $? -eq 0 ]
     then
@@ -11,4 +11,4 @@ mvn clean compile dependency:copy-dependencies
  fi
 
 # Now build the JAR:
-mvn process-resources
+mvn -Dossindex.skip=true process-resources

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <!-- Prototyping framework -->
 
         <dependency>
-            <groupId>com.github.ONSdigital</groupId>
+            <groupId>com.github.onsdigital</groupId>
             <artifactId>restolino</artifactId>
             <version>v0.2.0</version>
         </dependency>
@@ -169,7 +169,7 @@
 
         <!-- Logging -->
         <dependency>
-            <groupId>com.github.ONSdigital</groupId>
+            <groupId>com.github.onsdigital</groupId>
             <artifactId>dp-logging</artifactId>
             <version>${dp-logging.version}</version>
         </dependency>
@@ -255,6 +255,33 @@
                         <!-- Default output folder is ${project.build.api}/dependency -->
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.ossindex.maven</groupId>
+                <artifactId>ossindex-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>audit-dependencies-critical</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>audit</goal>
+                        </goals>
+                        <!-- configuration for mvn validate -->
+                        <configuration>
+                            <!-- if CVSS >= 9.0 (critical) then ERROR else WARN -->
+                            <fail>true</fail>
+                            <cvssScoreThreshold>9.0</cvssScoreThreshold>
+                        </configuration>
+                    </execution>
+                </executions>
+                <!-- configuration for mvn ossindex:audit -->
+                <configuration>
+                    <!-- if CVSS >= 7.0 (high or critical) then ERROR else WARN -->
+                    <fail>true</fail>
+                    <cvssScoreThreshold>7.0</cvssScoreThreshold>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
### What

Add java auditing. This complements the existing JS auditing previously added.

### How to review

Run `make audit`, `make audit-java` & `make audit-js`. Also build and debug targets should still function.  
NB. the java and js auditing steps run sequentially so should the first fail, the second will not be attempted.

### Who can review

Anyone but me.
