### PR TITLE
Fix/cookies banner jitter

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -48,7 +48,7 @@
 
 	</head>
 	<body class="{{type}}">
-
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js' : 'js');</script>
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
                       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -22,14 +22,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/c9680eb{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/c9680eb{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/c9680eb{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/c9680eb{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
         {{> partials/gtm-data-layer }}
@@ -141,7 +141,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/c9680eb{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -1,5 +1,5 @@
 <form action="/cookies/accept-all" method="GET" id="global-cookie-message"
-      class="cookies-banner js-hidden js-cookies-banner-form clearfix"
+      class="cookies-banner cookies-banner--hidden js-cookies-banner-form clearfix"
       aria-label="cookie banner">
     <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
         <div>

--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -1,6 +1,6 @@
 <form action="/cookies/accept-all" method="GET" id="global-cookie-message"
-      class="cookies-banner js-cookies-banner-form clearfix"
-      aria-label="cookie banner" style="display: block;">
+      class="cookies-banner js-hidden js-cookies-banner-form clearfix"
+      aria-label="cookie banner">
     <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
         <div>
             <div class="cookies-banner__message adjust-font-size--18">

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,7 +51,7 @@ The commented code below is what needs to go in the parent.
     {{/if}}
   {{/if}}
 
-  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b07c373{{/if}}/js/main.js"></script>
+  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/c9680eb{{/if}}/js/main.js"></script>
   <script type="text/javascript" src="/js/app.js"></script>
 
   <script type="text/javascript" src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What

This PR adds a script tag which appends a `js` class to the body tag (i.e., to signify that JavaScript is enabled). This will allow us to implement certain JS-specific interactivity. In this case, it fixes a jitter bug we had with the cookies banner rendering on refresh.

### How to review

Check the code changes make sense. Should include updated sixteens path, a change to add the script in the main template file, and another to add `cookies-banner--hidden` class which is where the functionality is implemented

### Who can review

Anyone but me
