### PR TITLE
Non descriptive image alt for official statistic image

### DIFF
--- a/src/main/web/package-lock.json
+++ b/src/main/web/package-lock.json
@@ -806,19 +806,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.9.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
-            "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
-            "requires": {
-                "commander": "~2.20.3"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-                }
-            }
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
+            "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA=="
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/src/main/web/templates/handlebars/content/partials/bulletin-header.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/bulletin-header.handlebars
@@ -146,7 +146,7 @@
         <div class="col-wrap margin-top--3 margin-left--0">
                 {{#if description.nationalStatistic}} <div class="col col--md-4 col--lg-4"><a class="meta__image" href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
                 class="meta__image margin-right--0" src="/img/national-statistics.png"
-                alt="This is an accredited national statistic."/></a></div>{{/if}}
+                alt="This is an accredited national statistic. For information about types of official statistics click this link."/></a></div>{{/if}}
             <p class="col {{class}} col--md-12 col--lg-15 margin-bottom-sm--1 margin-bottom-md--3 margin-top-sm--1 padding-bottom--0 padding-top--0">
                 <span class="font-weight-700">{{labels.contact}}: </span><br/><a href="mailto:{{description.contact.email}}" class="text--white"><span class="visuallyhidden">Email </span>{{#if description.contact.name}}{{description.contact.name}}{{else}}{{description.contact.email}}{{/if}}</a>
             </p>

--- a/src/main/web/templates/handlebars/content/partials/metadata/contact.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/metadata/contact.handlebars
@@ -3,6 +3,6 @@
     {{#if description.nationalStatistic}} <a
             href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
             class="meta__image" src="/img/national-statistics.png"
-            alt="National Statistics logo"/></a>{{/if}}
+            alt="This is an accredited national statistic. For information about types of official statistics click this link."/></a>{{/if}}
 	<span>{{labels.contact}}: </span><br/><a href="mailto:{{description.contact.email}}">{{#if description.contact.name}}{{description.contact.name}}{{else}}{{description.contact.email}}{{/if}}</a>
 </p>

--- a/src/main/web/templates/handlebars/content/partials/metadata/ns-logo.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/metadata/ns-logo.handlebars
@@ -3,6 +3,6 @@
 <p class="col col--md-4 col--lg-4 padding-left">
     <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
             class="meta__image" src="/node_modules/ONS-Pattern-Library/dist/img/national-statistics.png"
-            alt="National Statistics logo"/></a>
+            alt="This is an accredited national statistic. For information about types of official statistics click this link."/></a>
 </p>
 {{/if}}

--- a/src/main/web/templates/handlebars/content/t7-1.handlebars
+++ b/src/main/web/templates/handlebars/content/t7-1.handlebars
@@ -62,7 +62,7 @@
                         <div class="col col--md-4 {{#if_all description.surveyName description.frequency description.compilation description.sampleSize description.geographicCoverage}}col--lg-5{{else}}col--lg-4{{/if_all}}">
                             <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
                                     class="meta__image padding-left padding-top--half"
-                                    src="/img/national-statistics.png" alt="National Statistics logo"/></a>
+                                    src="/img/national-statistics.png" alt="This is an accredited national statistic. For information about types of official statistics click this link."/></a>
                         </div>
                         {{#if description.surveyName}}
                             <p class="col {{#if_all description.surveyName description.frequency description.compilation description.sampleSize description.geographicCoverage}}col--md-8 col--lg-11{{else}}col--md-11 col--lg-14{{/if_all}} meta__item">

--- a/src/main/web/templates/handlebars/pdf/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/pdf/partials/header.handlebars
@@ -21,7 +21,7 @@
                 <img
                     class="meta__image"
                     src="https://www.ons.gov.uk/img/national-statistics.png"
-                    alt="National Statistics logo" width="47"
+                    alt="This is an accredited national statistic. For information about types of official statistics click this link." width="47"
                     height="47"/>
             </a>
         {{/if}}


### PR DESCRIPTION
### What
Changed the image alt text where the official statistic image is shown. This includes dataset and bulletin pages

### How to review
1. Visit a dataset or bulleting page
1. The alt text of the image will be not very descriptive usually "National Statistics logo"
1. Check out this branch and restart babbage
1. See that the alt text of the image will now be "This is an accredited national statistic. For information about types of official statistics click this link."

### Who can review
Anyone
