### PR TITLE
Fix - Use of lists

### DIFF
--- a/src/main/web/templates/handlebars/content/t2.handlebars
+++ b/src/main/web/templates/handlebars/content/t2.handlebars
@@ -44,9 +44,9 @@
 			{{/if_any}}
 			{{/resolve}}
 			{{#if @last}}
-			<div class="col col--md-half col--lg-one-third">
+			<li class="col col--md-half col--lg-one-third height--31-indented-ellipsis margin-top--0 margin-left-md--1 margin-bottom--2 padding-top--0 padding-right--0 padding-bottom--0 padding-left--0">
 				{{> partials/local-box}}
-            </div>
+			</li>
 			{{/if}}
 			{{/each}}
 		</ul>

--- a/src/main/web/templates/handlebars/content/t6-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t6-3.handlebars
@@ -17,28 +17,28 @@
         </div>
         {{!-- LIST OF DOWNLOADS --}}
         <div class="col col--md-36 col--lg-39">
-            <ul class="list--neutral margin-top--0">
-                {{#if downloads}}
-                    <h2 class="margin-top--2">{{labels.downloads}}</h2>
-                    {{#each downloads}}
-                        <li>
-                            <h3><a href='/file?uri={{concat uri "/" (fn file)}}'>{{title}}</a> ({{fs (concat uri "/" (fn file))}}, {{fe (concat uri "/" (fn file))}})</h3>
-                            <p class="flush">{{fileDescription}}</p>
-                        </li>
+            {{#if downloads}}
+                <h2 class="margin-top--2">{{labels.downloads}}</h2>
+                <ul class="list--neutral">
+                {{#each downloads}}
+                    <li>
+                        <h3><a href='/file?uri={{concat uri "/" (fn file)}}'>{{title}}</a> ({{fs (concat uri "/" (fn file))}}, {{fe (concat uri "/" (fn file))}})</h3>
+                        <p class="flush">{{fileDescription}}</p>
+                    </li>
+                {{/each}}
+                </ul>
+            {{/if}}
+            {{#if relatedDatasets}}
+                <h2>{{labels.related-data}}</h2>
+                <ul class="list--neutral">
+                    {{#each relatedDatasets}}
+                        {{#resolve this.uri filter="description"}}
+                            <li><h3><a data-gtm-type="related-datasets" data-gtm-title="{{description.title}}" href="{{absolute uri}}">{{description.title}}</a></h3></li>
+                            <p class="flush">{{description.summary}}</p>
+                        {{/resolve}}
                     {{/each}}
-                {{/if}}
-                {{#if relatedDatasets}}
-                    <h2>{{labels.related-data}}</h2>
-                    <ul class="list--neutral">
-                        {{#each relatedDatasets}}
-                            {{#resolve this.uri filter="description"}}
-                                <li><h3><a data-gtm-type="related-datasets" data-gtm-title="{{description.title}}" href="{{absolute uri}}">{{description.title}}</a></h3></li>
-                                <p class="flush">{{description.summary}}</p>
-                            {{/resolve}}
-                        {{/each}}
-                    </ul>
-                {{/if}}
-            </ul>
+                </ul>
+            {{/if}}
         </div>
         {{!-- CONTACT --}}
         <div class="col col--md-11 col--lg-20">

--- a/src/main/web/templates/handlebars/content/t6-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t6-3.handlebars
@@ -17,7 +17,7 @@
         </div>
         <div class="col-wrap">
         {{!-- LIST OF DOWNLOADS --}}
-        <div class="col col--lg-two-thirds margin-left--0">
+        <div class="col col--lg-two-thirds margin-left-lg--1">
             {{#if downloads}}
                 <h2 class="margin-top--2">{{labels.downloads}}</h2>
                 <ul class="list--neutral">

--- a/src/main/web/templates/handlebars/content/t6-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t6-3.handlebars
@@ -15,8 +15,9 @@
                 <p>{{downloads.size}} download{{#if_ne downloads.size 1}}s{{/if_ne}}</p>
             </div>
         </div>
+        <div class="col-wrap">
         {{!-- LIST OF DOWNLOADS --}}
-        <div class="col col--md-36 col--lg-39">
+        <div class="col col--lg-two-thirds margin-left--0">
             {{#if downloads}}
                 <h2 class="margin-top--2">{{labels.downloads}}</h2>
                 <ul class="list--neutral">
@@ -40,38 +41,40 @@
                 </ul>
             {{/if}}
         </div>
-        {{!-- CONTACT --}}
-        <div class="col col--md-11 col--lg-20">
-            <div class="tiles__item tiles__item--nav-type flush-col">
-                <h3 class="tiles__title-h3 tiles__title-h3--nav">
-                    {{#if_ne downloads.size 1}}
-                        {{labels.contact-details-for-these}} datasets
-                    {{else}}
-                        {{labels.contact-details-for-this}} dataset
-                    {{/if_ne}}
-                </h3>
-                <div class="tiles__content--nav">
-                    <address>
-                        {{#if description.contact.name}}{{description.contact.name}}<br/>{{/if}}
-                        <a href="mailto:{{description.contact.email}}">{{description.contact.email}}</a><br/>
-                        {{#if description.contact.telephone}}{{labels.telephone}}: {{description.contact.telephone}}{{/if}}
-                    </address>
+        {{!-- METHODOLOGY AND LOCAL --}}
+        <div class="col col--lg-one-third margin-bottom-md--1 margin-bottom-sm--1">
+            {{!-- CONTACT --}}
+            <div>
+                <div class="tiles__item tiles__item--nav-type flush-col">
+                    <h3 class="tiles__title-h3 tiles__title-h3--nav">
+                        {{#if_ne downloads.size 1}}
+                            {{labels.contact-details-for-these}} datasets
+                        {{else}}
+                            {{labels.contact-details-for-this}} dataset
+                        {{/if_ne}}
+                    </h3>
+                    <div class="tiles__content--nav">
+                        <address>
+                            {{#if description.contact.name}}{{description.contact.name}}<br/>{{/if}}
+                            <a href="mailto:{{description.contact.email}}">{{description.contact.email}}</a><br/>
+                            {{#if description.contact.telephone}}{{labels.telephone}}: {{description.contact.telephone}}{{/if}}
+                        </address>
+                    </div>
                 </div>
             </div>
-        </div>
-        {{!-- METHODOLOGY AND LOCAL --}}
-        <div class="col-wrap">
+
             {{!-- Related methodology --}}
             {{#if_any relatedMethodology}}
-                <div class="col col--lg-half col--md-half">
+                <div>
                     {{> partials/related/methodology }}
                 </div>
             {{/if_any}}
             {{!-- Local --}}
-            <div class="col col--md-half col--lg-one-third">
+            <div>
                 {{> partials/local-box}}
             </div>
         </div>
+    </div>
 {{/partial}}
 {{!-- Inheriting from statistics template --}}
 {{> content/base/statistics typeLabel=labels.compendium}}


### PR DESCRIPTION
### What
1. Replace `div` with `li` on `taxonomy_landing_page` for the local statistics box
1. Replace `div` on `compendium_data` page

### How to review
1. See that the `taxonomy_landing_page` looks like it does
1. See that on the `compendium_data` page looks as it does including a smaller statisics box and missing margins when in small and medium view ports.
1. Switch to this branch 
1. See that the `taxonomy_landing_page` is unchanged
1. See that the `compendium_data` page list of downloads is unchanged but now works well in all view ports

### Who can review
Anyone
