### PR TITLE
Fix - Unlabelled inputs

### DIFF
--- a/src/main/web/templates/handlebars/list/filters/publish-date.handlebars
+++ b/src/main/web/templates/handlebars/list/filters/publish-date.handlebars
@@ -1,8 +1,7 @@
 <fieldset class="filters__fieldset">
     <legend class="filters__title">
         Published after
-        {{!-- Hidden text to help screen reader users when they focus on first input --}}
-        <span class="hide" id="date-hint">For example, 29 4 2016</span>
+        <span class="visuallyhidden">For example, 29 4 2016</span>
     </legend>
     <div class="js-auto-submit__error filters__error" id="from-date-error">
         {{#each errors}}
@@ -14,21 +13,21 @@
     <div id="inputs-start-date">
         <div class="filters__date filters__date--day">
             <label for="fromDateDay">Day</label>
-            <input type="number" autocomplete="off" name="fromDateDay"
+            <input type="number" autocomplete="off" name="fromDateDay" id="fromDateDay"
                    value="{{df parameters.fromDateDay.0 outputFormat="d" inputFormat="d"}}"
                    class="js-auto-submit__input js-auto-submit__input--date"
-                   min="0" max="31" pattern="[0-9]*" aria-describedby="date-hint">
+                   min="0" max="31" pattern="[0-9]*">
         </div>
         <div class="filters__date filters__date--month">
             <label for="fromDateMonth">Month</label>
-            <input type="number" autocomplete="off" name="fromDateMonth"
+            <input type="number" autocomplete="off" name="fromDateMonth" id="fromDateMonth"
                    value="{{df parameters.fromDateMonth.0 outputFormat="M" inputFormat="M"}}"
                    class="js-auto-submit__input js-auto-submit__input--date"
                    min="1" max="12" maxlength="2" pattern="[0-9]*">
         </div>
         <div class="filters__date filters__date--year">
             <label for="fromDateYear">Year</label>
-            <input type="number" autocomplete="off" name="fromDateYear"
+            <input type="number" autocomplete="off" name="fromDateYear" id="fromDateYear"
                    value="{{df parameters.fromDateYear.0 outputFormat="yyyy" inputFormat="yyyy"}}"
                    class="js-auto-submit__input js-auto-submit__input--date"
                    min="1900" max="2050" maxlength="4" pattern="[0-9]*">
@@ -41,6 +40,7 @@
 <fieldset class="filters__fieldset">
     <legend class="filters__title">
         Published before
+        <span class="visuallyhidden">For example, 29 4 2016</span>
     </legend>
     <div class="js-auto-submit__error filters__error" id="to-date-error">
         {{#each errors}}
@@ -52,21 +52,21 @@
     <div id="inputs-end-date">
         <div class="filters__date filters__date--day">
             <label for="toDateDay">Day</label>
-            <input type="number" autocomplete="off" name="toDateDay"
+            <input type="number" autocomplete="off" name="toDateDay" id="toDateDay"
                    value="{{df parameters.toDateDay.0 outputFormat="d" inputFormat="d"}}"
                    class="js-auto-submit__input js-auto-submit__input--date"
-                   min="0" max="31" pattern="[0-9]*" aria-describedby="date-hint">
+                   min="0" max="31" pattern="[0-9]*">
         </div>
         <div class="filters__date filters__date--month">
             <label for="toDateMonth">Month</label>
-            <input type="number" autocomplete="off" name="toDateMonth"
+            <input type="number" autocomplete="off" name="toDateMonth" id="toDateMonth"
                    value="{{df parameters.toDateMonth.0 outputFormat="M" inputFormat="M"}}"
                    class="js-auto-submit__input js-auto-submit__input--date"
                    min="1" max="12" maxlength="2" pattern="[0-9]*">
         </div>
         <div class="filters__date filters__date--year">
             <label for="toDateYear">Year</label>
-            <input type="number" autocomplete="off" name="toDateYear"
+            <input type="number" autocomplete="off" name="toDateYear" id="toDateYear"
                    value="{{df parameters.toDateYear.0 outputFormat="yyyy" inputFormat="yyyy"}}"
                    class="js-auto-submit__input js-auto-submit__input--date"
                    min="1900" max="2050" maxlength="4" pattern="[0-9]*">

--- a/src/main/web/templates/handlebars/list/t13.handlebars
+++ b/src/main/web/templates/handlebars/list/t13.handlebars
@@ -82,12 +82,11 @@
 
 			{{!-- Checkbox --}}
 			<div class="input__wrapper col col--md-3 col--lg-3 margin-left-md--1 padding-left-md--1 padding-bottom-sm" >
-				<input  type="checkbox" name="" data-title="{{description.title}}" data-cdid="{{description.cdid}}" data-datasetId="{{description.datasetId}}" data-uri="{{uri}}" value="" class="timeseries__select js-timeseriestool-select js--show" aria-label="{{description.title}}">
+				<input id="select-{{description.datasetId}}"type="checkbox" name="" data-title="{{description.title}}" data-cdid="{{description.cdid}}" data-datasetId="{{description.datasetId}}" data-uri="{{uri}}" value="" class="timeseries__select js-timeseriestool-select js--show" aria-label="{{description.title}}">
 			</div>
-
 			{{!-- Title --}}
 			<div class="col col--md-21 col--lg-25 padding-right-md--1">
-				<p class="margin-bottom-md--0 flush--sm"><a href="{{uri}}">{{{description.title}}}</a></p>
+				<p class="margin-bottom-md--0 flush--sm"><a href="{{uri}}"><label for="select-{{description.datasetId}}">{{description.title}}</label></a></p>
 			</div>
 
 			{{!-- Is new? --}}


### PR DESCRIPTION
### What
Fix input labelling in babbage templates
1. Fix labelling with date filtering on list pages (documented in DAC report)
2. Fix labelling on selection input for the `timeseriestool` (code search)

### How to review
#### Search/list pages
1. See that the inputs are unlabelled and description is confusing when using the date search refinement from a screen reader (to or from) 
1. See that this PR improves this by making the description read at the beginning with the group and then each field labelled individually.
#### Timeseries tool
1. See that the selection checkboxes are unlabelled when visiting [the timeseries tool](http://localhost:20000/timeseriestool)
1. See that this PR adds labels read by the screen reader so the user know what they are selecting.

### Who can review
Anyone but me