### PR TITLE
Fix  - Select truncated text

### DIFF
--- a/src/main/web/templates/handlebars/list/filters/size.handlebars
+++ b/src/main/web/templates/handlebars/list/filters/size.handlebars
@@ -14,7 +14,7 @@
     <div class="baseline">
         <label for="page-size">Results per page:</label>
         <select name="size" id="page-size"
-                class="input select--thin font-size--14 width--3 padding-left--1 padding-right--1 js-auto-submit__input">
+            class="input select font-size--14 width-auto js-auto-submit__input">
             <option value="10" {{#if_eq parameters.size.0 "10"}}selected{{/if_eq}}>10</option>
             <option value="25" {{#if_eq parameters.size.0 "25"}}selected{{/if_eq}}>25</option>
             <option value="50" {{#if_eq parameters.size.0 "50"}}selected{{/if_eq}}>50</option>

--- a/src/main/web/templates/handlebars/list/filters/sort.handlebars
+++ b/src/main/web/templates/handlebars/list/filters/sort.handlebars
@@ -15,7 +15,7 @@
 
 		<div class="js-mobile-filters__sort">
 			<label for="sort" class="sort__label">{{labels.sort-by}}
-				<select class="input select select--thin width-auto js-auto-submit__input" id="sort" name="sortBy">
+				<select class="input select width-auto js-auto-submit__input" id="sort" name="sortBy">
 					<option class="sort__option" value="relevance" {{#if_eq result.sortBy "relevance"}}selected{{/if_eq}}>{{labels.relevance}}
 					</option>
 					<option class="sort__option" value="release_date"

--- a/src/main/web/templates/handlebars/list/filters/topics-hardcoded.handlebars
+++ b/src/main/web/templates/handlebars/list/filters/topics-hardcoded.handlebars
@@ -2,7 +2,7 @@
 
 <label class="filters__title" for="select-topic">Topics</label>
 <div class="filters__field">
-    <select class="input inline js-auto-submit__input" id="select-topic" name="topic">
+    <select class="input select inline js-auto-submit__input" id="select-topic" name="topic">
         <option value="" >Select topic</option>
         <option value="/economy/nationalaccounts/balanceofpayments"
                 {{#if_eq parameters.topic.0 "/economy/nationalaccounts/balanceofpayments"}}selected{{/if_eq}}>

--- a/src/main/web/templates/handlebars/list/filters/topics.handlebars
+++ b/src/main/web/templates/handlebars/list/filters/topics.handlebars
@@ -1,6 +1,6 @@
 <label for="select-topic" class="filters__title">Topics</label>
 <div class="filters__field">
-    <select class="input inline js-auto-submit__input" id="select-topic" name="topic">
+    <select class="input select inline js-auto-submit__input" id="select-topic" name="topic">
         <option value="" >Select topic</option>
         {{#each topics.results}}
             <option value="{{this.uri}}" {{#if_eq parameters.topic.0 this.uri}}selected{{/if_eq}}>{{description.title}}</option>

--- a/src/main/web/templates/handlebars/list/filters/update-date.handlebars
+++ b/src/main/web/templates/handlebars/list/filters/update-date.handlebars
@@ -1,6 +1,6 @@
 <div class="margin-top--2">
     <label class="filters__title" for="select-updated">Updated</label>
-    <select class="input inline js-auto-submit__input" id="select-updated" name="updated">
+    <select class="input select inline js-auto-submit__input" id="select-updated" name="updated">
         <option value="">Select last updated</option>
         <option value="today" {{#if_eq parameters.updated.0 "today"}}selected{{/if_eq}}>Today</option>
         <option value="week" {{#if_eq parameters.updated.0 "week"}}selected{{/if_eq}}>Last 7 days</option>

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -22,14 +22,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b416024{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cea80ce{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b416024{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cea80ce{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b416024{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b416024{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cea80ce{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cea80ce{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
         {{> partials/gtm-data-layer }}
@@ -141,7 +141,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b416024{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cea80ce{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,7 +51,7 @@ The commented code below is what needs to go in the parent.
     {{/if}}
   {{/if}}
 
-  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/b416024{{/if}}/js/main.js"></script>
+  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cea80ce{{/if}}/js/main.js"></script>
   <script type="text/javascript" src="/js/app.js"></script>
 
   <script type="text/javascript" src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What
Ensure that select boxes are no longer truncating their contents on:
1. Timeseries refinements - topics and updated
1. Page size list pages
1. Sorting on search page

### How to review
1. See that the timeseries refinements, page size and search sorting `select`s truncate their contents 
1. Check out this branch and `fix/select-field-text-truncate` in sixteens
1. Restart babbage
1. See that those issues are resolved.

### Who can review
Anyone but me