### PR TITLE
Fix - Confusing Charts

### DIFF
--- a/src/main/web/js/app/accessibility-enhance.js
+++ b/src/main/web/js/app/accessibility-enhance.js
@@ -21,5 +21,5 @@ function highchartsAccessibilityAttrs(selector, labelText, removeAttrs) {
 }
 
 function timeseriesAccessibilityAttrs(removeAttrs) {
-    highchartsAccessibilityAttrs($('.timeseries__chart'), 'Chart representing data available. Select "table" in show data as to display data as a table', removeAttrs);
+    highchartsAccessibilityAttrs($('.timeseries__chart'), 'Interactive chart representing data, includes a table view option.', removeAttrs);
 }

--- a/src/main/web/js/app/accessibility-enhance.js
+++ b/src/main/web/js/app/accessibility-enhance.js
@@ -21,5 +21,5 @@ function highchartsAccessibilityAttrs(selector, labelText, removeAttrs) {
 }
 
 function timeseriesAccessibilityAttrs(removeAttrs) {
-    highchartsAccessibilityAttrs($('.timeseries__chart'), 'Chart representing data available in table alternative. Select "table" in filters to display table', removeAttrs);
+    highchartsAccessibilityAttrs($('.timeseries__chart'), 'Chart representing data available. Select "table" in show data as to display data as a table', removeAttrs);
 }

--- a/src/main/web/js/app/linechart.js
+++ b/src/main/web/js/app/linechart.js
@@ -238,6 +238,7 @@ var renderLineChart = function (timeseries) {
             chart.yAxis.min = min;
         }
         show(chartContainer);
+        chartContainer.attr('tabIndex', '0');
         chartContainer.highcharts(chart);
     }
 

--- a/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
@@ -1,5 +1,6 @@
 <form class="timeseries__filters nojs--hide">
     <h2 class="tiles__title-h2">{{labels.filters}}</h2>
+    <span class="visuallyhidden">Use these filters to interact with the following chart of data.</span>
     <div class="tiles__content">
         <div data-chart-controls="" data-chart-controls-for="">
             <div class="col col--md-8 col--lg-12 margin-right-md--4 margin-right-lg--2">

--- a/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
@@ -5,61 +5,55 @@
             <div class="col col--md-8 col--lg-12 margin-right-md--4 margin-right-lg--2">
                 <fieldset class="btn-group">
                     <legend id="data-type">{{labels.show-data-as}}</legend>
-                    <div role="radiogroup" aria-labelledby="data-type">
-                        <label for="type-chart" class="btn btn--secondary btn--chart-control">
-                            {{labels.chart}}
-                            <input id="type-chart" type="radio" name="type" data-chart-controls-type="chart" aria-controls="data" checked>
-                        </label>
-                        <label for="type-table" class="btn btn--secondary btn--chart-control">
-                            {{labels.table}}
-                            <input id="type-table" type="radio" name="type" data-chart-controls-type="table" aria-controls="data">
-                        </label>
-                    </div>
+                    <label for="type-chart" class="btn btn--secondary btn--chart-control">
+                        {{labels.chart}}
+                        <input id="type-chart" type="radio" name="type" data-chart-controls-type="chart" aria-controls="data" checked>
+                    </label>
+                    <label for="type-table" class="btn btn--secondary btn--chart-control">
+                        {{labels.table}}
+                        <input id="type-table" type="radio" name="type" data-chart-controls-type="table" aria-controls="data">
+                    </label>
                 </fieldset>
             </div>
             <div class="col col--md-12 col--lg-18 margin-right-md--4 margin-right-lg--2">
                 <fieldset class="btn-group" role="radiogroup">
                     <legend id="frequency">{{labels.frequency}}</legend>
-                    <div role="radiogroup" aria-labelledby="frequency">
-                        <label class="btn btn--secondary btn--chart-control frequency-select">
-                            {{labels.month}}
-                            <input type="radio" class="frequency" name="scale" data-chart-controls-scale="months"
-                                   value="months" aria-controls="data">
-                        </label>
-                        <label class="btn btn--secondary btn--chart-control frequency-select">
-                            {{labels.quarter}}
-                            <input type="radio" class="frequency" name="scale" data-chart-controls-scale="quarters"
-                                   value="quarters" aria-controls="data">
-                        </label>
-                        <label class="btn btn--secondary btn--chart-control frequency-select">
-                            {{labels.year}}
-                            <input type="radio" class="frequency" name="scale" data-chart-controls-scale="years"
-                                   value="years" aria-controls="data">
-                        </label>
-                    </div>
+                    <label class="btn btn--secondary btn--chart-control frequency-select">
+                        {{labels.month}}
+                        <input type="radio" class="frequency" name="scale" data-chart-controls-scale="months"
+                                value="months" aria-controls="data">
+                    </label>
+                    <label class="btn btn--secondary btn--chart-control frequency-select">
+                        {{labels.quarter}}
+                        <input type="radio" class="frequency" name="scale" data-chart-controls-scale="quarters"
+                                value="quarters" aria-controls="data">
+                    </label>
+                    <label class="btn btn--secondary btn--chart-control frequency-select">
+                        {{labels.year}}
+                        <input type="radio" class="frequency" name="scale" data-chart-controls-scale="years"
+                                value="years" aria-controls="data">
+                    </label>
                 </fieldset>
             </div>
             <div class="col col--md-17 col--lg-23">
                 <fieldset class="btn-group">
                     <legend id="period">{{labels.time-period}}</legend>
-                    <div role="radiogroup" aria-labelledby="period">
-                        <label class="btn btn--secondary btn--chart-control btn--chart-control--all btn--secondary-active">
-                            {{labels.all}}
-                            <input type="radio" name="range" data-chart-controls-range="all" aria-controls="data" checked>
-                        </label>
-                        <label class="btn btn--secondary btn--chart-control">
-                            {{labels.last-10-years}}
-                            <input type="radio" name="range" data-chart-controls-range="10yr" aria-controls="data">
-                        </label>
-                        <label class="btn btn--secondary btn--chart-control">
-                            {{labels.last-5-years}}
-                            <input type="radio" name="range" data-chart-controls-range="5yr" aria-controls="data">
-                        </label>
-                        <label class="btn btn--secondary btn--chart-control">
-                            {{labels.custom}}
-                            <input type="radio" name="range" data-chart-control-custom-trigger-for="chart-area__controls__custom" aria-controls="customControls">
-                        </label>
-                    </div>
+                    <label class="btn btn--secondary btn--chart-control btn--chart-control--all btn--secondary-active">
+                        {{labels.all}}
+                        <input type="radio" name="range" data-chart-controls-range="all" aria-controls="data" checked>
+                    </label>
+                    <label class="btn btn--secondary btn--chart-control">
+                        {{labels.last-10-years}}
+                        <input type="radio" name="range" data-chart-controls-range="10yr" aria-controls="data">
+                    </label>
+                    <label class="btn btn--secondary btn--chart-control">
+                        {{labels.last-5-years}}
+                        <input type="radio" name="range" data-chart-controls-range="5yr" aria-controls="data">
+                    </label>
+                    <label class="btn btn--secondary btn--chart-control">
+                        {{labels.custom}}
+                        <input type="radio" name="range" data-chart-control-custom-trigger-for="chart-area__controls__custom" aria-controls="customControls">
+                    </label>
                 </fieldset>
 
                 <div class="chart-area__controls__custom js-hidden" id="customControls">
@@ -136,7 +130,7 @@
         </div>
     </div>
 </form>
-<div class="timeseries__chart" id="data">
+<div class="timeseries__chart" id="data" tabindex="0">
     <h2 id="title-type" class="tiles__title-h2">{{labels.chart}}</h2>
     <div class="col col--md-45 col--lg-57 margin-left-sm--1 margin-left-md--1 padding-right-sm--2 chart-area__timeseries">
         <div class="js--show nojs--hide chart linechart" data-chart="" data-uri="{{uri}}" ></div>

--- a/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
@@ -130,7 +130,7 @@
         </div>
     </div>
 </form>
-<div class="timeseries__chart" id="data" tabindex="0">
+<div class="timeseries__chart" id="data">
     <h2 id="title-type" class="tiles__title-h2">{{labels.chart}}</h2>
     <div class="col col--md-45 col--lg-57 margin-left-sm--1 margin-left-md--1 padding-right-sm--2 chart-area__timeseries">
         <div class="js--show nojs--hide chart linechart" data-chart="" data-uri="{{uri}}" ></div>


### PR DESCRIPTION
### What
On timeseries chart the structure caused double reading of the content in NVDA and was confusing. 
1. This change removes the wrapping `div` as recommended in the report
1. Make the chart tab focussable
1. Improve the wording read when the chart is focussed.

**NB** I don't have NVDA so haven't been able to confirm the issue is resolved there.

### How to review
1. Visit a timeseries page
1. See that the chart is not focussable
1. Switch the branch
1. See that the chart is focussable and reads a sensible description from a screen reader
1. See that visually the page is unchanged.

### Who can review
Anyone 