### PR TITLE
Update focus order in tables

### DIFF
--- a/src/main/web/js/app/mobile-table.js
+++ b/src/main/web/js/app/mobile-table.js
@@ -6,10 +6,12 @@ $(function() {
 
         $('.btn--mobile-table-show').click(function () {
             $(this).closest('.markdown-table-container').find('.markdown-table-wrap').show();
+            $(this).closest('.markdown-table-container').find('.markdown-table-wrap').find('table').attr("tabindex", "0").focus();
         });
 
         $('.btn--mobile-table-hide').click(function () {
-            $(this).closest('.markdown-table-wrap').css('display', '');
+            $(this).closest(markdownTable).css('display', '');
+            $(this).closest('.markdown-table-container').find('.btn--mobile-table-show').focus();
         });
     }
 });


### PR DESCRIPTION
### What

This PR updates the JS logic of the `mobile-table` module so that it automatically sets focus onto a table when the user clicks to view it in a mobile viewport. Screen readers can then read the content of the table. When closing the table, the focus then returns back to the "View Table" button

### How to review

Check current behaviour: that when a table is opened in sm viewport size on a page with a table, the focus does not move to the newly-opened table

Checkout this branch and check on a page that has a table in small viewport and ensure that the focus order works as described above.

Example page with table `//peoplepopulationandcommunity/culturalidentity/ethnicity/bulletins/detailedcharacteristicsforenglandandwales/2013-05-16#religion`

### Who can review

Anyone but me
