### PR TITLE
added Welsh translation for ONS logo alt text

### DIFF
--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -1,4 +1,5 @@
 office-for-national-statistics=Office for National Statistics
+ons-logo-alt=Office for National Statistics logo - Homepage
 release-calendar=Release calendar
 methodology=Methodology
 about=About

--- a/src/main/resources/LabelsBundle_cy.properties
+++ b/src/main/resources/LabelsBundle_cy.properties
@@ -1,4 +1,5 @@
 office-for-national-statistics=Swyddfa Ystadegau Gwladol
+ons-logo-alt=Logo Swyddfa Ystadegau Gwladol - Hafan
 release-calendar=Calendar datganiadau
 methodology=Methodoleg
 about=Amdanom ni

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -14,10 +14,10 @@
 				<div class="col col--lg-one-third col--md-one-third">
 					<a href="/">
 						<!--[if lte IE 8]>
-							<img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png" alt="Office for National Statistics">
+							<img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png" alt="{{labels.ons-logo-alt}}">
 						<![endif]-->
 						<!--[if gte IE 9]><!-->
-							<img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.svg" alt="Office for National Statistics logo - homepage">
+							<img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.svg" alt="{{labels.ons-logo-alt}}">
 						<![endif]-->
 					</a>
 				</div>


### PR DESCRIPTION
### What

This PR adds Welsh translation for the text, "Office for National Statistics logo - Homepage" that is applied to the ONS logo `alt` in the header. As the sentence structure differed between English and Welsh translations, it felt sensible to include the whole sentence as a separate key in the localisation files

### How to review

Check that the alt text for the ONS logo in the header is correctly applied as per text in the localisation files in a page handled by Babbage (e.g. `/businessindustryandtrade`).

You can change the language locally by setting the cookie, `lang`, to either `en` or `cy`. Once the page is refreshed, the site should be in the language chosen

### Who can review

Anyone but me