### PR TITLE
 Fix - Official statistics wording on dataset and bulletin pages

### DIFF
--- a/src/main/web/templates/handlebars/content/partials/bulletin-header.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/bulletin-header.handlebars
@@ -146,7 +146,7 @@
         <div class="col-wrap margin-top--3 margin-left--0">
                 {{#if description.nationalStatistic}} <div class="col col--md-4 col--lg-4"><a class="meta__image" href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
                 class="meta__image margin-right--0" src="/img/national-statistics.png"
-                alt="This is an accredited national statistic. For information about types of official statistics click this link."/></a></div>{{/if}}
+                alt="This is an accredited National Statistic. Click for information about types of official statistics."/></a></div>{{/if}}
             <p class="col {{class}} col--md-12 col--lg-15 margin-bottom-sm--1 margin-bottom-md--3 margin-top-sm--1 padding-bottom--0 padding-top--0">
                 <span class="font-weight-700">{{labels.contact}}: </span><br/><a href="mailto:{{description.contact.email}}" class="text--white"><span class="visuallyhidden">Email </span>{{#if description.contact.name}}{{description.contact.name}}{{else}}{{description.contact.email}}{{/if}}</a>
             </p>

--- a/src/main/web/templates/handlebars/content/partials/metadata/contact.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/metadata/contact.handlebars
@@ -3,6 +3,6 @@
     {{#if description.nationalStatistic}} <a
             href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
             class="meta__image" src="/img/national-statistics.png"
-            alt="This is an accredited national statistic. For information about types of official statistics click this link."/></a>{{/if}}
+            alt="This is an accredited National Statistic. Click for information about types of official statistics."/></a>{{/if}}
 	<span>{{labels.contact}}: </span><br/><a href="mailto:{{description.contact.email}}">{{#if description.contact.name}}{{description.contact.name}}{{else}}{{description.contact.email}}{{/if}}</a>
 </p>

--- a/src/main/web/templates/handlebars/content/partials/metadata/ns-logo.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/metadata/ns-logo.handlebars
@@ -3,6 +3,6 @@
 <p class="col col--md-4 col--lg-4 padding-left">
     <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
             class="meta__image" src="/node_modules/ONS-Pattern-Library/dist/img/national-statistics.png"
-            alt="This is an accredited national statistic. For information about types of official statistics click this link."/></a>
+            alt="This is an accredited National Statistic. Click for information about types of official statistics."/></a>
 </p>
 {{/if}}

--- a/src/main/web/templates/handlebars/content/t7-1.handlebars
+++ b/src/main/web/templates/handlebars/content/t7-1.handlebars
@@ -62,7 +62,7 @@
                         <div class="col col--md-4 {{#if_all description.surveyName description.frequency description.compilation description.sampleSize description.geographicCoverage}}col--lg-5{{else}}col--lg-4{{/if_all}}">
                             <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/"><img
                                     class="meta__image padding-left padding-top--half"
-                                    src="/img/national-statistics.png" alt="This is an accredited national statistic. For information about types of official statistics click this link."/></a>
+                                    src="/img/national-statistics.png" alt="This is an accredited National Statistic. Click for information about types of official statistics."/></a>
                         </div>
                         {{#if description.surveyName}}
                             <p class="col {{#if_all description.surveyName description.frequency description.compilation description.sampleSize description.geographicCoverage}}col--md-8 col--lg-11{{else}}col--md-11 col--lg-14{{/if_all}} meta__item">

--- a/src/main/web/templates/handlebars/pdf/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/pdf/partials/header.handlebars
@@ -21,7 +21,7 @@
                 <img
                     class="meta__image"
                     src="https://www.ons.gov.uk/img/national-statistics.png"
-                    alt="This is an accredited national statistic. For information about types of official statistics click this link." width="47"
+                    alt="This is an accredited National Statistic. Click for information about types of official statistics." width="47"
                     height="47"/>
             </a>
         {{/if}}


### PR DESCRIPTION
### What
Changed the official statistics image alt text so it is less than 99 characters which is the limit read by some screen readers.

### How to review
1. Visit a dataset or bulletin page
1. The alt text of the image will very long - "This is an accredited national statistic. For information about types of official statistics click this link."
1. Check out this branch and restart babbage
1. See that the alt text of the image will now be "This is an accredited National Statistic. Click for information about types of official statistics.""

### Who can review
Anyone
