### PR TITLE
Feature - Interactive iframe title

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/InteractiveTagReplacer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/util/InteractiveTagReplacer.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 
 public class InteractiveTagReplacer extends TagReplacementStrategy {
 
-    private static final Pattern pattern = Pattern.compile("<ons-interactive\\surl=\"([-A-Za-z0-9+&@#/%?=~_|!:,.;()*$]+)\"\\s?(?:\\s?full-width=\"([a-zA-Z]*)\")?/>");
+    private static final Pattern pattern = Pattern.compile("<ons-interactive\\surl=\"([-A-Za-z0-9+&@#/%?=~_|!:,.;()*$]+)\"\\s?(?:\\s?full-width=\"([a-zA-Z]*)\")?\\s?(?:\\s?title=\"(.*)\")?/>");
     private final String template;
 
     /**
@@ -34,10 +34,12 @@ public class InteractiveTagReplacer extends TagReplacementStrategy {
     String replace(Matcher matcher) throws IOException {
         String tagPath = matcher.group(1);
         String fullWidth = matcher.group(2);
+        String title = matcher.group(3);
         LinkedHashMap<String, Object> additionalData = new LinkedHashMap<>();
         additionalData.put("id", UUID.randomUUID().toString().substring(10));
         additionalData.put("url", tagPath);
         additionalData.put("full-width", fullWidth);
+        additionalData.put("title", title);
         return TemplateService.getInstance().renderTemplate(template, null, additionalData);
     }
 }

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -93,6 +93,7 @@ download-this-entire-time-series=Download this entire time series
 image=Image
 time-series=Time series
 chart=Chart
+interactive-chart=Interactive chart
 table=Table
 show-data-as=Show data as
 month=Month

--- a/src/main/resources/LabelsBundle_cy.properties
+++ b/src/main/resources/LabelsBundle_cy.properties
@@ -93,6 +93,7 @@ download-this-entire-time-series=Lawrlwytho'r gyfres amser gyfan hon
 image=Delwedd
 time-series=Cyfres amser
 chart=Siart
+interactive-chart=Siart rhyngweithiol
 table=Tabl
 show-data-as=Dangos data fel
 month=Mis

--- a/src/main/web/js/app/pym-interactive.js
+++ b/src/main/web/js/app/pym-interactive.js
@@ -1,7 +1,9 @@
 
 $(function() {
     $('div.pym-interactive').each(function(index, element) {
-        var pymParent = new pym.Parent($(element).attr('id'), $(element).data('url'));
+        var pymParent = new pym.Parent($(element).attr('id'), $(element).data('url'), {
+            title: $(element).data('title')
+        });
         pymParent.onMessage('height', function(height) {
             addIframeHeightToEmbedCode($(this), height);
         });

--- a/src/main/web/templates/handlebars/partials/interactive.handlebars
+++ b/src/main/web/templates/handlebars/partials/interactive.handlebars
@@ -1,6 +1,6 @@
 <div class="js--show">
 
-    <div class="pym-interactive{{#if_eq full-width "true"}} pym-interactive--full-width margin-left--0{{/if_eq}}" id="{{id}}" data-url="{{url}}"></div>
+    <div class="pym-interactive{{#if_eq full-width "true"}} pym-interactive--full-width margin-left--0{{/if_eq}}" id="{{id}}" data-url="{{url}}" data-title="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}}"></div>
 
     <details class="details">
         <summary class="details__summary">Embed code</summary>


### PR DESCRIPTION
### What
Add the ability for a title to be defined for the iframe containing an interactive chart.

I used this article as the basis if you need some data. https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/bulletins/babynamesenglandandwales/2018/#oliver-and-olivia-remained-the-most-popular-baby-names-in-2018

### How to review
1. Load an article containing interactives
1. See that there is no title on the iframe so the screen readers read it just as `frame`
1. Load this branch and restart babbage.
1. See that the interactives iframe gets the title `Interactive chart`
1. Update an `ons-interactive` tag in the content to add a `title` attribute e.g. `\u003cons-interactive url\u003d\"/visualisations/dvc669/timeseriesmultiline2/index.html\" full-width\u003d\"false\" title\u003d\"here is my descriptive title\"/\u003e`
1. See that the title exists and is read by the screen reader.

### Who can review
Anyone but me
