### PR TITLE
remove extra ul element

### DIFF
--- a/src/main/web/templates/handlebars/list/t11.handlebars
+++ b/src/main/web/templates/handlebars/list/t11.handlebars
@@ -52,7 +52,6 @@
 {{/partial}}
 
 {{#partial "block-results"}}
-	<ul class="list--neutral">
 		{{#each result.results}}
 		<li class="search--result-item margin-bottom-md--2 margin-bottom-sm--2">
 			{{> list/partials/results-title showEdition=true}}
@@ -88,7 +87,6 @@
 			</p>
 		</li>
 		{{/each}}
-	</ul>
 {{/partial}}
 
 {{!-- Inheriting from base list template --}}


### PR DESCRIPTION
### What

Un-nested the lists on the results page. 

### How to review

Pull branch, inspect page. First child element in `<ul>` should be `<li>`. Previous version can be seen in image "NestedListBefore" <img width="1369" alt="NestedListBefore" src="https://user-images.githubusercontent.com/16807393/89285803-f08d4180-d648-11ea-8fb7-1e37bc57f48e.png">
has now been updated to "UnnestedListAfter" <img width="1369" alt="UnnestedListAfter" src="https://user-images.githubusercontent.com/16807393/89285835-ff73f400-d648-11ea-8413-81aed950f26c.png">. 

### Who can review



