### PR TITLE
Fix - Set correct page title for dataset pages

### DIFF
--- a/src/main/web/templates/handlebars/content/t12.handlebars
+++ b/src/main/web/templates/handlebars/content/t12.handlebars
@@ -12,15 +12,12 @@
 
     {{!-- Resolve title from parent --}}
 
-    {{#each breadcrumb}}
-        {{#if @last}}
-            {{#resolve uri}}
-
-                <h1 class="page-intro__title {{#if_any description._abstract description.summary}}{{else}}margin-bottom-sm--4 margin-bottom-md--4{{/if_any}}">{{#if typeLabel}}<span class="page-intro__type">{{typeLabel}}:</span>{{/if}}{{description.title}}
-
-            {{/resolve}}
-        {{/if}}
-    {{/each}}
+    {{#resolve (parentPath uri)}}
+        <h1 class="page-intro__title {{#if_any description._abstract description.summary}}{{else}}margin-bottom-sm--4 margin-bottom-md--4{{/if_any}}">
+            {{#if typeLabel}}<span class="page-intro__type">{{typeLabel}}:</span>{{/if}}
+            {{description.title}}
+        </h1>
+    {{/resolve}}
 
     {{!-- Output edition --}}
 

--- a/src/main/web/templates/handlebars/content/t12.handlebars
+++ b/src/main/web/templates/handlebars/content/t12.handlebars
@@ -64,7 +64,7 @@
                             {{#if description.datasetId}}
                                 <p class="col col--md-12 col--lg-15 meta__item">
                                     <span>{{labels.dataset-id}}: </span>{{description.datasetId}}&nbsp;
-                                    <span><a href="#" class="tooltip print--hide" title="This series ID is a unique random identifier for this individual time series. The digits themselves do not have any specific meaning">{{labels.dataset-what-is}} </a></span>
+                                    <span><a href="#" class="tooltip print--hide" title="This series ID is a unique random identifier for this individual time series. The digits themselves do not have any specific meaning">{{labels.dataset-what-is}}</a></span>
                                 </p>
                             {{/if}}
                         {{/resolve}}

--- a/src/main/web/templates/handlebars/partials/page-title.handlebars
+++ b/src/main/web/templates/handlebars/partials/page-title.handlebars
@@ -16,11 +16,9 @@
         {{#if_eq listType "relateddata"}}All data related to {{> list/partials/list-location upper=true}}{{/if_eq}}
         {{#if_eq listType "releasecalendar"}}Release calendar{{/if_eq}}
         {{#if_eq listType "timeseriestool"}}Time series explorer{{/if_eq}}
-    {{else}}
-        {{#if_eq type "timeseries_dataset"}}
-            {{#resolve (parentPath uri)}}{{description.title}}{{/resolve}}
-            {{else}}
-        {{#if description.title}}{{description.title}}{{else}}{{#if title}}{{{sub (sup title clear=true) clear=true}}}{{else}}Page not found{{/if}}{{/if}}
-        {{/if_eq}}
+    {{else if_any (eq type "timeseries_dataset") (eq type "dataset")}} {{#resolve (parentPath uri)}}{{description.title}}{{/resolve}}
+    {{else if description.title}} {{description.title}}
+    {{else if title}}{{{sub (sup title clear=true) clear=true}}}
+    {{else}}Page not found
     {{/if_eq}}
 {{/minify}}


### PR DESCRIPTION
### What
As per the page resolve the title from the parent dataset_landing_page

Additionally:
1. Tidied up the logic in the partial
1. Simplified the parent resolution on the page
1. Remove invalid character from the page

### How to review
1. Load a dataset page
1. See that the title is `Page not found`
1. Switch to this branch and see that the title now matches the page h1 heading

### Who can review
Anyone but me
