### PR TITLE
Fix - Language of language switch link

### DIFF
--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -25,11 +25,11 @@
                     {{!-- Show bothe language's and toggle--}}
                     <div class="language">
                         {{#if_eq location.hostname (concat "cy." (replace location.hostname "cy." ""))}}
-                            <a href="{{> partials/language-toggle language="en"}}" class="language__link">English (EN)</a>
+                            <a href="{{> partials/language-toggle language="en"}}" class="language__link" lang="en-GB">English (EN)</a>
                             <span> | Cymraeg (CY)</span>
                         {{else}}
                             <span>English (EN) | </span>
-                            <a href="{{> partials/language-toggle language="cym"}}" class="language__link">Cymraeg (CY)</a>
+                            <a href="{{> partials/language-toggle language="cym"}}" class="language__link" lang="cy">Cymraeg (CY)</a>
                         {{/if_eq}}
                     </div>
                 </div>


### PR DESCRIPTION
### What
Set link to correct language so that it is read by screen reader correctly

### How to review
#### Option 1 - With NVDA on Windows in Chrome or Edge latest (not IE11)
1. Load any page rendered by this (e.g. release calendar etc)
1. Hear that `Cymraeg` is not read correctly (something like _sim-rig_)
1. Switch to this branch and hear it read correctly

#### Option 2 - Looking at the source
1. Load any page rendered by this  (e.g. release calendar etc)
1. See that the link to `cy.ons.gov.uk` has no `lang` attribute
1. Switch to this branch and see that it has a `lang` attribute of `cy`

### Who can review
Anyone but me