### PR TITLE
Fix/button functionality

### DIFF
--- a/src/main/web/js/app/mobile-table.js
+++ b/src/main/web/js/app/mobile-table.js
@@ -2,14 +2,24 @@ $(function() {
     var markdownTable = $('.markdown-table-wrap');
 
     if (markdownTable.length) {
-        $('<button class="btn btn--secondary btn--mobile-table-hide">Close table</button>').insertAfter(markdownTable.find('table'));
+        $('<button class="btn btn--secondary btn--mobile-table-hide" aria-expanded="false" aria-hidden="true" aria-live="assertive">Close table</button>').insertAfter(markdownTable.find('table'));
 
-        $('.btn--mobile-table-show').click(function () {
+        var showButtons = $('.btn--mobile-table-show');
+        var hideButtons = $('.btn--mobile-table-hide');
+        showButtons.click(function () {
+            $(this).attr('aria-hidden', true);
+            $(this).attr('aria-expanded', true);
+            hideButtons.attr('aria-hidden', false);
+            hideButtons.attr('aria-expanded', true);
             $(this).closest('.markdown-table-container').find('.markdown-table-wrap').show();
             $(this).closest('.markdown-table-container').find('.markdown-table-wrap').find('table').attr("tabindex", "0").focus();
         });
 
-        $('.btn--mobile-table-hide').click(function () {
+        hideButtons.click(function () {
+            $(this).attr('aria-hidden', true);
+            $(this).attr('aria-expanded', false);
+            showButtons.attr('aria-hidden', false);
+            showButtons.attr('aria-expanded', false);
             $(this).closest(markdownTable).css('display', '');
             $(this).closest('.markdown-table-container').find('.btn--mobile-table-show').focus();
         });

--- a/src/main/web/templates/handlebars/partials/table-v2.handlebars
+++ b/src/main/web/templates/handlebars/partials/table-v2.handlebars
@@ -5,7 +5,7 @@
     </div>
 
     {{!-- 'View table' button for mobile --}}
-    <button class="btn btn--secondary btn--mobile-table-show nojs--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="view-table">View table</button>
+    <button class="btn btn--secondary btn--mobile-table-show nojs--hide" aria-expanded="false" aria-live="assertive" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="view-table">View table</button>
 
     <h5 class="print--hide font-size--h6">Download this table</h5>
     <a href="/download/table?format=xlsx&uri={{uri}}.json" title="Download as xlsx" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xlsx">.xlsx</a>

--- a/src/main/web/templates/handlebars/partials/table.handlebars
+++ b/src/main/web/templates/handlebars/partials/table.handlebars
@@ -7,7 +7,7 @@
     </div>
 
     {{!-- 'View table' button for mobile --}}
-    <button class="btn btn--secondary btn--mobile-table-show nojs--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="view-table">View table</button>
+    <button class="btn btn--secondary btn--mobile-table-show nojs--hide" aria-expanded="false" aria-live="assertive" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="view-table">View table</button>
 
     {{/resolveResource}}
     <h5 class="print--hide font-size--h6">Download this table</h5>


### PR DESCRIPTION
### What

Update the 'View Table' and 'Close Table' buttons for mobile to make it clear to screen readers users whether the table is expanded or not.

### How to review

- Use/emulate a mobile device and use a screenreader
- Navigate to a data page that contains a table.
- Click on the 'View table' button
- The table should be displayed, screen reader should announce the details of the 'Close table' button, included that the table is expanded, and the details of the table itself.
- Click the 'Close table' button
- The table should no longer be visible and screen reader should announce the 'View table' button, including that the table is now collapsed.

### Who can review

Anyone but me
