### PR TITLE
add aria-hidden and negative tabindex to datepicker button

### DIFF
--- a/src/main/web/templates/handlebars/list/partials/date-picker.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/date-picker.handlebars
@@ -1,4 +1,4 @@
-<button class="btn btn--narrow btn--small datepicker__icon nojs--hide" id={{buttonId}} type="button"><span class="icon icon-calendar--dark-small"></span></button>
+<button class="btn btn--narrow btn--small datepicker__icon nojs--hide" aria-hidden="true" tabindex="-1" id={{buttonId}} type="button"><span class="icon icon-calendar--dark-small"></span></button>
 <div id={{datepickerId}} class="datepicker" aria-hidden="true">
     <button class="datepicker__btn datepicker__btn--prev js-datepicker__prev" aria-labelledby="{{datepickerId}}-bn_prev-label"
             tabindex="0"><span class="icon icon-arrow-left--light"></span></button>

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -22,14 +22,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/9c4c0bc{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/684854f{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/9c4c0bc{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/684854f{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/9c4c0bc{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/9c4c0bc{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/684854f{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/684854f{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
         {{> partials/gtm-data-layer }}
@@ -141,7 +141,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/9c4c0bc{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/684854f{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,7 +51,7 @@ The commented code below is what needs to go in the parent.
     {{/if}}
   {{/if}}
 
-  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/9c4c0bc{{/if}}/js/main.js"></script>
+  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/684854f{{/if}}/js/main.js"></script>
   <script type="text/javascript" src="/js/app.js"></script>
 
   <script type="text/javascript" src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What

Added aria-hidden to date picker button and set its tabindex to -1 to remove it from the keyboard nav.
(Sixteens reference will be update once sixteens pr has been merged)

### How to review

(Needs to be run with the branch of the same name in sixteens)
- use a screen reader
- navigate to the /releasecalendar page.
- inspect the date picker button it should have the aria-hidden attribute set to true.
- the date picker button should not be announced by the screen reader.
- navigate through the page using the tab key, you should not be able to access the date picker button.

### Who can review

Anyone but me
