### PR TITLE
announce the expansion and collapse of the embed code section on scre…

### DIFF
--- a/src/main/web/js/app/accessibility-enhance.js
+++ b/src/main/web/js/app/accessibility-enhance.js
@@ -23,3 +23,13 @@ function highchartsAccessibilityAttrs(selector, labelText, removeAttrs) {
 function timeseriesAccessibilityAttrs(removeAttrs) {
     highchartsAccessibilityAttrs($('.timeseries__chart'), 'Interactive chart representing data, includes a table view option.', removeAttrs);
 }
+
+$(function() {
+    var embedCodeBtns = $('.details__summary');
+
+    if (embedCodeBtns.length) {
+        embedCodeBtns.click(function () {
+            $(this).attr('aria-expanded', $(this).attr('aria-expanded') === 'false');
+        });
+    }
+});

--- a/src/main/web/templates/handlebars/partials/interactive.handlebars
+++ b/src/main/web/templates/handlebars/partials/interactive.handlebars
@@ -3,7 +3,7 @@
     <div class="pym-interactive{{#if_eq full-width "true"}} pym-interactive--full-width margin-left--0{{/if_eq}}" id="{{id}}" data-url="{{url}}"></div>
 
     <details class="details">
-        <summary class="details__summary">Embed code</summary>
+        <summary class="details__summary" aria-expanded="false">Embed code</summary>
         <div class="details__body">
             <label class="embed-code__label" for="embed-{{id}}">Embed this interactive</label>
             <input class="embed-code__code width-md--32"


### PR DESCRIPTION
…en readers

### What

Added aria-expanded attribute to the 'Embed Code' toggle to assist screen reader users.

### How to review

- Use a screenreader
- Navigate to a data page that contains an 'Embed Code' option.
- move focus to the 'Embed Code' toggle, the screen reader should announce the details of the toggle, included that it is collapsed.
- Click the 'Embed Code' button
- The details should become visible and screen reader should announce that it is expanded.

### Who can review

Anyone but me
