### PR TITLE
Fix - Layout issue with list pages in Firefox

### DIFF
--- a/src/main/web/templates/handlebars/list/t13.handlebars
+++ b/src/main/web/templates/handlebars/list/t13.handlebars
@@ -102,8 +102,8 @@
 			</div>
 
             {{!-- Units --}}
-			<div class="col-wrap">
-				<div class="col col--md-18 col--lg-20 margin-left-md--5 margin-bottom-md--2">
+			<div class="col-wrap margin-bottom-md--2">
+				<div class="col col--md-18 col--lg-20 margin-left-md--5">
 					<p class="search-results__meta flush--sm">Dataset ID: {{{description.datasetId}}} | Series ID: {{{description.cdid}}}{{#if description.unit}} | Units: {{description.unit}}{{else}}&nbsp;{{/if}}</p>
 				</div>
 			</div>


### PR DESCRIPTION
### What
In Firefox the timeseries list pages looked broken
<img width="1157" alt="Screenshot 2020-08-12 at 09 50 53" src="https://user-images.githubusercontent.com/180903/89995490-703a9200-dc81-11ea-9cf3-f6306e83a41d.png">

This fixes the layout so it looks like Chrome and Safari
<img width="1274" alt="Screenshot 2020-08-12 at 09 51 04" src="https://user-images.githubusercontent.com/180903/89995518-7b8dbd80-dc81-11ea-9035-f0f78c883c21.png">

### How to review
1. Load a timeseries list page in Firefox
1. See the broken layout
1. Switch to this branch and see that it is fixed

### Who can review
Anyone but me
