### PR TITLE
Fix - Issue where causing duplicate ids and link not working

### DIFF
--- a/src/main/web/templates/handlebars/list/t13.handlebars
+++ b/src/main/web/templates/handlebars/list/t13.handlebars
@@ -82,11 +82,11 @@
 
 			{{!-- Checkbox --}}
 			<div class="input__wrapper col col--md-3 col--lg-3 margin-left-md--1 padding-left-md--1 padding-bottom-sm" >
-				<input id="select-{{description.datasetId}}"type="checkbox" name="" data-title="{{description.title}}" data-cdid="{{description.cdid}}" data-datasetId="{{description.datasetId}}" data-uri="{{uri}}" value="" class="timeseries__select js-timeseriestool-select js--show" aria-label="{{description.title}}">
+				<input type="checkbox" name="" data-title="{{description.title}}" data-cdid="{{description.cdid}}" data-datasetId="{{description.datasetId}}" data-uri="{{uri}}" value="" class="timeseries__select js-timeseriestool-select js--show" aria-label="{{description.title}}">
 			</div>
 			{{!-- Title --}}
 			<div class="col col--md-21 col--lg-25 padding-right-md--1">
-				<p class="margin-bottom-md--0 flush--sm"><a href="{{uri}}"><label for="select-{{description.datasetId}}">{{description.title}}</label></a></p>
+				<p class="margin-bottom-md--0 flush--sm"><a href="{{uri}}">{{description.title}}</a></p>
 			</div>
 
 			{{!-- Is new? --}}


### PR DESCRIPTION
### What
This page can be loaded where the dataset ids are identical this caused duplicate Ids on the page so clicking the link resulted in only one checkbox being selected.

Additionally the link should not have been used to be the label as this obviously prevented it from being a link 🤦‍♂️ 

Discussion with UX on how to solve this needs doing but at least they are now workubg

### How to review
1. Load a timeseries explorer page e.g. http://localhost:20000/timeseriestool?topic=/economy/grossdomesticproductgdp/timeseries
1. See that the links don't work and clicking them modifies just one checkbox
1. Load this branch
1. See that the links work, there are no duplicate ids and that we are as before with no label for the checkboxes

### Who can review
Anyone but me
