### PR TITLE
Fix - Pagination on iPhone with VoiceOver

### DIFF
--- a/src/main/web/templates/handlebars/list/partials/paginator.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/paginator.handlebars
@@ -12,8 +12,8 @@
                 {{#if_eq this paginator.currentPage}}
                 <span class="page-link btn btn--plain btn--plain-active btn--block">{{this}}</span>
                 {{else}}
-                <a href="{{location.pathname}}{{query_string exclude="page"}}page={{this}}" class="page-link btn btn--plain">
-                    <span class="visuallyhidden">Page</span> {{this}} <span class="visuallyhidden">of {{paginator.numberOfPages}}</span>
+                <a href="{{location.pathname}}{{query_string exclude="page"}}page={{this}}" class="page-link btn btn--plain" aria-label="Page {{this}} of {{paginator.numberOfPages}}">
+                    {{this}}
                 </a>
                 {{/if_eq}}
             </li>


### PR DESCRIPTION
### What
iPhone does not support `visuallyhidden` text inside of a link.
https://gist.github.com/nickcolley/19b80ed24d0364cfd3afd3b1b49c4014

We have to use aria-label as that has the best support for setting the
text read by screen readers for link.
https://www.powermapper.com/tests/screen-readers/labelling/a-aria-label/

### How to review
1. Using iPhone with VoiceOver
1. Visit a search page
1. See that tapping the pagination links read "2 link", "3 link" etc.
1. Switch to this branch
1. See that tapping the pagination links read "Page 2 of 22 link" etc.

### Who can review
Anyone but me
