### PR TITLE
Fix/descriptive embed button

### DIFF
--- a/src/main/web/templates/handlebars/partials/interactive.handlebars
+++ b/src/main/web/templates/handlebars/partials/interactive.handlebars
@@ -3,7 +3,7 @@
     <div class="pym-interactive{{#if_eq full-width "true"}} pym-interactive--full-width margin-left--0{{/if_eq}}" id="{{id}}" data-url="{{url}}" data-title="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}}"></div>
 
     <details class="details">
-        <summary class="details__summary">Embed code</summary>
+        <summary class="details__summary" aria-label="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}} embed code">Embed code</summary>
         <div class="details__body">
             <label class="embed-code__label" for="embed-{{id}}">Embed this interactive</label>
             <input class="embed-code__code width-md--32"

--- a/src/main/web/templates/handlebars/partials/interactive.handlebars
+++ b/src/main/web/templates/handlebars/partials/interactive.handlebars
@@ -3,7 +3,7 @@
     <div class="pym-interactive{{#if_eq full-width "true"}} pym-interactive--full-width margin-left--0{{/if_eq}}" id="{{id}}" data-url="{{url}}" data-title="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}}"></div>
 
     <details class="details">
-        <summary class="details__summary" aria-label="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}} embed code">Embed code</summary>
+        <summary class="details__summary" role="button" aria-label="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}} embed code">Embed code</summary>
         <div class="details__body">
             <label class="embed-code__label" for="embed-{{id}}">Embed this interactive</label>
             <input class="embed-code__code width-md--32"


### PR DESCRIPTION
### What

Added the interactive content title to the 'Embed code' button to make it clearer for screen readers.
(This is dependant on this previous PR https://github.com/ONSdigital/babbage/pull/429)

### How to review

- Use a screenreader
- Navigate to a data page that contains an 'Embed Code' option.
- move focus to the 'Embed Code' toggle
- the screen reader should read the title of the interactive content followed by 'embed code'

### Who can review

Anyone but me
