### PR TITLE
Fix - Download this description

### DIFF
--- a/src/main/web/templates/handlebars/content/t5-1.handlebars
+++ b/src/main/web/templates/handlebars/content/t5-1.handlebars
@@ -40,7 +40,7 @@
 
                     {{!-- Chart footer --}}
                     <div class="tiles__content">
-                        <h2>{{labels.download-this-time-series}}</h2>
+                        <h2><span role="text">{{labels.download-this-time-series}}<span class="visuallyhidden">{{description.title}}</span></span></h2>
                         <div class="chart-area__footer__actions">
                                                         <form class="timeseries__filters nojs--hide">
                             <div class="nojs--hide">

--- a/src/main/web/templates/handlebars/partials/highcharts/chart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/chart.handlebars
@@ -82,7 +82,7 @@
   {{/if}}
       </div>
   
-    <h5 class="print--hide font-size--h6 clear-left">Download this chart</h5>
+    <h5 class="print--hide font-size--h6 clear-left"><span role="text">Download this chart <span class="visuallyhidden">{{title}}</span></span></h5>
 {{#if_ne chartType "small-multiples"}}
     <a class="btn btn--primary print--hide js-chart-image-src" data-filename="{{filename}}" href="/chartimage?uri={{uri}}" download="{{{sub (sup title)}}}" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-chart-image"  aria-label="Download {{title}} as an image">Image</a>
       {{else}}

--- a/src/main/web/templates/handlebars/partials/image.handlebars
+++ b/src/main/web/templates/handlebars/partials/image.handlebars
@@ -18,7 +18,7 @@
             {{md notes}}
         {{/if}}
 
-        <h6 class="print--hide">Download this image</h6>
+        <h6 class="print--hide"><span role="text">Download this image <span class="visuallyhidden">{{title}}</span></span></h6>
         {{#each files}}
             {{#if (eq type "uploaded-image")}}
                 <a class="btn btn--primary print--hide" title="Download as {{fileType}}"

--- a/src/main/web/templates/handlebars/partials/table-v2.handlebars
+++ b/src/main/web/templates/handlebars/partials/table-v2.handlebars
@@ -7,7 +7,7 @@
     {{!-- 'View table' button for mobile --}}
     <button class="btn btn--secondary btn--mobile-table-show nojs--hide" aria-expanded="false" aria-live="assertive" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="view-table">View table</button>
 
-    <h5 class="print--hide font-size--h6">Download this table</h5>
+    <h5 class="print--hide font-size--h6"><span role="text">Download this table <span class="visuallyhidden">{{title}}</span></span></h5>
     <a href="/download/table?format=xlsx&uri={{uri}}.json" title="Download as xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xlsx" aria-label="Download {{title}} as xls">.xls</a>
     <a href="/download/table?format=csv&uri={{uri}}.json" title="Download as csv" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-csv" aria-label="Download {{title}} as csv">.csv</a>
 </div>

--- a/src/main/web/templates/handlebars/partials/table.handlebars
+++ b/src/main/web/templates/handlebars/partials/table.handlebars
@@ -10,6 +10,6 @@
     <button class="btn btn--secondary btn--mobile-table-show nojs--hide" aria-expanded="false" aria-live="assertive" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="view-table">View table</button>
 
     {{/resolveResource}}
-    <h5 class="print--hide font-size--h6">Download this table</h5>
+    <h5 class="print--hide font-size--h6"><span role="text">Download this table <span class="visuallyhidden">{{title}}</span></span></h5>
     <a href="/file?uri={{uri}}.xls" title="Download as xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xls" aria-label="Download table {{title}} as xls">.xls</a>
 </div>


### PR DESCRIPTION
### What

Add headings for the download this heading so that it makes sense.

Unfortunately we need to doubly wrap the content so that the
`visuallyhidden` class is read by the screen readers on voiceover for
iOS.

This was tested in VoiceOver for Mac, iPhone and NVDA on Windows.

### How to review
1. Find a download this heading e.g. a chart, table etc in a bulletin
1. View the heading rotor and see that it has no context
1. Switch to this branch
1. See that the context is read by the screen and is in the heading rotor

### Who can review
Anyone but me
