### PR TITLE
Fix - Add missing empty alt tags on product pages

### DIFF
--- a/src/main/web/templates/handlebars/partials/t3/highlighted-content-small.handlebars
+++ b/src/main/web/templates/handlebars/partials/t3/highlighted-content-small.handlebars
@@ -51,7 +51,7 @@
     {{else}}
         {{#if highlighted.imageUri}}
         <div class="col col--md-13 col--lg-13 margin-left--0">
-            <img src="/resource?uri={{highlighted.imageUri}}&width=208" />
+            <img src="/resource?uri={{highlighted.imageUri}}&width=208" alt="" />
         </div>
         {{/if}}
         <div class="col col--md-30 col--lg-38 margin-left--0">

--- a/src/main/web/templates/handlebars/partials/t3/related-articles.handlebars
+++ b/src/main/web/templates/handlebars/partials/t3/related-articles.handlebars
@@ -6,7 +6,7 @@
             <div class="col-wrap margin-left--1 padding-right-sm--2">
                 {{#if imageUri}}
                     <div class="col col--md-13 col--lg-13 margin-left--0">
-                        <img src="/resource?uri={{imageUri}}&width=208" />
+                        <img src="/resource?uri={{imageUri}}&width=208" alt="" />
                     </div>
                 {{/if}}
                 <div class="col col--md-30 col--lg-38 margin-left--0">


### PR DESCRIPTION
### What

Add missing alt tags to images on product page

### How to review

1. Visit a product page e.g. https://www.ons.gov.uk/peoplepopulationandcommunity/housing
1. See that some of the decorative images have no `alt` attributes
1. Switch to this branch
1. See that there are `alt` attributes

### Who can review

Anyone but me
