### PR TITLE
Fix/product page headings

### DIFF
--- a/src/main/web/templates/handlebars/partials/t3/timeseries-list.handlebars
+++ b/src/main/web/templates/handlebars/partials/t3/timeseries-list.handlebars
@@ -6,7 +6,7 @@
             <li class="col-wrap background--white padding-top--2 padding-bottom--2 padding-left--1 flush-col js-hover-click">
                 <div class="col col--md-15 col--lg-27">
                     <div class="box__content">
-                        <h3>
+                        <h3 class="font-size--h4">
                             <a class="underline-link" href="{{uri}}">{{description.title}}</a>
                         </h3>
                         {{#if description.keyNote}}

--- a/src/main/web/templates/handlebars/partials/t3/timeseries-list.handlebars
+++ b/src/main/web/templates/handlebars/partials/t3/timeseries-list.handlebars
@@ -6,9 +6,9 @@
             <li class="col-wrap background--white padding-top--2 padding-bottom--2 padding-left--1 flush-col js-hover-click">
                 <div class="col col--md-15 col--lg-27">
                     <div class="box__content">
-                        <h4>
+                        <h3>
                             <a class="underline-link" href="{{uri}}">{{description.title}}</a>
-                        </h4>
+                        </h3>
                         {{#if description.keyNote}}
                             <p class="flush">{{description.keyNote}}</p>
                         {{/if}}</div>


### PR DESCRIPTION
### What

Updated the heading levels on the product page to make them semantically correct.

### How to review

- Go to a product page
- See that the title of each of the time series items is an h4.
- Checkout this branch
- See that the titles are now h3 tags, but with the same styling.

### Who can review

Anyone but me
