### PR TITLE
Fix - Add download link context for user download page

### DIFF
--- a/src/main/web/templates/handlebars/content/t7-2.handlebars
+++ b/src/main/web/templates/handlebars/content/t7-2.handlebars
@@ -34,7 +34,7 @@
                             <ul class="list--neutral">
                                 {{#each downloads}}
                                     <li>
-                                        <a href="/file?uri={{concat uri "/" (fn file)}}">{{title}}</a>
+                                        <a href="/file?uri={{concat uri "/" (fn file)}}" aria-label="Download {{title}} as {{fe (concat uri "/" (fn file))}} ({{fs (concat uri "/"  (fn file))}})">{{title}}</a>
                                         ({{fs (concat uri "/"  (fn file))}} {{fe (concat uri "/" (fn file))}})
                                     </li>
                                 {{/each}}
@@ -60,7 +60,8 @@
                                         data-gtm-type="related-download" 
                                         data-gtm-title="{{title}}"
                                         data-gtm-download-file="{{file}}"
-                                        data-gtm-download-type="{{fe file}}" 
+                                        data-gtm-download-type="{{fe file}}"
+                                        aria-label="Download {{title}} as {{fe (concat uri "/" (fn file))}} ({{fs (concat uri "/"  (fn file))}})"
                                     >
                                         {{title}}</a> ({{fs (concat uri "/"  (fn file))}} {{fe (concat uri "/" (fn file))}})
                                 </li>


### PR DESCRIPTION
### What
Fix download link context for user requested download page.

### How to review
1. Visit a user requested download page
1. See that the links provide no context in screen reader rotor
1. Switch to this branch and restart babbage
1. See that the link contains information about the action and file information

### Who can review
Anyone but me
