### PR TITLE
Fix issue where title not showing in label on timeseries page

### DIFF
--- a/src/main/web/templates/handlebars/content/t5-1.handlebars
+++ b/src/main/web/templates/handlebars/content/t5-1.handlebars
@@ -62,25 +62,25 @@
                                 <div id="unfiltered-download-controls" class="chart-area__controls__download chart-area__controls__download--unfiltered width--22 padding-top--2 padding-bottom--2" aria-hidden="false">
                                         <div class="chart-area__controls__custom__container">
                                                 <p class="flush">{{labels.download-full-time-series-as}}:</p>
-                                                <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary" download="{{description.title}}" aria-title="Download {{title}} as an {{labels.image}}">{{labels.image}}</a>
-                                                <a class="btn btn--primary" title="Download as csv" data-gtm-download-file="{{uri}}" data-gtm-download-type="csv" href="/generator?format=csv&uri={{uri}}" aria-title="Download {{title}} as csv">.csv</a>
-                                                <a class="btn btn--primary" title="Download as xls" data-gtm-download-file="{{uri}}" data-gtm-download-type="xls" href="/generator?format=xls&uri={{uri}}" aria-title="Download {{title}} as xls">.xls</a>
+                                                <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary" download="{{description.title}}" aria-label="Download {{description.title}} as an {{labels.image}}">{{labels.image}}</a>
+                                                <a class="btn btn--primary" title="Download as csv" data-gtm-download-file="{{uri}}" data-gtm-download-type="csv" href="/generator?format=csv&uri={{uri}}" aria-label="Download {{description.title}} as csv">.csv</a>
+                                                <a class="btn btn--primary" title="Download as xls" data-gtm-download-file="{{uri}}" data-gtm-download-type="xls" href="/generator?format=xls&uri={{uri}}" aria-label="Download {{description.title}} as xls">.xls</a>
                                         </div>
                                 </div>
                                 {{!-- Filtered - parameters added dynamically--}}
                                 <div id="filtered-download-controls" class="chart-area__controls__download chart-area__controls__download--filtered width--22 padding-top--2 padding-bottom--2" aria-hidden="true">
                                         <div class="chart-area__controls__custom__container">
                                                 <p class="flush"> {{labels.download-filtered-time-series-as}}:</p>
-                                                <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary dlCustomData"  download="{{description.title}}" aria-title="Download {{title}} as an {{labels.image}}">{{labels.image}}</a>
-                                                <a class="btn btn--primary dlCustomData" title="Download as csv" data-gtm-download-file="{{uri}}" data-gtm-download-type="csv" href="/generator?format=csv&uri={{uri}}" aria-title="Download {{title}} as csv">.csv</a>
-                                                <a class="btn btn--primary dlCustomData" title="Download as xls" data-gtm-download-file="{{uri}}" data-gtm-download-type="xls" href="/generator?format=xls&uri={{uri}}" aria-title="Download {{title}} as xls">.xls</a>
+                                                <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary dlCustomData"  download="{{description.title}}" aria-label="Download {{description.title}} as an {{labels.image}}">{{labels.image}}</a>
+                                                <a class="btn btn--primary dlCustomData" title="Download as csv" data-gtm-download-file="{{uri}}" data-gtm-download-type="csv" href="/generator?format=csv&uri={{uri}}" aria-label="Download {{description.title}} as csv">.csv</a>
+                                                <a class="btn btn--primary dlCustomData" title="Download as xls" data-gtm-download-file="{{uri}}" data-gtm-download-type="xls" href="/generator?format=xls&uri={{uri}}" aria-label="Download {{description.title}} as xls">.xls</a>
                                         </div>
                                 </div>
                         </div>
                         </form>
                         {{!-- Show no-JS download options --}}
                         <div class="js--hide">
-                                <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary" aria-title="Download {{title}} as an image">image</a>
+                                <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary" aria-label="Download {{title}} as an image">image</a>
                                 {{> partials/highcharts/download format='csv'}}
                                 {{> partials/highcharts/download format='xls'}}
                         </div>


### PR DESCRIPTION
### What
Label not being shown because it was using `aria-title`.

### How to review
1. Visit a timeseries page
1. See that the download links in the rotor say `xls`, `image` etc
1. Switch to this branch
1. See that they correctly now say `Download title as xls` etc.

### Who can review
Anyone but me
