### PR TITLE
Fix/search tabs

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/search/helpers/ONSSearchResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/search/helpers/ONSSearchResponse.java
@@ -115,6 +115,7 @@ public class    ONSSearchResponse {
         }
 
         ArrayList<Map<String, Object>> nestedObjects = new ArrayList<>();
+        Object label = null;
         for (Map.Entry<String, Object> sourceEntry : source.entrySet()) {
             Object field = sourceEntry.getValue();
             if (saveIfNested(nestedObjects, field)) {
@@ -124,12 +125,19 @@ public class    ONSSearchResponse {
                     saveIfNested(nestedObjects, o);
                 }
             }
+            if (sourceEntry.getKey() == "title") {
+                label = field;
+            }
             HighlightField highlightedField = highlightedFields.remove(getFieldName(sourceEntry.getKey()));
             if (highlightedField == null) {//not found
                 continue;
             } else {
                 overlay(sourceEntry, field, highlightedField);
             }
+        }
+
+        if (label != null) {
+            source.put("label", label);
         }
 
         for (Map<String, Object> nestedObject : nestedObjects) {
@@ -176,5 +184,4 @@ public class    ONSSearchResponse {
             return fieldKey;
         }
     }
-
 }

--- a/src/main/web/templates/handlebars/list/base/list.handlebars
+++ b/src/main/web/templates/handlebars/list/base/list.handlebars
@@ -69,7 +69,7 @@
 			</form>
 				
 			{{!-- RESULTS --}}
-			<div class="col col--md-34 col--lg-40 margin-left-md--1">
+			<section class="col col--md-34 col--lg-40 margin-left-md--1" aria-label="Search results">
 
 				<div id="results" class="results">
 
@@ -98,7 +98,7 @@
                     <div class="col col--md-22 col--lg-28">{{> list/partials/paginator paginator=result.paginator }}</div>
                     <div class="col col--md-12 col--lg-12 margin-top-md--2 padding-left--1">{{> list/filters/size }}</div>
                 </form>
-			</div>
+			</section>
 		</div>
 	</div>
 {{/partial}}

--- a/src/main/web/templates/handlebars/list/partials/results-title.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/results-title.handlebars
@@ -1,6 +1,6 @@
 <h3 class="search-results__title">
     <a href="/redir/{{ sign_url uri parameters.query.0 parameters.q.0 result.paginator.currentPage @index_1 listType parameters.size.0 }}" data-gtm-uri="{{ uri }}"
-       aria-label="{{{description.label}}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}">
+       aria-label="{{#if description.label}}{{{description.label}}}{{else}}{{{description.title}}}{{/if}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}">
         {{{description.title}}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}
     </a>
 </h3>

--- a/src/main/web/templates/handlebars/list/partials/results-title.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/results-title.handlebars
@@ -1,6 +1,6 @@
 <h3 class="search-results__title">
     <a href="/redir/{{ sign_url uri parameters.query.0 parameters.q.0 result.paginator.currentPage @index_1 listType parameters.size.0 }}" data-gtm-uri="{{ uri }}"
        aria-label="{{#if description.label}}{{{description.label}}}{{else}}{{{description.title}}}{{/if}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}">
-        {{{description.title}}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}
+        <span role="text">{{{description.title}}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}</span>
     </a>
 </h3>

--- a/src/main/web/templates/handlebars/list/partials/results-title.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/results-title.handlebars
@@ -1,3 +1,6 @@
 <h3 class="search-results__title">
-        <a href="/redir/{{ sign_url uri parameters.query.0 parameters.q.0 result.paginator.currentPage @index_1 listType parameters.size.0 }}" data-gtm-uri="{{ uri }}">{{{description.title}}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}</a>
+    <a href="/redir/{{ sign_url uri parameters.query.0 parameters.q.0 result.paginator.currentPage @index_1 listType parameters.size.0 }}" data-gtm-uri="{{ uri }}"
+       aria-label="{{{description.label}}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}">
+        {{{description.title}}}{{#if_all description.edition showEdition}}{{#if_all (ne description.edition 'yes') (ne description.edition '<strong>yes</strong>')}}: {{{description.edition}}}{{/if_all}}{{/if_all}} {{#if description.latestRelease}}({{labels.latest-release}}){{/if}}
+    </a>
 </h3>

--- a/src/main/web/templates/handlebars/list/partials/tab-item.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/tab-item.handlebars
@@ -2,7 +2,7 @@
     {{#if active}}
         <a href="{{href}}?{{#if parameters.q}}q={{parameters.q.0}}{{else}}query={{parameters.query.0}}{{/if}}"
                 aria-current="page" aria-label="{{name}} ({{nf count alt=0}}). Current page.">
-            <span class="tab__link tab__link--active" aria-label="Current page">{{name}} ({{nf count alt=0}})</span>
+            <span class="tab__link tab__link--active">{{name}} ({{nf count alt=0}})</span>
         </a>
     {{else}}
         <a href="{{href}}?{{#if parameters.q}}q={{parameters.q.0}}{{else}}query={{parameters.query.0}}{{/if}}" class="tab__link"

--- a/src/main/web/templates/handlebars/list/partials/tab-item.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/tab-item.handlebars
@@ -1,8 +1,12 @@
 <li class="tab__item width-sm--6">
     {{#if active}}
-        <span class="tab__link tab__link--active">{{name}} ({{nf count alt=0}})</span>
+        <a href="/search?{{href}}?{{#if parameters.q}}q={{parameters.q.0}}{{else}}query={{parameters.query.0}}{{/if}}"
+                aria-current="page" aria-label="{{name}} ({{nf count alt=0}}). Current page.">
+            <span class="tab__link tab__link--active" aria-label="Current page">{{name}} ({{nf count alt=0}})</span>
+        </a>
     {{else}}
-        <a href="{{href}}?{{#if parameters.q}}q={{parameters.q.0}}{{else}}query={{parameters.query.0}}{{/if}}" class="tab__link">
+        <a href="{{href}}?{{#if parameters.q}}q={{parameters.q.0}}{{else}}query={{parameters.query.0}}{{/if}}" class="tab__link"
+                aria-label="Search '{{name}}' results for '{{#if parameters.q}}{{parameters.q.0}}{{else}}{{parameters.query.0}}{{/if}}' ({{nf count alt=0}} results)">
             {{name}} ({{nf count alt=0}})
         </a>
     {{/if}}

--- a/src/main/web/templates/handlebars/list/partials/tab-item.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/tab-item.handlebars
@@ -1,6 +1,6 @@
 <li class="tab__item width-sm--6">
     {{#if active}}
-        <a href="/search?{{href}}?{{#if parameters.q}}q={{parameters.q.0}}{{else}}query={{parameters.query.0}}{{/if}}"
+        <a href="{{href}}?{{#if parameters.q}}q={{parameters.q.0}}{{else}}query={{parameters.query.0}}{{/if}}"
                 aria-current="page" aria-label="{{name}} ({{nf count alt=0}}). Current page.">
             <span class="tab__link tab__link--active" aria-label="Current page">{{name}} ({{nf count alt=0}})</span>
         </a>

--- a/src/main/web/templates/handlebars/list/partials/tab-item.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/tab-item.handlebars
@@ -1,8 +1,8 @@
 <li class="tab__item width-sm--6">
     {{#if active}}
         <a href="{{href}}?{{#if parameters.q}}q={{parameters.q.0}}{{else}}query={{parameters.query.0}}{{/if}}"
-                aria-current="page" aria-label="{{name}} ({{nf count alt=0}}). Current page.">
-            <span class="tab__link tab__link--active">{{name}} ({{nf count alt=0}})</span>
+          class="tab__link tab__link--active" aria-current="page" aria-label="{{name}} ({{nf count alt=0}}). Current page.">
+            {{name}} ({{nf count alt=0}})
         </a>
     {{else}}
         <a href="{{href}}?{{#if parameters.q}}q={{parameters.q.0}}{{else}}query={{parameters.query.0}}{{/if}}" class="tab__link"

--- a/src/main/web/templates/handlebars/list/partials/tabs.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/tabs.handlebars
@@ -1,4 +1,4 @@
-<nav class="tabs--js">
+<nav class="tabs--js" aria-label="Search types">
 	<ul class="list--neutral flush">
 		{{#block "block-list-tabs"}}{{/block}}
 	</ul>

--- a/src/main/web/templates/handlebars/list/t11.handlebars
+++ b/src/main/web/templates/handlebars/list/t11.handlebars
@@ -7,16 +7,20 @@
 {{#partial "block-list-tabs"}}
 	<li class="tab__item">
         {{#unless parameters.view.0}}
-            <span class="tab__link tab__link--active">Published releases</span>
+            <a href="/releasecalendar{{#if parameters.query.0}}?query={{parameters.query.0}}{{/if}}" aria-current="page" aria-label="Published releases. Current page.">
+                <span class="tab__link tab__link--active" aria-label="Current page">Published releases</span>
+            </a>
         {{else}}
-		    <a href="/releasecalendar{{#if parameters.query.0}}?query={{parameters.query.0}}{{/if}}" class="tab__link">Published releases</a>
+            <a href="/releasecalendar{{#if parameters.query.0}}?query={{parameters.query.0}}{{/if}}" class="tab__link" aria-label="Search for Published releases">Published releases</a>
         {{/unless}}
 	</li>
 	<li class="tab__item">
         {{#if_eq parameters.view.0 "upcoming"}}
-            <span class="tab__link tab__link--active">Upcoming releases</span>
+            <a href="/releasecalendar?view=upcoming{{#if parameters.query.0}}&query={{parameters.query.0}}{{/if}}" aria-current="page" aria-label="Upcoming releases. Current page.">
+                <span class="tab__link tab__link--active" aria-label="Current page">Upcoming releases</span>
+            </a>
         {{else}}
-		    <a href="/releasecalendar?view=upcoming{{#if parameters.query.0}}&query={{parameters.query.0}}{{/if}}" class="tab__link">Upcoming releases</a>
+            <a href="/releasecalendar?view=upcoming{{#if parameters.query.0}}&query={{parameters.query.0}}{{/if}}" class="tab__link" aria-label="Search for Upcoming releases">Upcoming releases</a>
         {{/if_eq}}
 	</li>
 {{/partial}}

--- a/src/main/web/templates/handlebars/list/t9-8.handlebars
+++ b/src/main/web/templates/handlebars/list/t9-8.handlebars
@@ -6,14 +6,16 @@
 
 {{#partial "block-list-tabs"}}
 	<li class="tab__item">
-		<a href="datalist{{#if parameters.query.0}}?query={{parameters.query.0}}{{/if}}" class="tab__link">
-			Data  {{!-- ({{nf (add counts.docCounts.timeseries counts.docCounts.dataset_landing_page counts.docCounts.reference_tables counts.docCounts.static_adhoc) alt=0}}) --}}
-		</a>
+        <a href="datalist{{#if parameters.query.0}}?query={{parameters.query.0}}{{/if}}" class="tab__link" aria-label="Search results for Data">
+            Data  {{!-- ({{nf (add counts.docCounts.timeseries counts.docCounts.dataset_landing_page counts.docCounts.reference_tables counts.docCounts.static_adhoc) alt=0}}) --}}
+        </a>
 	</li>
 	<li class="tab__item">
-		<span class="tab__link tab__link--active">
-			Publications {{!-- ({{nf (add counts.docCounts.bulletin counts.docCounts.article counts.docCounts.article_download counts.docCounts.compendium_landing_page) alt=0}}) --}}
-		</span>
+        <a href="publications{{#if parameters.query.0}}?query={{parameters.query.0}}{{/if}}" aria-current="page" aria-label="Publication results. Current page.">
+            <span class="tab__link tab__link--active" aria-label="Current page">
+                Publications {{!-- ({{nf (add counts.docCounts.bulletin counts.docCounts.article counts.docCounts.article_download counts.docCounts.compendium_landing_page) alt=0}}) --}}
+            </span>
+        </a>
 	</li>
 {{/partial}}
 

--- a/src/main/web/templates/handlebars/list/t9-9.handlebars
+++ b/src/main/web/templates/handlebars/list/t9-9.handlebars
@@ -6,14 +6,16 @@
 
 {{#partial "block-list-tabs"}}
 	<li class="tab__item">
-		<span class="tab__link tab__link--active">
-			Data {{!-- ({{nf (add counts.docCounts.timeseries counts.docCounts.dataset_landing_page counts.docCounts.reference_tables counts.docCounts.static_adhoc) alt=0}}) --}}
-		</span>
+        <a href="datalist{{#if parameters.query.0}}?query={{parameters.query.0}}{{/if}}" aria-current="page" aria-label="Data results. Current page.">
+            <span class="tab__link tab__link--active" aria-label="Current page">
+                Data {{!-- ({{nf (add counts.docCounts.timeseries counts.docCounts.dataset_landing_page counts.docCounts.reference_tables counts.docCounts.static_adhoc) alt=0}}) --}}
+            </span>
+        </a>
 	</li>
 	<li class="tab__item">
-		<a href="publications{{#if parameters.query.0}}?query={{parameters.query.0}}{{/if}}" class="tab__link">
-			Publications {{!-- ({{nf (add counts.docCounts.bulletin counts.docCounts.article counts.docCounts.article_download counts.docCounts.compendium_landing_page) alt=0}}) --}}
-		</a>
+        <a href="publications{{#if parameters.query.0}}?query={{parameters.query.0}}{{/if}}" class="tab__link" aria-label="Search results for Publications">
+            Publications {{!-- ({{nf (add counts.docCounts.bulletin counts.docCounts.article counts.docCounts.article_download counts.docCounts.compendium_landing_page) alt=0}}) --}}
+        </a>
 	</li>
 {{/partial}}
 


### PR DESCRIPTION
### What

Updated how the tabs and results on the search page are structured to work better with screen readers.

### How to review

- Using a screen reader.
- Enter a search in the nav bar.
- On the search results page, move focus to each of the navigation tabs (All Results, Data, Publications). The screen reader should announce the subset of results, the number of results on that tab and the current page should be announced as such.
- Now move focus to a search result title, the screen reader announce the title of the result with correct spacing between the words.

### Who can review

Anyone but me.
