### PR TITLE
update datasets heading structure

### DIFF
--- a/src/main/web/templates/handlebars/partials/t3/dataset-list.handlebars
+++ b/src/main/web/templates/handlebars/partials/t3/dataset-list.handlebars
@@ -5,11 +5,11 @@
         {{#loop this limit=6}}
         <li class="background--gallery flush-col padding-top--2 padding-bottom--4 padding-left--1 js-hover-click">
             <div class="box__content">
-                <h4>
+                <h3 class="font-size--h4">
                     <a class="underline-link" href="{{uri}}">
                         {{title}}
                     </a>
-                </h4>
+                </h3>
                 <p class="flush">{{summary}}</p>
             </div>
         {{/loop}}


### PR DESCRIPTION
### What

Updated the heading levels of the datasets on the product page to make them semantically correct.

### How to review

- Go to a product page
- See that the title of each of the time series items is an h4.
- Checkout this branch
- See that the titles are now h3 tags, but with the same styling.

### Who can review

Anyone but me