### PR TITLE
Black/Whitelist added to datalayer and data-gtm-checkbox attribute

### DIFF
--- a/src/main/web/templates/handlebars/list/t13.handlebars
+++ b/src/main/web/templates/handlebars/list/t13.handlebars
@@ -82,7 +82,7 @@
 
 			{{!-- Checkbox --}}
 			<div class="input__wrapper col col--md-3 col--lg-3 margin-left-md--1 padding-left-md--1 padding-bottom-sm" >
-				<input type="checkbox" name="" data-title="{{description.title}}" data-cdid="{{description.cdid}}" data-datasetId="{{description.datasetId}}" data-uri="{{uri}}" value="" class="timeseries__select js-timeseriestool-select js--show" aria-label="{{description.title}}">
+				<input type="checkbox" name="" data-title="{{description.title}}" data-gtm-checkbox="{{description.title}}" data-cdid="{{description.cdid}}" data-datasetId="{{description.datasetId}}" data-uri="{{uri}}" value="" class="timeseries__select js-timeseriestool-select js--show" aria-label="{{description.title}}">
 			</div>
 			{{!-- Title --}}
 			<div class="col col--md-21 col--lg-25 padding-right-md--1">

--- a/src/main/web/templates/handlebars/partials/gtm-data-layer.handlebars
+++ b/src/main/web/templates/handlebars/partials/gtm-data-layer.handlebars
@@ -21,7 +21,9 @@
     {{!-- Add title to dataLayer. Dont include the edition on dataset versions pages --}}
     var dataLayer = [{
         contentTitle: htmlUnescape("{{> partials/page-title}}{{#if description.edition}}{{#if_ne description.edition "Current"}}: {{description.edition}}{{/if_ne}}{{/if}}"),
-        analyticsOptOut: getUsageCookieValue()
+        analyticsOptOut: getUsageCookieValue(),
+        "gtm.whitelist": ["google","hjtc","lcl"],
+        "gtm.blacklist": ["customScripts","sp","adm","awct","k","d","j"]
     }];
 
     {{#if description.releaseDate}}


### PR DESCRIPTION
### What

Implemented the black/whitelist for the GTM datalayer - further details listed as per ticket instructions. Also implemented a `data-gtm-checkbox` attribute to the search results checkbox (where applicable)

### How to review

Check the changes make sense and align with requirements.

You can go to a search results page e.g. `/timeseriestool` and see in the browser that a search result's checkbox has the new `data-gtm-checkbox` attribute

### Who can review

Anyone
