### PR TITLE
Fix - Reflow - Overflow scrollable with shadows

### DIFF
--- a/src/main/web/js/app/markdown-chart.js
+++ b/src/main/web/js/app/markdown-chart.js
@@ -18,12 +18,8 @@ $(function() {
     //set the annotation and chart size based on the viewport
     if ($("body").hasClass("viewport-sm")) {
         viewport = 'sm';
-        nominalWidth = 360;
-        smallWidth = 300
     }else if ($("body").hasClass("viewport-md")) {
         viewport = 'md';
-        nominalWidth = 520;
-        smallWidth = 250
     }else  {
         viewport = 'lg';
     }

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -22,14 +22,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/6b0bc76{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/6b0bc76{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/6b0bc76{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/6b0bc76{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
         {{> partials/gtm-data-layer }}
@@ -141,7 +141,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/6b0bc76{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/highcharts/chart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/chart.handlebars
@@ -61,10 +61,12 @@
             <h5 class="flush--third--bottom">{{{sub (sup subtitle)}}}</h5>
         {{/if}}
 
-      <div id="chart-{{filename}}" data-filename="{{filename}}" data-uri="{{uri}}" class="markdown-chart">
-          <!--[if gt IE 8]><!--><noscript><!--[endif]-->
-          <img src="/chartimage?uri={{uri}}&width={{width}}&hideSource=true" alt="{{alt-text}}" />
-          <!--[if gt IE 8]><!--></noscript><!--[endif]-->
+      <div class="scrollable-container">
+        <div id="chart-{{filename}}" data-filename="{{filename}}" data-uri="{{uri}}" class="markdown-chart">
+            <!--[if gt IE 8]><!--><noscript><!--[endif]-->
+            <img src="/chartimage?uri={{uri}}&width={{width}}&hideSource=true" alt="{{alt-text}}" />
+            <!--[if gt IE 8]><!--></noscript><!--[endif]-->
+        </div>
       </div>
   
   {{/if_eq}}

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,7 +51,7 @@ The commented code below is what needs to go in the parent.
     {{/if}}
   {{/if}}
 
-  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/6b0bc76{{/if}}/js/main.js"></script>
+  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/js/main.js"></script>
   <script type="text/javascript" src="/js/app.js"></script>
 
   <script type="text/javascript" src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What
Use scrollable overflows with shadows for charts so that the users aren't forced to scroll horizontally on small and medium viewports.

### How to review
1. Visit an article or bulletin with a chart
1. At small and medium viewport sizes see that they need to scroll horizontally
1. Switch to this branch and checkout sixteens branch `fix/overflow-container`
1. See that there is now a scroll bar and shadows that appear showing that there is more content.

### Who can review
Anyone but me