### PR TITLE
Fix/mobile menu screenreaders

### DIFF
--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -8,6 +8,7 @@ home=Home
 search=Search
 hide=Hide
 menu=Menu
+sub-menu=sub menu
 taking-part-in-a-survey=Taking part in a survey?
 find-official-statistics-produced-by-other-governmnet-departments=Find official statistics produced by other government departments
 search-for-a-keyword-or-time-series-id=Search for a keyword(s) or time series ID

--- a/src/main/resources/LabelsBundle_cy.properties
+++ b/src/main/resources/LabelsBundle_cy.properties
@@ -9,6 +9,7 @@ home=Hafan
 search=Chwilio
 hide=Cuddio
 menu=Dewislen
+sub-menu=is-dewislen
 taking-part-in-a-survey=Cymryd rhan mewn arolwg?
 find-official-statistics-produced-by-other-governmnet-departments=Dod o hyd i ystadegau swyddogol gan adrannau eraill y llywodraeth
 search-for-a-keyword-or-time-series-id=Chwilio am allweddair neu ID cyfres amser

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -22,14 +22,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e21a0d8{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e21a0d8{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e21a0d8{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e21a0d8{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
         {{> partials/gtm-data-layer }}
@@ -141,7 +141,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e21a0d8{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -87,8 +87,13 @@
 					{{#each navigation}}
 					{{#if_eq this.type "taxonomy_landing_page"}}
 					<li class="primary-nav__item js-nav js-expandable {{#if_any (eq uri breadcrumb.1/uri)  (eq uri ../uri) }}primary-nav__item--active{{/if_any}}">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="{{uri}}" aria-haspopup="true">{{description.title}}</a>
-						<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
+                        <a class="primary-nav__link col col--md-8 col--lg-10" href="{{uri}}" aria-expanded="false" aria-label="{{description.title}} sub menu">
+                            <span aria-hidden="true" class="expansion-indicator"></span>
+                            <span aria-label="{{description.title}} sub menu" role="text" class="submenu-title">
+                                {{description.title}}
+                            </span>
+                        </a>
+                        <ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
 							{{!-- loop each child node --}}
 							{{#each children}}
 							<li class="primary-nav__child-item {{#if_any (eq uri breadcrumb.2/uri) (eq uri ../../uri)}}primary-nav__child-item--active{{/if_any}} js-expandable__child">

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -87,9 +87,9 @@
 					{{#each navigation}}
 					{{#if_eq this.type "taxonomy_landing_page"}}
 					<li class="primary-nav__item js-nav js-expandable {{#if_any (eq uri breadcrumb.1/uri)  (eq uri ../uri) }}primary-nav__item--active{{/if_any}}">
-                        <a class="primary-nav__link col col--md-8 col--lg-10" href="{{uri}}" aria-expanded="false" aria-label="{{description.title}} sub menu">
+                        <a class="primary-nav__link col col--md-8 col--lg-10" href="{{uri}}" aria-expanded="false" aria-label="{{description.title}} {{labels.sub-menu}}">
                             <span aria-hidden="true" class="expansion-indicator"></span>
-                            <span aria-label="{{description.title}} sub menu" role="text" class="submenu-title">
+                            <span aria-label="{{description.title}} {{labels.sub-menu}}" role="text" class="submenu-title">
                                 {{description.title}}
                             </span>
                         </a>

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,7 +51,7 @@ The commented code below is what needs to go in the parent.
     {{/if}}
   {{/if}}
 
-  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e2e787a{{/if}}/js/main.js"></script>
+  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/e21a0d8{{/if}}/js/main.js"></script>
   <script type="text/javascript" src="/js/app.js"></script>
 
   <script type="text/javascript" src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What

Screen readers (particularly on mobile) were picking up the '+' as a separate link. Added a slightly hacky patch to improve this until the new nav is implemented

### How to review

(Main focus is on iPhone voiceover)
(Requires the PR from sixteens to work correctly ONSdigital/sixteens#222)

- Using a screen reader on a mobile device.
- Go to any page and open the menu.
- Navigate to the first expansion toggle in the menu.
- You should not be able to navigate to the '+'.
- The screen reader should announce the name of the sub menu followed by 'sub menu toggle' and that it is collapsed.
- Expand the sub menu and the screen reader should announce the sub menu is now expanded.
- Navigate to the first item in the sub menu, the screen reader should announce the title of the menu item only.

### Who can review

Anyone but me.
