### PR TITLE
Fix - Missing file sizes

### DIFF
--- a/src/main/web/templates/handlebars/partials/image.handlebars
+++ b/src/main/web/templates/handlebars/partials/image.handlebars
@@ -23,7 +23,7 @@
             {{#if (eq type "uploaded-image")}}
                 <a class="btn btn--primary print--hide" title="Download as {{fileType}}"
                    data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-{{fileType}}"
-                   href="/file?uri={{uri}}.{{fileType}}" aria-label="Download {{title}} as {{fileType}}">.{{fileType}}</a>
+                   href="/file?uri={{uri}}.{{fileType}}" aria-label="Download {{title}} as {{fileType}} ({{fs(concat uri "." fileType)}})">.{{fileType}} ({{fs(concat uri "." fileType)}})</a>
             {{/if}}
         {{/each}}
 
@@ -31,7 +31,7 @@
             {{#if (eq type "uploaded-data")}}
                 <a class="btn btn--primary print--hide" title="Download as {{fileType}}"
                    data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-{{fileType}}"
-                   href="/file?uri={{uri}}.{{fileType}}" aria-label="Download {{title}} as {{fileType}}">.{{fileType}}
+                   href="/file?uri={{uri}}.{{fileType}}" aria-label="Download {{title}} as ({{fs(concat uri "." fileType)}})">.{{fileType}} ({{fs(concat uri "." fileType)}})
                 </a>
             {{/if}}
         {{/each}}

--- a/src/main/web/templates/handlebars/partials/related/downloads.handlebars
+++ b/src/main/web/templates/handlebars/partials/related/downloads.handlebars
@@ -7,7 +7,8 @@
                     <li>
                         <a data-gtm-title="{{title}}"
                            data-gtm-type="related-download"
-                           href="/file?uri={{absolute (concat uri "/" file)}}">{{title}}</a>
+                           aria-label="Download {{title}} as {{fe(concat uri "/" file)}} ({{fs(concat uri "/" file)}})"
+                           href="/file?uri={{absolute (concat uri "/" file)}}">{{title}} ({{fs(concat uri "/" file)}} {{fe(concat uri "/" file)}})</a>
                     </li>
                 {{/each}}
             </ul>

--- a/src/main/web/templates/handlebars/partials/table.handlebars
+++ b/src/main/web/templates/handlebars/partials/table.handlebars
@@ -9,5 +9,5 @@
         </div>
     {{/resolveResource}}
     <h4 class="print--hide font-size--h6 margin-top--1 padding-top--0"><span role="text">Download this table <span class="visuallyhidden">{{title}}</span></span></h4>
-    <a href="/file?uri={{uri}}.xls" title="Download as xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xls" aria-label="Download table {{title}} as xls">.xls</a>
+    <a href="/file?uri={{uri}}.xls" title="Download as xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xls" aria-label="Download table {{title}} as xls ({{fs(concat uri ".xls")}})">.xls ({{fs(concat uri ".xls")}})</a>
 </div>


### PR DESCRIPTION
### What
Add download sizes where we already have the files.

### How to review
1. Visit either a static article page (with downloads), an article with a v1 table or `ons-image`.
1. See that the download size is not included in the link text
1. Switch to this branch
1. See that it is now included

### Who can review
Anyone but me.
