### PR TITLE
static page accessibility fixes

### DIFF
--- a/src/main/web/templates/handlebars/partials/breadcrumb.handlebars
+++ b/src/main/web/templates/handlebars/partials/breadcrumb.handlebars
@@ -1,4 +1,4 @@
-<nav>
+<nav aria-label="Breadcrumbs">
     <div class="breadcrumb print--hide">
         <ol class="breadcrumb__list">
             {{#each breadcrumb}}

--- a/src/main/web/templates/handlebars/partials/footer.handlebars
+++ b/src/main/web/templates/handlebars/partials/footer.handlebars
@@ -2,7 +2,7 @@
 	<h2 class="visuallyhidden">Footer links</h2>
 	<div class="footer">
 		<div class="wrapper">
-			<nav>
+			<nav aria-label="Footer links">
                 <div class="footer-nav col-wrap">
                     <div class="col col--lg-one-third col--md-one-third">
                         <h3 class="footer-nav__heading">{{labels.help}}</h3>

--- a/src/main/web/templates/handlebars/partials/related/related-links.handlebars
+++ b/src/main/web/templates/handlebars/partials/related/related-links.handlebars
@@ -1,8 +1,8 @@
 {{#if links}}
 	<div class="tiles__item tiles__item--nav-type flush-col">
-		<h3 class="tiles__title-h3 tiles__title-h3--nav">
+		<h2 class="font-size--21 tiles__title-h3 tiles__title-h3--nav">
 			{{labels.you-might-also-be-interested-in}}:
-		</h3>
+		</h2>
 		<div class="tiles__content--nav">
 			<ul class="list--neutral">
 				{{#each links}}


### PR DESCRIPTION
### What

Fixes for aspects of the static pages after auditing with Axe and Wave

- Changed Related Links heading from `h3` to `h2` to ensure correct heading levels and set the font size using a utility class instead (can be checked on a `static_landing_page` type)
- Added `aria-label` attributes to the `nav` elements in the breadcrumb and footer. This ensures they are unique landmarks

### How to review

Ensure changes as described have been made

### Who can review

Anyone