### PR TITLE
Fix - Timeseries filters accessibility

### DIFF
--- a/src/main/web/js/app/linechart.js
+++ b/src/main/web/js/app/linechart.js
@@ -60,18 +60,24 @@ $(function () {
             });
 
             $button.on('keydown', function (e) {
-                e.preventDefault();
-                e.stopPropagation();
                 if (e.keyCode === KEYS.right) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     switchActiveTab(currentIndex + 1);
                 }
                 else if (e.keyCode === KEYS.left) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     switchActiveTab(currentIndex - 1);
                 }
                 else if (e.keyCode === KEYS.home) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     switchActiveTab(0)
                 }
                 else if (e.keyCode === KEYS.end) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     switchActiveTab(tabs.length - 1);
                 }
             });

--- a/src/main/web/js/app/linechart.js
+++ b/src/main/web/js/app/linechart.js
@@ -18,60 +18,65 @@ $(function () {
     }
 
     var ACTIVE_BUTTON_CLASS="btn--secondary-active";
+    var KEYS = {
+        end: 35,
+        home: 36,
+        left: 37,
+        right: 39,
+      };
 
     $('.js--linechart-filter-tabs').each(function(_, wrapper) {
         var $wrapper = $(wrapper);
+        var tabs = [];
+
+        function switchActiveTab(index) {
+            var clampedIndex = Math.abs(index % tabs.length);
+            var tab = tabs[clampedIndex];
+
+            $wrapper.find('.' + ACTIVE_BUTTON_CLASS)
+                .removeClass(ACTIVE_BUTTON_CLASS)
+                .attr('tabindex', '-1')
+                .attr('aria-selected', 'false');
+
+            tab.$button.addClass(ACTIVE_BUTTON_CLASS)
+                .removeAttr('tabindex')
+                .attr('aria-selected', 'true')
+                .focus();
+
+            $wrapper.find('[role="tabpanel"]').attr('hidden', '');
+            tab.$panel.removeAttr('hidden');
+        }
+
         $wrapper.find('[role="tablist"] button').each(function(_, button) {
             var $button = $(button);
             var $panel = $wrapper.find('#' + $button.attr('aria-controls'));
 
+            var currentIndex = tabs.length;
+            tabs.push({ $button: $button, $panel: $panel });
+
             $button.on('click', function (e) {
                 e.preventDefault();
-                $wrapper.find('.' + ACTIVE_BUTTON_CLASS)
-                    .removeClass(ACTIVE_BUTTON_CLASS)
-                    .attr('tabindex', -1);
+                switchActiveTab(currentIndex);
+            });
 
-                $button.addClass(ACTIVE_BUTTON_CLASS);
-                $button.removeAttr('tabindex');
-
-                $wrapper.find('[role="tabpanel"]').attr('hidden', '');
-                $panel.removeAttr('hidden');
+            $button.on('keydown', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                if (e.keyCode === KEYS.right) {
+                    switchActiveTab(currentIndex + 1);
+                }
+                else if (e.keyCode === KEYS.left) {
+                    switchActiveTab(currentIndex - 1);
+                }
+                else if (e.keyCode === KEYS.home) {
+                    switchActiveTab(0)
+                }
+                else if (e.keyCode === KEYS.end) {
+                    switchActiveTab(tabs.length - 1);
+                }
             });
         });
     });
-
-    // Add accessibility enhancements to linechart controls
-    // $('.btn--chart-control--download').on("keyup mouseup", function () {
-    //     var $activeButton = $(this), // button clicked
-    //         $activeControl = $('#' + $activeButton.find('input').attr('id') + '-controls'), //control (button) block related to clicked button
-    //         $activeInput = $activeButton.find('input'),
-    //         $buttons = $('.btn--chart-control--download'),
-    //         $controls = $('.chart-area__controls__download');
-
-    //     // remove active class from all buttons
-    //     $buttons.each(function () {
-    //         var $input = $(this).find('input');
-    //         if ($input.attr('aria-expanded') == 'true') {
-    //             $input.attr('aria-expanded', 'false');
-    //             $input.prop('checked', false);
-    //         }
-    //     });
-    //     $buttons.removeClass('btn--secondary-active');
-
-    //     // set all controls to hidden
-    //     $controls.each(function () {
-    //         if ($(this).attr('aria-hidden') == 'false') {
-    //             $(this).attr('aria-hidden', 'true');
-    //         }
-    //     });
-
-    //     // set active class on clicked button and unhide correct controls (button) block
-    //     $activeButton.addClass('btn--secondary-active');
-    //     $activeInput.attr('aria-expanded', 'true');
-    //     $activeInput.prop('checked', true);
-    //     $activeControl.attr('aria-hidden', 'false');
-    // });
-
 });
 
 var renderLineChart = function (timeseries) {

--- a/src/main/web/js/app/linechart.js
+++ b/src/main/web/js/app/linechart.js
@@ -17,37 +17,60 @@ $(function () {
         });
     }
 
-    // Add accessibility enhancements to linechart controls
-    $('.btn--chart-control--download').on("keyup mouseup", function () {
-        var $activeButton = $(this), // button clicked
-            $activeControl = $('#' + $activeButton.find('input').attr('id') + '-controls'), //control (button) block related to clicked button
-            $activeInput = $activeButton.find('input'),
-            $buttons = $('.btn--chart-control--download'),
-            $controls = $('.chart-area__controls__download');
+    var ACTIVE_BUTTON_CLASS="btn--secondary-active";
 
-        // remove active class from all buttons
-        $buttons.each(function () {
-            var $input = $(this).find('input');
-            if ($input.attr('aria-expanded') == 'true') {
-                $input.attr('aria-expanded', 'false');
-                $input.prop('checked', false);
-            }
+    $('.js--linechart-filter-tabs').each(function(_, wrapper) {
+        var $wrapper = $(wrapper);
+        $wrapper.find('[role="tablist"] button').each(function(_, button) {
+            var $button = $(button);
+            var $panel = $wrapper.find('#' + $button.attr('aria-controls'));
+
+            $button.on('click', function (e) {
+                e.preventDefault();
+                $wrapper.find('.' + ACTIVE_BUTTON_CLASS)
+                    .removeClass(ACTIVE_BUTTON_CLASS)
+                    .attr('tabindex', -1);
+
+                $button.addClass(ACTIVE_BUTTON_CLASS);
+                $button.removeAttr('tabindex');
+
+                $wrapper.find('[role="tabpanel"]').attr('hidden', '');
+                $panel.removeAttr('hidden');
+            });
         });
-        $buttons.removeClass('btn--secondary-active');
-
-        // set all controls to hidden
-        $controls.each(function () {
-            if ($(this).attr('aria-hidden') == 'false') {
-                $(this).attr('aria-hidden', 'true');
-            }
-        });
-
-        // set active class on clicked button and unhide correct controls (button) block
-        $activeButton.addClass('btn--secondary-active');
-        $activeInput.attr('aria-expanded', 'true');
-        $activeInput.prop('checked', true);
-        $activeControl.attr('aria-hidden', 'false');
     });
+
+    // Add accessibility enhancements to linechart controls
+    // $('.btn--chart-control--download').on("keyup mouseup", function () {
+    //     var $activeButton = $(this), // button clicked
+    //         $activeControl = $('#' + $activeButton.find('input').attr('id') + '-controls'), //control (button) block related to clicked button
+    //         $activeInput = $activeButton.find('input'),
+    //         $buttons = $('.btn--chart-control--download'),
+    //         $controls = $('.chart-area__controls__download');
+
+    //     // remove active class from all buttons
+    //     $buttons.each(function () {
+    //         var $input = $(this).find('input');
+    //         if ($input.attr('aria-expanded') == 'true') {
+    //             $input.attr('aria-expanded', 'false');
+    //             $input.prop('checked', false);
+    //         }
+    //     });
+    //     $buttons.removeClass('btn--secondary-active');
+
+    //     // set all controls to hidden
+    //     $controls.each(function () {
+    //         if ($(this).attr('aria-hidden') == 'false') {
+    //             $(this).attr('aria-hidden', 'true');
+    //         }
+    //     });
+
+    //     // set active class on clicked button and unhide correct controls (button) block
+    //     $activeButton.addClass('btn--secondary-active');
+    //     $activeInput.attr('aria-expanded', 'true');
+    //     $activeInput.prop('checked', true);
+    //     $activeControl.attr('aria-hidden', 'false');
+    // });
 
 });
 

--- a/src/main/web/templates/handlebars/content/t5-1.handlebars
+++ b/src/main/web/templates/handlebars/content/t5-1.handlebars
@@ -42,7 +42,7 @@
                         <h2><span role="text">{{labels.download-this-time-series}}<span class="visuallyhidden">{{description.title}}</span></span></h2>
                         <div class="chart-area__footer__actions">
                             <div class="timeseries__filters nojs--hide js--linechart-filter-tabs">
-                                <div role="tablist" aria-label="{{labels.download-options}}" class="chart-area__radiogroup">
+                                <div role="tablist" aria-label="{{labels.download-options}}" class="chart-area__radiogroup btn-group">
                                     <button 
                                         id="filtered-button" role="tab" aria-selected="true" aria-controls="unfiltered-download-controls"
                                         class="btn btn--secondary btn--chart-control btn--chart-control--download btn--secondary-active">

--- a/src/main/web/templates/handlebars/content/t5-1.handlebars
+++ b/src/main/web/templates/handlebars/content/t5-1.handlebars
@@ -31,62 +31,57 @@
 {{#partial "block-content"}}
 {{!-- Hide chart section if no data to draw the chart with --}}
 {{!-- TODO: Add isdatavailable to timeseries to do this check --}}
+    <div class="wrapper">
     {{#if_any years quarters months}}
-        <div class="wrapper">
             <div class="col-wrap">
                 <div class="col col--lg-one tiles__item margin-top-sm--4 margin-top-md--5 flush-bottom">
-
                     {{> partials/highcharts/linechart}}
 
                     {{!-- Chart footer --}}
                     <div class="tiles__content">
                         <h2><span role="text">{{labels.download-this-time-series}}<span class="visuallyhidden">{{description.title}}</span></span></h2>
                         <div class="chart-area__footer__actions">
-                                                        <form class="timeseries__filters nojs--hide">
-                            <div class="nojs--hide">
-                                <fieldset class="btn-group">
-                                        <legend id="data-download">{{labels.download-options}}</legend>
-                                        <div class="chart-area__radiogroup" role="radiogroup" aria-labelledby="data-download">
-                                                <label for="unfiltered-download" class="btn btn--secondary btn--chart-control btn--chart-control--download btn--secondary-active">
-                                                        {{labels.full-unfiltered-time-series}}
-                                                        <input id="unfiltered-download" type="radio" name="type" data-chart-controls-type="unfiltered-download" aria-controls="unfiltered-download-controls" aria-expanded="true" checked>
-                                                </label>
-                                                <label for="filtered-download" class="btn btn--secondary btn--chart-control btn--chart-control--download">
-                                                        {{labels.filtered-time-series}}
-                                                        <input id="filtered-download" type="radio" name="type" data-chart-controls-type="filtered-download" aria-controls="filtered-download-controls" aria-expanded="false">
-                                                </label>
-                                        </div>
-                                </fieldset>
-
-                                {{!-- Unflitered --}}
-                                <div id="unfiltered-download-controls" class="chart-area__controls__download chart-area__controls__download--unfiltered padding-top--2 padding-bottom--2" aria-hidden="false">
-                                        <div class="chart-area__controls__custom__container">
-                                                <p class="flush">{{labels.download-full-time-series-as}}:</p>
-                                                <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary" download="{{description.title}}" aria-label="Download {{description.title}} as an {{labels.image}}">{{labels.image}}</a>
-                                                <a class="btn btn--primary" title="Download as csv" data-gtm-download-file="{{uri}}" data-gtm-download-type="csv" href="/generator?format=csv&uri={{uri}}" aria-label="Download {{description.title}} as csv">.csv</a>
-                                                <a class="btn btn--primary" title="Download as xls" data-gtm-download-file="{{uri}}" data-gtm-download-type="xls" href="/generator?format=xls&uri={{uri}}" aria-label="Download {{description.title}} as xls">.xls</a>
-                                        </div>
+                            <div class="timeseries__filters nojs--hide js--linechart-filter-tabs">
+                                <div role="tablist" aria-label="{{labels.download-options}}" class="chart-area__radiogroup">
+                                    <button 
+                                        id="filtered-button" role="tab" aria-selected="true" aria-controls="unfiltered-download-controls"
+                                        class="btn btn--secondary btn--chart-control btn--chart-control--download btn--secondary-active">
+                                        {{labels.full-unfiltered-time-series}}
+                                    </button>
+                                    <button 
+                                        id="unfiltered-button" role="tab" aria-selected="false" aria-controls="filtered-download-controls" tabindex="-1"
+                                        class="btn btn--secondary btn--chart-control btn--chart-control--download">
+                                        {{labels.filtered-time-series}}
+                                    </button>
                                 </div>
-                                {{!-- Filtered - parameters added dynamically--}}
-                                <div id="filtered-download-controls" class="chart-area__controls__download chart-area__controls__download--filtered padding-top--2 padding-bottom--2" aria-hidden="true">
-                                        <div class="chart-area__controls__custom__container">
-                                                <p class="flush"> {{labels.download-filtered-time-series-as}}:</p>
-                                                <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary dlCustomData"  download="{{description.title}}" aria-label="Download {{description.title}} as an {{labels.image}}">{{labels.image}}</a>
-                                                <a class="btn btn--primary dlCustomData" title="Download as csv" data-gtm-download-file="{{uri}}" data-gtm-download-type="csv" href="/generator?format=csv&uri={{uri}}" aria-label="Download {{description.title}} as csv">.csv</a>
-                                                <a class="btn btn--primary dlCustomData" title="Download as xls" data-gtm-download-file="{{uri}}" data-gtm-download-type="xls" href="/generator?format=xls&uri={{uri}}" aria-label="Download {{description.title}} as xls">.xls</a>
-                                        </div>
+                                <div tabindex="0" role="tabpanel" aria-labelledby="unfiltered-button" id="unfiltered-download-controls" 
+                                    class="chart-area__controls__download chart-area__controls__download--unfiltered padding-top--2 padding-bottom--2">
+                                    <div class="chart-area__controls__custom__container">
+                                        <p class="flush">{{labels.download-full-time-series-as}}:</p>
+                                        <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary" download="{{description.title}}" aria-label="Download {{description.title}} as an {{labels.image}}">{{labels.image}}</a>
+                                        <a class="btn btn--primary" title="Download as csv" data-gtm-download-file="{{uri}}" data-gtm-download-type="csv" href="/generator?format=csv&uri={{uri}}" aria-label="Download {{description.title}} as csv">.csv</a>
+                                        <a class="btn btn--primary" title="Download as xls" data-gtm-download-file="{{uri}}" data-gtm-download-type="xls" href="/generator?format=xls&uri={{uri}}" aria-label="Download {{description.title}} as xls">.xls</a>
+                                    </div>
                                 </div>
-                        </div>
-                        </form>
-                        {{!-- Show no-JS download options --}}
-                        <div class="js--hide">
+                                <div tabindex="0" role="tabpanel" aria-labelledby="filtered-button" id="filtered-download-controls" hidden="" 
+                                    class="chart-area__controls__download chart-area__controls__download--filtered padding-top--2 padding-bottom--2">
+                                    <div class="chart-area__controls__custom__container">
+                                        <p class="flush"> {{labels.download-filtered-time-series-as}}:</p>
+                                        <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary dlCustomData"  download="{{description.title}}" aria-label="Download {{description.title}} as an {{labels.image}}">{{labels.image}}</a>
+                                        <a class="btn btn--primary dlCustomData" title="Download as csv" data-gtm-download-file="{{uri}}" data-gtm-download-type="csv" href="/generator?format=csv&uri={{uri}}" aria-label="Download {{description.title}} as csv">.csv</a>
+                                        <a class="btn btn--primary dlCustomData" title="Download as xls" data-gtm-download-file="{{uri}}" data-gtm-download-type="xls" href="/generator?format=xls&uri={{uri}}" aria-label="Download {{description.title}} as xls">.xls</a>
+                                    </div>
+                                </div>
+                            </div>
+                            {{!-- Show no-JS download options --}}
+                            <div class="js--hide">
                                 <a href="{{uri}}/linechartimage" title="Download as an image" class="btn btn--primary" aria-label="Download {{title}} as an image">image</a>
                                 {{> partials/highcharts/download format='csv'}}
                                 {{> partials/highcharts/download format='xls'}}
-                        </div>
-                </div>
+                            </div>
+                        </div>   
                     </div> {{!-- /tiles__content --}}
-                                        <!--[if gt IE 8]><!--><noscript><![endif]-->
+                    <!--[if gt IE 8]><!--><noscript><![endif]-->
                         <div class="tiles__content js--hide">
                             <h2>{{labels.table}}</h2>
                             <table>
@@ -118,10 +113,10 @@
                                 </tbody>
                             </table>
                         </div>
-                                                <!--[if gt IE 8]><!--></noscript><![endif]-->
+                    <!--[if gt IE 8]><!--></noscript><![endif]-->
                 </div> {{!-- /col --}}
             </div> {{!-- /col-wrap --}}
-        {{/if_any}}
+    {{/if_any}}
 
         <div class="meta-wrap meta-wrap--gallery margin-bottom padding-right-sm--1">
             <div class="col-wrap">


### PR DESCRIPTION
### What
Reimplement the filter/unfiltered tabs for timeseries following aria best practices. This implementation is heavily dervied from the example here. https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html

### How to review
1. Load a timeseries page
1. See that the tabs are confusing to a screen reader or keyboard user
1. Switch to this branch
1. See that the keyboard controls are now more sensible and it is read correctly by a screen reader.

### Who can review
Anyone but me
