### PR TITLE
Fix/static page articles accessibility

### DIFF
--- a/src/main/web/templates/handlebars/content/partials/bulletin-header.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/bulletin-header.handlebars
@@ -2,7 +2,7 @@
     <div class="wrapper">
         <div class="col-wrap">
             <div class="col">
-                <nav>
+                <nav aria-label="Bulletin breadcrumbs">
                     <div class="breadcrumb-bulletins print--hide">
                         <ol class="breadcrumb-bulletins__list">
                             {{#each breadcrumb}}

--- a/src/main/web/templates/handlebars/content/partials/compendium-navigation.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/compendium-navigation.handlebars
@@ -1,5 +1,5 @@
 <div class="col-wrap print--hide">
-    <nav>
+    <nav aria-label="Compendium breadcrumbs">
         <ul class="list--neutral margin-left-md--1">
         {{#last breadcrumb}}
             {{#resolve uri}}

--- a/src/main/web/templates/handlebars/content/t3.handlebars
+++ b/src/main/web/templates/handlebars/content/t3.handlebars
@@ -3,7 +3,7 @@
 <div class="nav-secondary-wrap">
     <div class="wrapper">
         <div class="col-wrap">
-            <nav>
+            <nav aria-label="on-this-page">
                 <div class="nav-secondary nav-secondary--border-right-lg col col--lg-half">
                     <h2 class="nav-secondary__title">{{labels.on-this-page}}:</h2>
                     <ul class="nav-secondary__list">
@@ -26,7 +26,7 @@
                     </ul>
                 </div>
             </nav>
-            <nav>
+            <nav aria-label="related content">
                 <div class="nav-secondary col col--lg-half">
                     <h2 class="nav-secondary__title">{{labels.view-all-content-related-to-this-topic}}:</h2>
                     <ul class="nav-secondary__list">

--- a/src/main/web/templates/handlebars/content/t3.handlebars
+++ b/src/main/web/templates/handlebars/content/t3.handlebars
@@ -3,7 +3,7 @@
 <div class="nav-secondary-wrap">
     <div class="wrapper">
         <div class="col-wrap">
-            <nav aria-label="on-this-page">
+            <nav aria-label="On this page">
                 <div class="nav-secondary nav-secondary--border-right-lg col col--lg-half">
                     <h2 class="nav-secondary__title">{{labels.on-this-page}}:</h2>
                     <ul class="nav-secondary__list">
@@ -26,7 +26,7 @@
                     </ul>
                 </div>
             </nav>
-            <nav aria-label="related content">
+            <nav aria-label="Related content">
                 <div class="nav-secondary col col--lg-half">
                     <h2 class="nav-secondary__title">{{labels.view-all-content-related-to-this-topic}}:</h2>
                     <ul class="nav-secondary__list">

--- a/src/main/web/templates/handlebars/content/t4-3.handlebars
+++ b/src/main/web/templates/handlebars/content/t4-3.handlebars
@@ -3,7 +3,7 @@
         <div class="wrapper">
             <div class="col-wrap">
                 <div class="col">
-                    <nav>
+                    <nav aria-label="Article breadcrumbs">
                         <div class="breadcrumb-neutral print--hide">
                             <ol class="breadcrumb-neutral__list">
                                 {{#each breadcrumb}}

--- a/src/main/web/templates/handlebars/list/partials/paginator.handlebars
+++ b/src/main/web/templates/handlebars/list/partials/paginator.handlebars
@@ -1,6 +1,6 @@
 {{!-- Paginator --}}
 {{#if paginator}}
-    <nav>
+    <nav aria-label="Pagination breadcrumbs">
         <ul class="list--neutral list--inline margin-right-sm--1 margin-right-md--1 margin-bottom-sm--7 margin-bottom-md--7">
             {{#if_ne paginator.currentPage paginator.start}}
             <li class="margin-top-sm--0 margin-top-md--0">

--- a/src/main/web/templates/handlebars/partials/breadcrumb-neutral.handlebars
+++ b/src/main/web/templates/handlebars/partials/breadcrumb-neutral.handlebars
@@ -1,4 +1,4 @@
-<nav>
+<nav aria-label="Breadcrumbs">
     <div class="breadcrumb-neutral print--hide">
         <ol class="breadcrumb-neutral__list">
             {{#each breadcrumb}}

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -65,7 +65,7 @@
 
 	{{!-- MAIN NAV --}}
 	<div class="primary-nav print--hide">
-		<nav aria-label="Footer links">
+		<nav aria-label="Header links">
 			{{!-- MENU AND SEARCH TOGGLES ON MOBILE --}}
 			<ul class="nav--controls">
 				<li class="nav--controls__item">

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -65,7 +65,7 @@
 
 	{{!-- MAIN NAV --}}
 	<div class="primary-nav print--hide">
-		<nav>
+		<nav aria-label="Footer links">
 			{{!-- MENU AND SEARCH TOGGLES ON MOBILE --}}
 			<ul class="nav--controls">
 				<li class="nav--controls__item">

--- a/src/main/web/templates/handlebars/partials/highcharts/chart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/chart.handlebars
@@ -58,7 +58,7 @@
 
       <h3 class="flush--third--vertical font-size--18 padding-top--0 margin-bottom--1">{{{sub (sup title)}}}</h3>
         {{#if subtitle}}
-            <h4 class="flush--third--bottom font-size--16 padding-top--0 margin-top--0 font--weight-400">{{{sub (sup subtitle)}}}</h4>
+            <h4 class="flush--third--bottom font-size--16 padding-top--0 margin-top--0">{{{sub (sup subtitle)}}}</h4>
         {{/if}}
 
       <div class="scrollable-container">

--- a/src/main/web/templates/handlebars/partials/highcharts/chart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/chart.handlebars
@@ -2,9 +2,9 @@
 
 
   <div class="markdown-chart-container panel--bottom-mar print--avoid-break">
-          <h4 class="flush--third--vertical">{{{sub (sup title)}}}</h4>
+          <h3 class="flush--third--vertical font-size--18 margin-top--0 padding-top--0 margin-top--0 margin-bottom--1">{{{sub (sup title)}}}</h3>
           {{#if subtitle}}
-              <h5 class="flush--third--bottom">{{{sub (sup subtitle)}}}</h5>
+              <h4 class="flush--third--bottom font-size--16 margin-top--0 padding-top--0">{{{sub (sup subtitle)}}}</h4>
           {{/if}}
    <div class="sm-multiple-holder">
   {{#each series}}
@@ -25,9 +25,9 @@
 
   {{#if_eq chartType "table"}}
   <div class="markdown-table-container panel--bottom-mar print--avoid-break">
-    <h4 class="flush--third--vertical">{{{sub (sup title)}}}</h4>
+    <h3 class="flush--third--vertical font-size--18 margin-top--0 padding-top--0">{{{sub (sup title)}}}</h3>
     {{#if subtitle}}
-        <h5 class="flush--third--bottom">{{{sub (sup subtitle)}}}</h5>
+        <h4 class="flush--third--bottom font-size--16 margin-top--0 padding-top--0">{{{sub (sup subtitle)}}}</h4>
     {{/if}}
 
     <table class="t1 table-chart">
@@ -56,9 +56,9 @@
 
     <div class="markdown-chart-container panel--bottom-mar print--avoid-break">
 
-      <h4 class="flush--third--vertical">{{{sub (sup title)}}}</h4>
+      <h3 class="flush--third--vertical font-size--18 padding-top--0 margin-bottom--1">{{{sub (sup title)}}}</h3>
         {{#if subtitle}}
-            <h5 class="flush--third--bottom">{{{sub (sup subtitle)}}}</h5>
+            <h4 class="flush--third--bottom font-size--16 padding-top--0 margin-top--0 font--weight-400">{{{sub (sup subtitle)}}}</h4>
         {{/if}}
 
       <div class="scrollable-container">
@@ -76,15 +76,15 @@
 
 
 
-  {{#if source}}<h5 class="flush--third--bottom font-size--h6 clear-left">Source: {{source}}</h5>{{/if}}
+  {{#if source}}<h4 class="flush--third--bottom font-size--h6 clear-left">Source: {{source}}</h4>{{/if}}
       <div id="notes-{{filename}}" class="notes-holder-js">
   {{#if notes}}
-      <h6 class="flush--third--bottom js-notes-title">Notes:</h6>
+      <h5 class="flush--third--bottom js-notes-title font-size--16 padding-top--0">Notes:</h5>
       {{md notes}}
   {{/if}}
       </div>
   
-    <h5 class="print--hide font-size--h6 clear-left"><span role="text">Download this chart <span class="visuallyhidden">{{title}}</span></span></h5>
+    <h4 class="print--hide padding-top--0 margin-top--0 font-size--h6 clear-left"><span role="text">Download this chart <span class="visuallyhidden">{{title}}</span></span></h4>
 {{#if_ne chartType "small-multiples"}}
     <a class="btn btn--primary print--hide js-chart-image-src" data-filename="{{filename}}" href="/chartimage?uri={{uri}}" download="{{{sub (sup title)}}}" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-chart-image"  aria-label="Download {{title}} as an image">Image</a>
       {{else}}

--- a/src/main/web/templates/handlebars/partials/table-v2.handlebars
+++ b/src/main/web/templates/handlebars/partials/table-v2.handlebars
@@ -1,12 +1,12 @@
 {{!--Not having line breaks before and after the div markups breaks tables displaying on the page--}}
 <div class="markdown-table-container print--avoid-break">
-    <div class="scrollable-container">
+    <div class="scrollable-container" tabindex="0">
         <div class="markdown-table-wrap">
             {{{tableHtml}}}
         </div>
     </div>
 
-    <h5 class="print--hide font-size--h6"><span role="text">Download this table <span class="visuallyhidden">{{title}}</span></span></h5>
+    <h4 class="print--hide font-size--h6 padding-top--0"><span role="text">Download this table <span class="visuallyhidden">{{title}}</span></span></h4>
     <a href="/download/table?format=xlsx&uri={{uri}}.json" title="Download as xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xlsx" aria-label="Download {{title}} as xls">.xls</a>
     <a href="/download/table?format=csv&uri={{uri}}.json" title="Download as csv" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-csv" aria-label="Download {{title}} as csv">.csv</a>
 </div>

--- a/src/main/web/templates/handlebars/partials/table.handlebars
+++ b/src/main/web/templates/handlebars/partials/table.handlebars
@@ -1,6 +1,6 @@
 {{!--Not having line breaks before and after the div markups breaks tables displaying on the page--}}
 <div class="markdown-table-container print--avoid-break">
-    <h4>{{{sub (sup title)}}}</h4>
+    <h3 class="font-size--18 margin-top--1">{{{sub (sup title)}}}</h3>
     {{#resolveResource (concat uri ".html")}}
         <div class="scrollable-container">
             <div class="markdown-table-wrap">
@@ -8,6 +8,6 @@
             </div>
         </div>
     {{/resolveResource}}
-    <h5 class="print--hide font-size--h6"><span role="text">Download this table <span class="visuallyhidden">{{title}}</span></span></h5>
+    <h4 class="print--hide font-size--h6 margin-top--1 padding-top--0"><span role="text">Download this table <span class="visuallyhidden">{{title}}</span></span></h4>
     <a href="/file?uri={{uri}}.xls" title="Download as xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xls" aria-label="Download table {{title}} as xls">.xls</a>
 </div>


### PR DESCRIPTION
### What

Accessibility audit showed that there were heading levels being skipped in the charts - this PR updates those to ensure that the heading level hierarchy isn't compromised

This PR also makes tables focusable - as per accessibility audit recommendation

### How to review

- Check that code changes make sense
- Go to an article/bulletin page where charts are present and ensure the update to the heading tags visually align with what we currently have

### Who can review

Describe who worked on the changes, so that other people can review.
