### PR TITLE
Fix - Remove unnecessary role from main navigation

### DIFF
--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -89,7 +89,7 @@
 					<li class="primary-nav__item js-nav js-expandable {{#if_any (eq uri breadcrumb.1/uri)  (eq uri ../uri) }}primary-nav__item--active{{/if_any}}">
                         <a class="primary-nav__link col col--md-8 col--lg-10" href="{{uri}}" aria-expanded="false" aria-label="{{description.title}} {{labels.sub-menu}}">
                             <span aria-hidden="true" class="expansion-indicator"></span>
-                            <span aria-label="{{description.title}} {{labels.sub-menu}}" role="text" class="submenu-title">
+                            <span aria-label="{{description.title}} {{labels.sub-menu}}" class="submenu-title">
                                 {{description.title}}
                             </span>
                         </a>


### PR DESCRIPTION
### What
Remove unnecessary `role="text"` from main navigation. This was added to fix issue on iPhone VoiceOver but was not actually needed. 

Tested in NVDA and VoiceOver.

### How to review
1. Load any page
1. See that the main navigation links that expand contain a role="text"
1. Switch to this branch and `dp-frontend-renderer` branch `fix/misc-remove-unnecessary-role`
1. See that the labels are read correctly by screen readers.

### Who can review
Anyone but me
