### PR TITLE
Fix - Remove unnecessary role

### DIFF
--- a/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
@@ -17,7 +17,7 @@
                 </fieldset>
             </div>
             <div class="col col--md-12 col--lg-18 margin-right-md--4 margin-right-lg--2">
-                <fieldset class="btn-group" role="radiogroup">
+                <fieldset class="btn-group">
                     <legend id="frequency">{{labels.frequency}}</legend>
                     <label class="btn btn--secondary btn--chart-control frequency-select">
                         {{labels.month}}


### PR DESCRIPTION
### What
Remove unnecessary `role="radiogroup"` from `fieldset` in linechart frequency options.
Neither the `Show data as` nor `Time period` `fieldset`s have this and it doesn't seem to affect how it is read by screenreaders.

Came up as part of axe auditing.

### How to review
1. Visit a page with a linechart e.g. timeseries
1. See that the frequency legend has an unnecessary role
1. Switch to this branch

### Who can review
Anyone
