### PR TITLE
Fix - Set correct headings for previous timeseries page

### DIFF
--- a/src/main/web/templates/handlebars/content/t12-2.handlebars
+++ b/src/main/web/templates/handlebars/content/t12-2.handlebars
@@ -67,7 +67,7 @@
 
                 </div>
 
-                <h3 class="margin-top-md--4">Latest version</h3>
+                <h2 class="margin-top-md--4 font-size--h3">Latest version</h3>
                 <a href="/generator?format=xls&uri={{absolute uri}}"
                    class="btn btn--primary btn--thin btn--narrow btn--small"
                    data-gtm-type="download-version-xls"
@@ -80,7 +80,7 @@
 
                 {{#if versions}}
 
-                    <h3 class="margin-top-md--5">Previous versions</h3>
+                    <h2 class="margin-top-md--5 font-size--h3">Previous versions</h3>
 
                     <table class="table-advanced margin-bottom-sm--2 margin-bottom-md--2">
                         <thead>
@@ -143,7 +143,7 @@
                 {{#if section.markdown}}
                     <div class="section__content--static-markdown">
                         <section>
-                            <h3>{{labels.dataset-notes}}</h3>
+                            <h2 class="font-size--h3">{{labels.dataset-notes}}</h3>
                             {{md section.markdown}}
                         </section>
                     </div>


### PR DESCRIPTION
### What
Fix incorrect heading numbers on previous timeseries pages.

### How to review
1. Visit a previous timeseries page
1. See that headings go `h1` and then `h3` (shown in WAVE)
1. Switch to this branch
1. See that this issue is resolved

### Who can review
Anyone but me
