### PR TITLE
Fix - Search - PreviousReleases - Increment headings by one step

### DIFF
--- a/src/main/web/templates/handlebars/list/t9-6.handlebars
+++ b/src/main/web/templates/handlebars/list/t9-6.handlebars
@@ -24,9 +24,9 @@
 					{{#each result.results}}
 					<li {{#if_all @first (eq result.paginator.currentPage 1)}}class="margin-bottom--double"{{/if_all}}>
                     {{#if_all @first (eq result.paginator.currentPage 1)}}<h3 class="flush">{{labels.previous-latest}}</h3>
-						<h3 class="flush stand-out-text">
+						<h2 class="flush stand-out-text font-size--h3">
 					{{else}}
-						<h3 class="flush">
+						<h2 class="flush font-size--h3">
 					{{/if_all}}
 						<a href="{{uri}}">{{description.title}}
 							{{#if description.edition}}


### PR DESCRIPTION
### What
Headings should only increment by one step each time. This is not the case on the bullet previous releases page. Found using AXE.

### How to review
1. Visit a bulletin previous release page
1. See that the headings do not increment by one step.
1. Switch to this branch
1. See that this issue is resolved.

### Who can review
Anyone but me.
