### PR TITLE
Fix - Search - Missing fieldsets

### DIFF
--- a/src/main/web/templates/handlebars/list/t10-2.handlebars
+++ b/src/main/web/templates/handlebars/list/t10-2.handlebars
@@ -18,8 +18,10 @@
 {{/partial}}
 
 {{#partial "block-filters"}}
-	<h4 class="filters__title">{{labels.content-types-to-show}}</h4>
-	{{> list/filters/data docCounts=counts.docCounts}}
+	<fieldset class="filters__fieldset">
+		<legend class="filters__title">{{labels.content-types-to-show}}</legend>
+		{{> list/filters/data docCounts=counts.docCounts}}
+	</fieldset>
 	<input class="sort__input" type="hidden" name="q" value="{{parameters.q.0}}">
 {{/partial}}
 

--- a/src/main/web/templates/handlebars/list/t10-3.handlebars
+++ b/src/main/web/templates/handlebars/list/t10-3.handlebars
@@ -18,8 +18,10 @@
 {{/partial}}
 
 {{#partial "block-filters"}}
-	<h4 class="filters__title">{{labels.content-types-to-show}}</h4>
-	{{> list/filters/publications docCounts=counts.docCounts}}
+	<fieldset class="filters__fieldset">
+		<legend class="filters__title">{{labels.content-types-to-show}}</legend>
+		{{> list/filters/publications docCounts=counts.docCounts}}
+	</fieldset>
 	<input class="sort__input" type="hidden" name="q" value="{{parameters.q.0}}">
 {{/partial}}
 

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -22,14 +22,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cf2e1ea{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cf2e1ea{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cf2e1ea{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cf2e1ea{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
         {{> partials/gtm-data-layer }}
@@ -141,7 +141,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cf2e1ea{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,7 +51,7 @@ The commented code below is what needs to go in the parent.
     {{/if}}
   {{/if}}
 
-  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/cf2e1ea{{/if}}/js/main.js"></script>
+  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/js/main.js"></script>
   <script type="text/javascript" src="/js/app.js"></script>
 
   <script type="text/javascript" src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What
On the `/searchdata` and `/searchpublication` pages then the checkbox groups aren't wrapped in a `fieldset`. Found in WAVE

### How to review
1. Visit the search pages mentioned above
1. See the missing fieldset
1. Switch to this branch
1. See that the issue is resolved

### Who can review
Anyone but me
