### PR TITLE
Fix - Timeseriestool - Divs in UL

### DIFF
--- a/src/main/web/templates/handlebars/list/t13.handlebars
+++ b/src/main/web/templates/handlebars/list/t13.handlebars
@@ -70,15 +70,15 @@
 
 {{#partial "block-results"}}
         
-	<div id="select-all-container" class="js--show col">
+	<li id="select-all-container" class="js--show col margin-top--0 margin-bottom--0">
 		{{#if result.results}}
 			<input id="select-all"  type="checkbox" name="" value="" class="timeseries__select-all js-timeseriestool-select-all">
 			<label for="select-all">Select all</label>
 		{{/if}}
-	</div>
+	</li>
 
 	{{#each result.results}}
-		<div class="col-wrap {{#unless @first}}border-top--iron-sm border-top--iron-md{{/unless}}">
+		<li class="col-wrap {{#unless @first}}border-top--iron-sm border-top--iron-md{{/unless}} margin-top--0 margin-bottom--0">
 
 			{{!-- Checkbox --}}
 			<div class="input__wrapper col col--md-3 col--lg-3 margin-left-md--1 padding-left-md--1 padding-bottom-sm" >
@@ -108,7 +108,7 @@
 				</div>
 			</div>
 
-		</div>
+		</li>
 	{{/each}}
 
 {{/partial}}


### PR DESCRIPTION
### What
In the timeseries tool there are divs as results when the wrapping parent is a `ul`. These have now been changed to `li` with necessary classes added to maintain layout.

Found with AXE

### How to review
1. Visit the timeseriestool
1. See that the page results are `div`s in a parent `ul`
1. Switch to this branch
1. See that they are now `li`s and the layout is unaffected.

### Who can review
Anyone but me
