### PR TITLE
Fix - Letter spacing

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -22,14 +22,14 @@
 
 		<!--[if IE]><![endif]-->
 		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/css/old-ie.css"/>
+		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1697d8d{{/if}}/css/old-ie.css"/>
 		<![endif]-->
         <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/css/ie-9.css">
+              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1697d8d{{/if}}/css/ie-9.css">
         <![endif]-->
 		<!--[if gt IE 9]><!-->
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1697d8d{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1697d8d{{/if}}/css/pdf.css">{{/if}}
         <![endif]-->
 
         {{> partials/gtm-data-layer }}
@@ -141,7 +141,7 @@
 
 
         <!--[if gt IE 8]><!-->
-        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/js/main.js"></script>
+        <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1697d8d{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -80,45 +80,44 @@
 				</li>
 			</ul>
 			{{!-- PRIMARY NAVIGATION --}}
-			<div class="wrapper nav-main--hidden" id="nav-primary">
-				<ul class="primary-nav__list">
-					<li class="primary-nav__item {{#if_eq uri '/'}}primary-nav__item--active{{/if_eq}} js-nav hide--sm old-ie--display-block"><a class="primary-nav__link col col--md-7 col--lg-9" href="/">{{labels.home}}</a></li>
-					{{!-- loop each top node --}}
-					{{#each navigation}}
-					{{#if_eq this.type "taxonomy_landing_page"}}
-					<li class="primary-nav__item js-nav js-expandable {{#if_any (eq uri breadcrumb.1/uri)  (eq uri ../uri) }}primary-nav__item--active{{/if_any}}">
-                        <a class="primary-nav__link col col--md-8 col--lg-10" href="{{uri}}" aria-expanded="false" aria-label="{{description.title}} {{labels.sub-menu}}">
-                            <span aria-hidden="true" class="expansion-indicator"></span>
-                            <span aria-label="{{description.title}} {{labels.sub-menu}}" class="submenu-title">
-                                {{description.title}}
-                            </span>
-                        </a>
-                        <ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
-							{{!-- loop each child node --}}
-							{{#each children}}
-							<li class="primary-nav__child-item {{#if_any (eq uri breadcrumb.2/uri) (eq uri ../../uri)}}primary-nav__child-item--active{{/if_any}} js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="{{uri}}" >{{description.title}}</a>
-							</li>
-							{{/each}}
-						</ul>
-					</li>
+			<ul class="wrapper nav-main--hidden primary-nav__list" id="nav-primary" aria-expanded="false">
+				<li class="primary-nav__item {{#if_eq uri '/'}}primary-nav__item--active{{/if_eq}} js-nav hide--sm old-ie--display-block"><a class="primary-nav__link col col--md-7 col--lg-9" href="/">{{labels.home}}</a></li>
+				{{!-- loop each top node --}}
+				{{#each navigation}}
+				{{#if_eq this.type "taxonomy_landing_page"}}
+				<li class="primary-nav__item js-nav js-expandable {{#if_any (eq uri breadcrumb.1/uri)  (eq uri ../uri) }}primary-nav__item--active{{/if_any}}">
+					<a class="primary-nav__link col col--md-8 col--lg-10" href="{{uri}}" aria-expanded="false" aria-label="{{description.title}} {{labels.sub-menu}}">
+						<span aria-hidden="true" class="expansion-indicator"></span>
+						<span aria-label="{{description.title}} {{labels.sub-menu}}" class="submenu-title">
+							{{description.title}}
+						</span>
+					</a>
+					<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
+						{{!-- loop each child node --}}
+						{{#each children}}
+						<li class="primary-nav__child-item {{#if_any (eq uri breadcrumb.2/uri) (eq uri ../../uri)}}primary-nav__child-item--active{{/if_any}} js-expandable__child">
+							<a class="primary-nav__child-link" tabindex="-1" href="{{uri}}" >{{description.title}}</a>
+						</li>
+						{{/each}}
+					</ul>
+				</li>
+				{{/if_eq}}
+				{{/each}}
+				{{!-- SECONDARY NAV - PRIMARY --}}
+				<li class="primary-nav__item {{#if_eq uri '/surveys'}}primary-nav__item--active{{/if_eq}} js-nav">
+					<a class="primary-nav__link  col col--md-8 col--lg-10" href="/surveys">
+						{{labels.taking-part-in-a-survey}}
+					</a>
+				</li>
+				<li class="hide--md primary-nav__language">
+					{{#if_eq location.hostname (concat "cy." (replace location.hostname "cy." ""))}}
+						<a href="{{> partials/language-toggle language="en"}}" class="language__link">English (EN)</a>
+						<span> | Cymraeg (CY)</span>
+					{{else}}
+						<span>English (EN) | </span>
+						<a href="{{> partials/language-toggle language="cym"}}" class="language__link">Cymraeg (CY)</a>
 					{{/if_eq}}
-					{{/each}}
-					{{!-- SECONDARY NAV - PRIMARY --}}
-					<li class="primary-nav__item {{#if_eq uri '/surveys'}}primary-nav__item--active{{/if_eq}} js-nav">
-						<a class="primary-nav__link  col col--md-8 col--lg-10" href="/surveys">
-							{{labels.taking-part-in-a-survey}}
-						</a>
-					</li>
-                    <li class="hide--md primary-nav__language">
-                        {{#if_eq location.hostname (concat "cy." (replace location.hostname "cy." ""))}}
-                            <a href="{{> partials/language-toggle language="en"}}" class="language__link">English (EN)</a>
-                            <span> | Cymraeg (CY)</span>
-                        {{else}}
-                            <span>English (EN) | </span>
-                            <a href="{{> partials/language-toggle language="cym"}}" class="language__link">Cymraeg (CY)</a>
-                        {{/if_eq}}
-                    </li>
+				</li>
 				</ul>
 			</div>
 		</nav>

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,7 +51,7 @@ The commented code below is what needs to go in the parent.
     {{/if}}
   {{/if}}
 
-  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/49ef6ce{{/if}}/js/main.js"></script>
+  <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/1697d8d{{/if}}/js/main.js"></script>
   <script type="text/javascript" src="/js/app.js"></script>
 
   <script type="text/javascript" src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What
Completely rework the homepage styling to remove fixed heights so that when the letter spacing is changed the content expands and the content is not obscured.

One known issue is that there is some unintended spacing on the home page in the tablet (breakpoint md) when the text spacing is there. This seems unavoidable without JS which seems unnecessary. This has been signed off by @armstrongb  

This works on all supported browsers.

### How to review
1. Visit any page
1. Run the letter spacing bookmarklet
1. See that content is obscured or the design is broken
1. Switch to this branch, dp-frontend-renderer branch  `fix/letter-spacing-homepage` and babbage branch `fix/letter-spacing`

### Who can review
Anyone but me
