### PR TITLE
remove EnableCookiesControl flag

### DIFF
--- a/run-publishing.sh
+++ b/run-publishing.sh
@@ -22,7 +22,6 @@ export DEV_ENVIRONMENT="Y"
 export IS_PUBLISHING="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
-export ENABLE_COOKIES_CONTROL=false
 export ENABLE_COVID19_FEATURE=false
 export ENABLE_JSONLD_CONTROL=false
 

--- a/run-publishing.sh
+++ b/run-publishing.sh
@@ -23,7 +23,6 @@ export IS_PUBLISHING="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
 export ENABLE_COVID19_FEATURE=false
-export ENABLE_JSONLD_CONTROL=false
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/run.sh
+++ b/run.sh
@@ -22,7 +22,6 @@ export DEV_ENVIRONMENT="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
 export ENABLE_COVID19_FEATURE=false
-export ENABLE_JSONLD_CONTROL=false
 
 # Development: reloadable
 java $JAVA_OPTS \

--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,6 @@ export DP_LOGGING_FORMAT=pretty_json
 export DEV_ENVIRONMENT="Y"
 export RELOAD_TEMPLATES="Y"
 export TEMPLATES_DIR=src/main/web/templates/handlebars
-export ENABLE_COOKIES_CONTROL=false
 export ENABLE_COVID19_FEATURE=false
 export ENABLE_JSONLD_CONTROL=false
 

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
@@ -16,7 +16,6 @@ public class Handlebars implements AppConfig {
     private static final String TEMPLATES_SUFFIX_KEY = "TEMPLATES_SUFFIX";
     private static final String RELOAD_TEMPLATES_KEY = "RELOAD_TEMPLATES";
     private static final String ENABLE_COVID19_FEATURE = "ENABLE_COVID19_FEATURE";
-    private static final String ENABLE_COOKIES_CONTROL = "ENABLE_COOKIES_CONTROL";
     private static final String ENABLE_JSONLD_CONTROL = "ENABLE_JSONLD_CONTROL";
 
     private final String defaultHandlebarsDatePattern;
@@ -26,7 +25,6 @@ public class Handlebars implements AppConfig {
     private final String templatesSuffix;
     private final boolean reloadTemplateChanges;
     private final boolean enableCovid19Feature;
-    private final boolean enableCookiesControl;
     private final boolean enableJSONLDControl;
 
     static Handlebars getInstance() {
@@ -49,7 +47,6 @@ public class Handlebars implements AppConfig {
         templatesSuffix = getValueOrDefault(TEMPLATES_SUFFIX_KEY, ".handlebars");
         reloadTemplateChanges = getStringAsBool(RELOAD_TEMPLATES_KEY, "N");
         enableCovid19Feature = Boolean.parseBoolean(getValue(ENABLE_COVID19_FEATURE));
-        enableCookiesControl = Boolean.parseBoolean(getValue(ENABLE_COOKIES_CONTROL));
         enableJSONLDControl = Boolean.parseBoolean(getValue(ENABLE_JSONLD_CONTROL));
     }
 
@@ -77,10 +74,6 @@ public class Handlebars implements AppConfig {
         return reloadTemplateChanges;
     }
 
-    public boolean isEnableCookiesControl() {
-        return enableCookiesControl;
-    }
-
     public boolean isEnableCovid19Feature() {
         return enableCovid19Feature;
     }
@@ -99,7 +92,6 @@ public class Handlebars implements AppConfig {
         config.put("templatesSuffix", templatesSuffix);
         config.put("reloadTemplateChanges", reloadTemplateChanges);
         config.put("enableCovid19Feature", enableCovid19Feature);
-        config.put("enableCookiesControl", enableCookiesControl);
         config.put("enableJSONLDControl", enableJSONLDControl);
         return config;
     }

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Handlebars.java
@@ -16,7 +16,6 @@ public class Handlebars implements AppConfig {
     private static final String TEMPLATES_SUFFIX_KEY = "TEMPLATES_SUFFIX";
     private static final String RELOAD_TEMPLATES_KEY = "RELOAD_TEMPLATES";
     private static final String ENABLE_COVID19_FEATURE = "ENABLE_COVID19_FEATURE";
-    private static final String ENABLE_JSONLD_CONTROL = "ENABLE_JSONLD_CONTROL";
 
     private final String defaultHandlebarsDatePattern;
     private final String mainContentTemplateName;
@@ -25,7 +24,6 @@ public class Handlebars implements AppConfig {
     private final String templatesSuffix;
     private final boolean reloadTemplateChanges;
     private final boolean enableCovid19Feature;
-    private final boolean enableJSONLDControl;
 
     static Handlebars getInstance() {
         if (INSTANCE == null) {
@@ -47,7 +45,6 @@ public class Handlebars implements AppConfig {
         templatesSuffix = getValueOrDefault(TEMPLATES_SUFFIX_KEY, ".handlebars");
         reloadTemplateChanges = getStringAsBool(RELOAD_TEMPLATES_KEY, "N");
         enableCovid19Feature = Boolean.parseBoolean(getValue(ENABLE_COVID19_FEATURE));
-        enableJSONLDControl = Boolean.parseBoolean(getValue(ENABLE_JSONLD_CONTROL));
     }
 
     public String getHandlebarsDatePattern() {
@@ -78,10 +75,6 @@ public class Handlebars implements AppConfig {
         return enableCovid19Feature;
     }
 
-    public boolean isEnableJSONLDControl() {
-        return enableJSONLDControl;
-    }
-
     @Override
     public Map<String, Object> getConfig() {
         Map<String, Object> config = new HashMap<>();
@@ -92,7 +85,6 @@ public class Handlebars implements AppConfig {
         config.put("templatesSuffix", templatesSuffix);
         config.put("reloadTemplateChanges", reloadTemplateChanges);
         config.put("enableCovid19Feature", enableCovid19Feature);
-        config.put("enableJSONLDControl", enableJSONLDControl);
         return config;
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -28,7 +28,6 @@ public class PageRequestHandler extends BaseRequestHandler {
     private static final String REQUEST_TYPE = "/";
     private static final String PDF = "pdf";
     private static final String PDF_STYLE = "pdf_style";
-    private static final String ENABLE_COOKIES_CONTROL = "EnableCookiesControl";
     private static final String ENABLE_COVID19_FEATURE = "EnableCovid19Feature";
     private static final String ENABLE_JSONLD_CONTROL = "EnableJSONLDControl";
 
@@ -45,7 +44,6 @@ public class PageRequestHandler extends BaseRequestHandler {
                 additionalData.put(PDF_STYLE, true);
             }
             additionalData.put(ENABLE_COVID19_FEATURE, appConfig().handlebars().isEnableCovid19Feature());
-            additionalData.put(ENABLE_COOKIES_CONTROL, appConfig().handlebars().isEnableCookiesControl());
             additionalData.put(ENABLE_JSONLD_CONTROL, appConfig().handlebars().isEnableJSONLDControl());
             String html = TemplateService.getInstance().renderContent(dataStream, additionalData);
             return new BabbageContentBasedStringResponse(contentResponse, html, TEXT_HTML);

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -29,7 +29,6 @@ public class PageRequestHandler extends BaseRequestHandler {
     private static final String PDF = "pdf";
     private static final String PDF_STYLE = "pdf_style";
     private static final String ENABLE_COVID19_FEATURE = "EnableCovid19Feature";
-    private static final String ENABLE_JSONLD_CONTROL = "EnableJSONLDControl";
 
     @Override
     public BabbageResponse get(String uri, HttpServletRequest request) throws IOException, ContentReadException {
@@ -44,7 +43,6 @@ public class PageRequestHandler extends BaseRequestHandler {
                 additionalData.put(PDF_STYLE, true);
             }
             additionalData.put(ENABLE_COVID19_FEATURE, appConfig().handlebars().isEnableCovid19Feature());
-            additionalData.put(ENABLE_JSONLD_CONTROL, appConfig().handlebars().isEnableJSONLDControl());
             String html = TemplateService.getInstance().renderContent(dataStream, additionalData);
             return new BabbageContentBasedStringResponse(contentResponse, html, TEXT_HTML);
         }

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -42,9 +42,7 @@
         })(window,document,'script','dataLayer','GTM-MBCBVQS');</script>
         <!-- End Google Tag Manager -->
 
-        {{#if EnableJSONLDControl}}
-            {{> partials/json-ld/base }}
-        {{/if}}
+        {{> partials/json-ld/base }}
 
 	</head>
 	<body class="{{type}}">

--- a/src/main/web/templates/handlebars/partials/footer.handlebars
+++ b/src/main/web/templates/handlebars/partials/footer.handlebars
@@ -10,18 +10,12 @@
                             <li class="footer-nav__item">
                                 <a href="/help/accessibility">{{labels.accessibility}}</a>
                             </li>
-                            {{#if EnableCookiesControl}}
                             <li class="footer-nav__item">
                                 <a href="/cookies">{{labels.cookies-footer}}</a>
                             </li>
                             <li class="footer-nav__item">
                                 <a href="/help/privacynotice">{{labels.privacy-footer}}</a>
                             </li>
-                            {{else}}
-                                <li class="footer-nav__item">
-                                    <a href="/help/cookiesandprivacy">{{labels.cookies-and-privacy}}</a>
-                                </li>
-                            {{/if}}
                             <li class="footer-nav__item">
                                 <a href="/help/termsandconditions">{{labels.terms-and-conditions}}</a>
                             </li>

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -3,9 +3,7 @@
     <a class="skiplink" href="#main" tabindex="0">
         Skip to main content
     </a>
-	{{#if EnableCookiesControl}}
-		{{> partials/cookies-banner}}
-	{{/if}}
+    {{> partials/cookies-banner}}
 	{{!-- produced for download analytics function --}}
 	<div id="pagePath" class="hide">{{uri}}</div>
 	{{!-- LANGUAGE TOGGLE AND SECONDARY NAV - DESKTOP --}}


### PR DESCRIPTION
### What

Removed `CookiesRoutesEnabled` flag as GDPR is now live
Removed JSONLD flag

### How to review

- Ensure relevant GDPR code is removed and that the cookies banner page still loads on Babbage served pages
- Check this in tandem with [this PR for `dp-frontend-renderer`](https://github.com/ONSdigital/dp-frontend-renderer/pull/508) and [this PR for `dp-frontend-router`](https://github.com/ONSdigital/dp-frontend-router/pull/237)
- Ensure JSONLD on Babbage pages (timeseries, bulletin, articles) still renders as expected

### Who can review

Anyone
