### PR TITLE
move cookies banner to Main handlebars to apply to all pages

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -47,6 +47,8 @@
 	</head>
 	<body class="{{type}}">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js' : 'js');</script>
+    {{> partials/cookies-banner}}
+
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
                       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -3,7 +3,6 @@
     <a class="skiplink" href="#main" tabindex="0">
         Skip to main content
     </a>
-    {{> partials/cookies-banner}}
 	{{!-- produced for download analytics function --}}
 	<div id="pagePath" class="hide">{{uri}}</div>
 	{{!-- LANGUAGE TOGGLE AND SECONDARY NAV - DESKTOP --}}


### PR DESCRIPTION
### What

Moved the cookies banner partial from the header to the Main handlebars template. This is because not all pages use the header, subsequently meaning the banner would not display

### How to review

- Sense check
- Going to a search/list page like `/timeseriestool` - you should now see the cookies banner when you haven't already set preferences. You should ensure you are running the latest Develop branch of the frontend router too

### Who can review

Anyone but me
