### PR TITLE
fit button and link on same line on medium screens

### DIFF
--- a/src/main/web/templates/handlebars/partials/interactive.handlebars
+++ b/src/main/web/templates/handlebars/partials/interactive.handlebars
@@ -6,7 +6,7 @@
         <summary class="details__summary" role="button" aria-label="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}} embed code">Embed code</summary>
         <div class="details__body">
             <label class="embed-code__label" for="embed-{{id}}">Embed this interactive</label>
-            <input class="embed-code__code width-md--32"
+            <input class="embed-code__code width-md--31"
         value='<iframe width="100%" src="{{#if (containsAny url "http" "https")}}{{url}}{{else}}{{#if is_dev}}http://{{location.host}}{{else}}https://{{location.hostname}}{{/if}}{{url}}{{/if}}"></iframe>'
                    id="embed-{{id}}"
                    name="embed-{{id}}"


### PR DESCRIPTION
### What

Adjusted column width so that button and link are on same line

### How to review

Go to any page with an "Embed code" accordion. See that when on a medium screen the copy button moves underneath the link. Pull this branch. Copy button and link are on the same line.  

### Who can review

Anyone but me. 
