### PR TITLE
show last updated only on static pages

### DIFF
--- a/src/main/web/templates/handlebars/content/partials/intro-meta.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/intro-meta.handlebars
@@ -1,4 +1,5 @@
-{{#if description.releaseDate}}
+{{#if_eq type "static_page" }}
+    {{#if description.releaseDate}}
     <div class="meta-wrap meta-wrap--thin">
         <div class="wrapper">
             <dl class="col-wrap">
@@ -9,4 +10,7 @@
             </dl>
         </div>
     </div>
-{{/if}}
+    {{/if}}
+{{/if_eq}}
+
+

--- a/src/main/web/templates/handlebars/partials/interactive.handlebars
+++ b/src/main/web/templates/handlebars/partials/interactive.handlebars
@@ -6,7 +6,7 @@
         <summary class="details__summary" role="button" aria-label="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}} embed code">Embed code</summary>
         <div class="details__body">
             <label class="embed-code__label" for="embed-{{id}}">Embed this interactive</label>
-            <input class="embed-code__code width-md--32"
+            <input class="embed-code__code width-md--31"
         value='<iframe width="100%" src="{{#if (containsAny url "http" "https")}}{{url}}{{else}}{{#if is_dev}}http://{{location.host}}{{else}}https://{{location.hostname}}{{/if}}{{url}}{{/if}}"></iframe>'
                    id="embed-{{id}}"
                    name="embed-{{id}}"


### PR DESCRIPTION
### What

"Last updated" should only appear on static pages. 

### How to review

Go to a static_landing_pages, timeseries and user_requested_data pages and see "Last updated". Pull this branch and "last updated should no longer appear on those pages but should only be on static pages. 

### Who can review

Anyone but me. 