### PR TITLE
Added output format for release date in t11 and t16 handlebars

### DIFF
--- a/src/main/web/templates/handlebars/content/t16.handlebars
+++ b/src/main/web/templates/handlebars/content/t16.handlebars
@@ -14,19 +14,19 @@
         {{#if description.cancelled}}
             Proposed release date:
             <br/>
-            {{df description.releaseDate}}
+            {{df description.releaseDate outputFormat="d MMMM yyyy HH:mm"}}
         {{else}}
             {{#if description.finalised}}
                 {{labels.release-date}}:
                 <br>
-                {{df description.releaseDate}}
+                {{df description.releaseDate outputFormat="d MMMM yyyy HH:mm"}}
             {{else}}
                 Provisional release date:
                 <br>
                 {{#if description.provisionalDate}}
                     {{description.provisionalDate}}
                 {{else}}
-                    {{df description.releaseDate}}
+                    {{df description.releaseDate outputFormat="d MMMM yyyy HH:mm"}}
                 {{/if}}
             {{/if}}
         {{/if}}
@@ -305,7 +305,7 @@
                                                         <li class="margin-bottom overflow--hidden">
                                                             <dl>
                                                                 <dt class="col col--md-10 col--lg-10">Previous date:</dt>
-                                                                <dd class="col col--md-37 col--lg-49">{{df previousDate}}</dd>
+                                                                <dd class="col col--md-37 col--lg-49">{{df previousDate outputFormat="d MMMM yyyy HH:mm"}}</dd>
                                                                 <dt class="col col--md-10 col--lg-10">Reason for change:</dt>
                                                                 <dd class="col col--md-37 col--lg-49">{{changeNotice}}</dd>
                                                             </dl>

--- a/src/main/web/templates/handlebars/list/t11.handlebars
+++ b/src/main/web/templates/handlebars/list/t11.handlebars
@@ -63,7 +63,7 @@
 				{{#if description.provisionalDate}}
 					{{description.provisionalDate}}
 				{{else}}
-					{{df description.releaseDate}}
+					{{df description.releaseDate outputFormat="d MMMM yyyy HH:mm"}}
 				{{/if}}
 				<span>
 					{{#if description.cancelled}}
@@ -83,7 +83,7 @@
 							<br>
 							<span class="flush">
 								<a href="{{uri}}#datechanges">
-                                    This date has been changed from {{df previousDate}} <span class="visuallyhidden">for {{{description.title}}}{{#if description.edition}}: {{{description.edition}}}{{/if}}</span>
+                                    This date has been changed from {{df previousDate outputFormat="d MMMM yyyy HH:mm"}} <span class="visuallyhidden">for {{{description.title}}}{{#if description.edition}}: {{{description.edition}}}{{/if}}</span>
                                 </a>
 							</span>
 						{{/last}}


### PR DESCRIPTION
### What

Added output format  {{df updateDate outputFormat="d MMMM yyyy HH:mm"}} 
Display time on screen where 'Release Date' and 'Previous' appear in releaseCalendar and releases
https://trello.com/c/IbIiZS1d/116-can-we-make-release-time-clearer-on-calendar-entries-2d

### How to review
Run services for publishing journey
locally create a collection, edit the content and publish it. Go to localhost:8081 and select release calendar for the change to be displayed. click to view the release  and release date should be displayed as formatted

Then edit the content of the release again(via florence) to change the release date and publish it again and check for the changes 

### Who can review

Anyone
