### PR TITLE
Fix/bad value http equiv

### DIFF
--- a/src/main/web/400.html
+++ b/src/main/web/400.html
@@ -8,11 +8,9 @@
 <!--<![endif]-->
 
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta charset="UTF-8">
     <title>400 Error</title>
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!-- http://www.phpied.com/conditional-comments-block-downloads/ -->
     <!--[if IE]><![endif]-->

--- a/src/main/web/404.html
+++ b/src/main/web/404.html
@@ -7,11 +7,9 @@
 <html class="no-js">
 <!--<![endif]-->
 <head>
-<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 <meta charset="UTF-8">
 <title>404 Error</title>
 <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-<meta content="on" http-equiv="cleartype" />
 <meta name="format-detection" content="telephone=no">
 <!-- http://www.phpied.com/conditional-comments-block-downloads/ -->
 <!--[if IE]><![endif]-->

--- a/src/main/web/500.html
+++ b/src/main/web/500.html
@@ -7,11 +7,9 @@
 <html class="no-js">
 <!--<![endif]-->
 <head>
-<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 <meta charset="UTF-8">
 <title>500 Error</title>
 <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-<meta content="on" http-equiv="cleartype" />
 <meta name="format-detection" content="telephone=no">
 <!-- http://www.phpied.com/conditional-comments-block-downloads/ -->
 <!--[if IE]><![endif]-->

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -6,11 +6,9 @@
 <html {{> partials/subdomain-lang }}>
 	<!--<![endif]-->
 	<head>
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <title>{{> partials/page-title }} - Office for National Statistics</title>
         <meta charset="utf-8" />
         <meta content="width=device-width,initial-scale=1.0,user-scalable=1" name="viewport">
-        <meta content="on" http-equiv="cleartype" />
         <meta name="theme-color" content="#58595B">
         <meta name="apple-mobile-web-app-status-bar-style" content="#58595B">
 

--- a/src/main/web/templates/html/404.html
+++ b/src/main/web/templates/html/404.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>T3</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/500.html
+++ b/src/main/web/templates/html/500.html
@@ -8,11 +8,9 @@
 <html class="no-js">
     <!--<![endif]-->
     <head>
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <title>T3</title>
         <meta charset="utf-8" />
         <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-        <meta content="on" http-equiv="cleartype" />
         <meta name="format-detection" content="telephone=no">
         <!--[if IE]><![endif]-->
         <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t1.html
+++ b/src/main/web/templates/html/t1.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>T1</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t10.html
+++ b/src/main/web/templates/html/t10.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>{{description.title}}</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t11.html
+++ b/src/main/web/templates/html/t11.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Release calendar</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t12.html
+++ b/src/main/web/templates/html/t12.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>CPI: Consumer Prices Index (% change)</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t14.html
+++ b/src/main/web/templates/html/t14.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Browse our statistics</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t16.html
+++ b/src/main/web/templates/html/t16.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Consumer Price Inflation, January 2015</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t2.html
+++ b/src/main/web/templates/html/t2.html
@@ -9,11 +9,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>T2</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t3.html
+++ b/src/main/web/templates/html/t3.html
@@ -8,11 +8,9 @@
 <html class="no-js">
     <!--<![endif]-->
     <head>
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <title>T3</title>
         <meta charset="utf-8" />
         <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-        <meta content="on" http-equiv="cleartype" />
         <meta name="format-detection" content="telephone=no">
         <!--[if IE]><![endif]-->
         <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t4-1.html
+++ b/src/main/web/templates/html/t4-1.html
@@ -8,11 +8,9 @@
 <html class="no-js">
     <!--<![endif]-->
     <head>
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <title>T4-1</title>
         <meta charset="utf-8" />
         <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-        <meta content="on" http-equiv="cleartype" />
         <meta name="format-detection" content="telephone=no">
         <!--[if IE]><![endif]-->
         <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t4-2.html
+++ b/src/main/web/templates/html/t4-2.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Economic Review, June 2014</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t6-1.html
+++ b/src/main/web/templates/html/t6-1.html
@@ -9,11 +9,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Blue book, 2014</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t6-2.html
+++ b/src/main/web/templates/html/t6-2.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Chapter 1: An introduction to the UK national accounts</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t6-3.html
+++ b/src/main/web/templates/html/t6-3.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Labour market statistics</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t7-1.html
+++ b/src/main/web/templates/html/t7-1.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Consumer Price Inflation</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t7-2.html
+++ b/src/main/web/templates/html/t7-2.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Contributions to the annual CPI inflation rate, by degree of import penetration</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t7-3.html
+++ b/src/main/web/templates/html/t7-3.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Contributions to the annual CPI inflation rate, by degree of import penetration</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t7-4-1.html
+++ b/src/main/web/templates/html/t7-4-1.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Economy</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t7-4-2.html
+++ b/src/main/web/templates/html/t7-4-2.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Methodology</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t7-5.html
+++ b/src/main/web/templates/html/t7-5.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Our statistics</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t7-6.html
+++ b/src/main/web/templates/html/t7-6.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Inflation and price indices</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t8-1.html
+++ b/src/main/web/templates/html/t8-1.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Labour market statistics</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t8-2.html
+++ b/src/main/web/templates/html/t8-2.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Population by age and sex</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t8-3.html
+++ b/src/main/web/templates/html/t8-3.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Index of production</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t9-1.html
+++ b/src/main/web/templates/html/t9-1.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>National accounts</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t9-2.html
+++ b/src/main/web/templates/html/t9-2.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Freedom of Information (FOI) disclosure log</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t9-3.html
+++ b/src/main/web/templates/html/t9-3.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Inflation and price indices</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t9-4.html
+++ b/src/main/web/templates/html/t9-4.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Inflation and price indices</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t9-5.html
+++ b/src/main/web/templates/html/t9-5.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Inflation and price indices</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>

--- a/src/main/web/templates/html/t9-6.html
+++ b/src/main/web/templates/html/t9-6.html
@@ -8,11 +8,9 @@
 <html class="no-js">
   <!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Consumer Price Inflation</title>
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
-    <meta content="on" http-equiv="cleartype" />
     <meta name="format-detection" content="telephone=no">
     <!--[if IE]><![endif]-->
     <!--[if lte IE 8]>


### PR DESCRIPTION
### What

Remove unnecessary meta tags `cleartype` and `X-UA-Compatible` since these are no longer needed for IE11. 

### How to review

Go to any page and inspect it, see the meta tags `cleartype` and X-UA-Compatible`. Pull this branch, see these tags are no longer present. 

### Who can review

Anyone but me. 
