### PR TITLE
Fix/remove conditional formatting

### DIFF
--- a/src/main/web/package-lock.json
+++ b/src/main/web/package-lock.json
@@ -311,7 +311,7 @@
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -551,7 +551,7 @@
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
@@ -806,9 +806,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.11.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.3.tgz",
-            "integrity": "sha512-wDRziHG94mNj2n3R864CvYw/+pc9y/RNImiTyrrf8BzgWn75JgFSwYvXrtZQMnMnOp/4UTrf3iCSQxSStPiByA=="
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.0.tgz",
+            "integrity": "sha512-8lBMSkFZuAK7gGF8LswsXmir8eX8d2AAMOnxSDWjKBx/fBR6MypQjs78m6ML9zQVp1/hD4TBdfeMZMC7nW1TAA=="
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html {{> partials/subdomain-lang }}>
 	<head>
         <title>{{> partials/page-title }} - Office for National Statistics</title>
         <meta charset="utf-8" />

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -1,10 +1,4 @@
 <!DOCTYPE html>
-<!--[if lt IE 7]><html class="no-js lt-ie8 lt-ie7" {{> partials/subdomain-lang }}><![endif]-->
-<!--[if IE 7]><html class="no-js lt-ie8 ie7"  {{> partials/subdomain-lang }}><![endif]-->
-<!--[if IE 8]><html class="ie8" {{> partials/subdomain-lang }}><![endif]-->
-<!--[if gt IE 8]><!--><!-->
-<html {{> partials/subdomain-lang }}>
-	<!--<![endif]-->
 	<head>
         <title>{{> partials/page-title }} - Office for National Statistics</title>
         <meta charset="utf-8" />

--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -11,18 +11,8 @@
         {{#if_any (eq type "bulletin") (eq type "article") (eq type "compendium_landing_page") (eq type "compendium_chapter")}}
             <link rel="canonical" href="{{uri}}" />
         {{/if_any}}
-
-		<!--[if IE]><![endif]-->
-		<!--[if lte IE 8]>
-		<link rel="stylesheet" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/24764b6{{/if}}/css/old-ie.css"/>
-		<![endif]-->
-        <!--[if IE 9]>
-              <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/24764b6{{/if}}/css/ie-9.css">
-        <![endif]-->
-		<!--[if gt IE 9]><!-->
         <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/24764b6{{/if}}/css/main.css">
 		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/24764b6{{/if}}/css/pdf.css">{{/if}}
-        <![endif]-->
 
         {{> partials/gtm-data-layer }}
 
@@ -130,8 +120,6 @@
 			{{/if_eq}}
 		{{/if_eq}}
 
-
-        <!--[if gt IE 8]><!-->
         <script type="text/javascript" src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/24764b6{{/if}}/js/main.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
 
@@ -142,8 +130,6 @@
             <script type="text/javascript" src="/js/third-party/highcharts-heatmap-5.0.7.js"></script>
             <script type="text/javascript" src="/js/third-party/highcharts-exporting-5.0.7.js"></script>
         {{/if}}
-
-        <![endif]-->
 
 	</body>
 </html>

--- a/src/test/java/com/github/onsdigital/babbage/search/helpers/SearchRequestHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/search/helpers/SearchRequestHelperTest.java
@@ -225,7 +225,7 @@ public class SearchRequestHelperTest {
     public void shouldRejectFromDateIfViewIsNotUpcoming() throws Exception {
         Date futureDate = DateTime.now().plusMonths(1).plusYears(1).toDate();
         String month = new SimpleDateFormat("MM").format(futureDate);
-        String year = new SimpleDateFormat("YY").format(futureDate);
+        String year = new SimpleDateFormat("yy").format(futureDate);
         setFrom("1", month, year);
 
         List<ValidationError> expectedErrors = new ImmutableList.Builder<ValidationError>()
@@ -245,7 +245,7 @@ public class SearchRequestHelperTest {
         DateTime futureDateTime = DateTime.now().plusMonths(1).plusYears(1);
         SimpleDateFormat formatter = new SimpleDateFormat("dd-MM-yyyy");
         String month = new SimpleDateFormat("MM").format(futureDateTime.toDate());
-        String year = new SimpleDateFormat("YY").format(futureDateTime.toDate());
+        String year = new SimpleDateFormat("yy").format(futureDateTime.toDate());
         String day = new SimpleDateFormat("dd").format(futureDateTime.toDate());
         setFrom(day, month, year);
 


### PR DESCRIPTION
### What

Remove conditional formatting for browsers older than IE11 since we no longer support these browsers. 

### How to review

Inspect any page, see conditional formatting that supports older IE browsers. Pull this branch, inspect any page and see there is no longer conditional formatting. 

### Who can review

Anyone but me. 
