### PR TITLE
Vulnerability Disclosure Programme

### DIFF
--- a/src/main/web/.well-known/security.txt
+++ b/src/main/web/.well-known/security.txt
@@ -1,0 +1,2 @@
+Contact: https://hackerone.com/52fa7bc0-5356-4c86-9f79-eeb03e1d55cc/embedded_submissions/new
+Policy: https://www.ons.gov.uk/help/vulnerability-reporting


### PR DESCRIPTION
### What

We are now participating in a cross government disclosure programme set up by the NCSC to identify security vulnerabilities.

This release will be coordinated with the publishing team. They have a policy page waiting to go out in sync with this release. - this is why it is being done as a hotfix, so that we don't have to wait on other items in develop being signed off nor other peoples work being held off until this is ready to go.

For more information on what this is, you can visit https://securitytxt.org/

### How to review

- Check the security.txt file appears at http://localhost:8081/.well-known/security.txt when run locally. 
- Check file name and contents are spelt correctly.

### Who can review

Anyone except me, but will not be released until we have communicated with publishing.

### Side notes

Our initial release is going to be simple like 
https://www.raf.mod.uk/.well-known/security.txt

But here are some other examples for the curious that are slightly different:
https://www.ncsc.gov.uk/.well-known/security.txt
https://www.nhs.uk/.well-known/security.txt