### PR TITLE
Fix/time filter radio toggle

### DIFF
--- a/src/main/web/js/app/linechart.js
+++ b/src/main/web/js/app/linechart.js
@@ -634,7 +634,6 @@ var renderLineChart = function (timeseries) {
                 var fromYear;
                 var fromMonth;
                 var fromQuarter;
-                e.preventDefault();
                 // toggleSelectedLink(elem);
                 // toggleTimePeriodButton(elem);
                 toggleSelectedButton();

--- a/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
@@ -17,19 +17,19 @@
                 </fieldset>
             </div>
             <div class="col col--md-12 col--lg-18 margin-right-md--4 margin-right-lg--2">
-                <fieldset>
+                <fieldset class="btn-group">
                     <legend id="frequency">{{labels.frequency}}</legend>
-                    <label>
+                    <label class="btn btn--secondary btn--chart-control frequency-select">
                         {{labels.month}}
                         <input type="radio" class="frequency" name="scale" data-chart-controls-scale="months"
                                 value="months" aria-controls="data">
                     </label>
-                    <label>
+                    <label class="btn btn--secondary btn--chart-control frequency-select">
                         {{labels.quarter}}
                         <input type="radio" class="frequency" name="scale" data-chart-controls-scale="quarters"
                                 value="quarters" aria-controls="data">
                     </label>
-                    <label>
+                    <label class="btn btn--secondary btn--chart-control frequency-select">
                         {{labels.year}}
                         <input type="radio" class="frequency" name="scale" data-chart-controls-scale="years"
                                 value="years" aria-controls="data">

--- a/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/linechart.handlebars
@@ -17,19 +17,19 @@
                 </fieldset>
             </div>
             <div class="col col--md-12 col--lg-18 margin-right-md--4 margin-right-lg--2">
-                <fieldset class="btn-group">
+                <fieldset>
                     <legend id="frequency">{{labels.frequency}}</legend>
-                    <label class="btn btn--secondary btn--chart-control frequency-select">
+                    <label>
                         {{labels.month}}
                         <input type="radio" class="frequency" name="scale" data-chart-controls-scale="months"
                                 value="months" aria-controls="data">
                     </label>
-                    <label class="btn btn--secondary btn--chart-control frequency-select">
+                    <label>
                         {{labels.quarter}}
                         <input type="radio" class="frequency" name="scale" data-chart-controls-scale="quarters"
                                 value="quarters" aria-controls="data">
                     </label>
-                    <label class="btn btn--secondary btn--chart-control frequency-select">
+                    <label>
                         {{labels.year}}
                         <input type="radio" class="frequency" name="scale" data-chart-controls-scale="years"
                                 value="years" aria-controls="data">


### PR DESCRIPTION
### What

Time period radio buttons do not select on timeseries

### How to review

Go to any timeseries page, select the radio buttons for time period and see that although the chart changes, the radio button does not show the user that it is selected. Pull this branch, see that the user can see they have selected a radio button. 

### Who can review

Anyone but me. 
