### PR TITLE
edited title display in t13 handlebar to use triple-stash

### DIFF
--- a/src/main/web/templates/handlebars/list/t13.handlebars
+++ b/src/main/web/templates/handlebars/list/t13.handlebars
@@ -86,7 +86,7 @@
 			</div>
 			{{!-- Title --}}
 			<div class="col col--md-21 col--lg-25 padding-right-md--1">
-				<p class="margin-bottom-md--0 flush--sm"><a href="{{uri}}">{{description.title}}</a></p>
+				<p class="margin-bottom-md--0 flush--sm"><a href="{{uri}}">{{{description.title}}}</a></p>
 			</div>
 
 			{{!-- Is new? --}}


### PR DESCRIPTION
### What

Fix for timeseries explorer list page where html tags were displayed as text. i.e. <strong>xxx</strong> rather than bold text.

### How to review

Load timeseries explorer page (`/timeseriestool`) locally on develop branch then search for a timeseries with a keyword, see the list results page showing the raw html text. Check out this branch then after the previous steps, the listed titles should show bold text. 

### Who can review

anyone
