### PR TITLE
Remove travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<!-- [![Build Status](https://travis-ci.org/ONSdigital/tredegar.svg?branch=master)](https://travis-ci.org/ONSdigital/tredegar) -->
-
 Babbage
 ========
 


### PR DESCRIPTION
### What

Remove travis build status from README.md

### How to review

See that its no longer there.

### Who can review

anyone