### PR TITLE
Adds missing base image for dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM openjdk:8-jre
+
 # Add the build artifacts
 WORKDIR /usr/src
 ADD ./target/dependency /usr/src/target/dependency

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,3 +1,5 @@
+FROM openjdk:8-jre
+
 WORKDIR /usr/src
 
 ADD web target/web


### PR DESCRIPTION
### What

Builds in develop are failing because the base image was removed from the dockerfile (sorry!) when removing references to `ghostscript`

This PR adds a base image, but not the one that was custom build to use in PDF generation as it's no longer needed

### How to review

Changes make sense?

### Who can review

Anyone
