### PR TITLE
Feature/add word count to datalayer

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
@@ -28,14 +28,14 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
 
                 String md = sectionText.get("markdown");
                 String mdWordCount = "0";
-                if(md != null && !md.isEmpty()) {
+                if (md != null && !md.isEmpty()) {
                     String mdHtml = mdHelper.apply(md, options).toString();
                     mdWordCount = StringHelper.wordCount.apply(mdHtml, options).toString();
                 }
 
                 String titleWordCount = "0";
                 String title = sectionText.get("title");
-                if(title != null && !title.isEmpty()) {
+                if (title != null && !title.isEmpty()) {
                     titleWordCount = StringHelper.wordCount.apply(title, options).toString();
                 }
 

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
@@ -17,7 +17,7 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
     totalWordCount {
         @Override
         public CharSequence apply(Object context, Options options) throws IOException {
-            if (options.isFalsy(context)) {
+            if (options.isFalsy(context) || ((List<Object>) context).isEmpty()) {
                 return null;
             }
 

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
@@ -1,5 +1,6 @@
 package com.github.onsdigital.babbage.template.handlebars.helpers;
 
+import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Options;
 import com.github.onsdigital.babbage.template.handlebars.helpers.base.BabbageHandlebarsHelper;
@@ -17,27 +18,19 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
     totalWordCount {
         @Override
         public CharSequence apply(Object context, Options options) throws IOException {
-            if (options.isFalsy(context) || ((List<Object>) context).isEmpty()) {
+            if (isEmpty(context, options)) {
                 return null;
             }
 
-            CustomMarkdownHelper mdHelper = new CustomMarkdownHelper();
             Integer runningWordCount = 0;
             for (Object section : (List<Object>) context) {
                 Map<String, String> sectionText = (Map<String, String>) section;
 
                 String md = sectionText.get("markdown");
-                String mdWordCount = "0";
-                if (md != null && !md.isEmpty()) {
-                    String mdHtml = mdHelper.apply(md, options).toString();
-                    mdWordCount = StringHelper.wordCount.apply(mdHtml, options).toString();
-                }
+                String mdWordCount = calculateWordCountFromMarkdown(md, options);
 
-                String titleWordCount = "0";
                 String title = sectionText.get("title");
-                if (title != null && !title.isEmpty()) {
-                    titleWordCount = StringHelper.wordCount.apply(title, options).toString();
-                }
+                String titleWordCount = calculateWordCountFromSection(title, options);
 
                 runningWordCount = Integer.parseInt(titleWordCount) + Integer.parseInt(mdWordCount) + runningWordCount;
             }
@@ -47,6 +40,28 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
         @Override
         public void register(Handlebars handlebars) {
             handlebars.registerHelper(this.name(), this);
+        }
+
+        private String calculateWordCountFromMarkdown(String md, Options options) throws IOException {
+            if (md == null || md.isEmpty()) {
+                return "0";
+            }
+
+            CustomMarkdownHelper mdHelper = new CustomMarkdownHelper();
+            String mdHtml = mdHelper.apply(md, options).toString();
+            return StringHelper.wordCount.apply(mdHtml, options).toString();
+        }
+
+        private String calculateWordCountFromSection(String title, Options options) throws IOException {
+            if (title == null || title.isEmpty()) {
+                return "0";
+            }
+
+            return StringHelper.wordCount.apply(title, options).toString();
+        }
+
+        private boolean isEmpty(Object context, Options options) {
+            return options.isFalsy(context) || ((List<Object>) context).isEmpty();
         }
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
@@ -25,9 +25,20 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
             Integer runningWordCount = 0;
             for (Object section : (List<Object>) context) {
                 Map<String, String> sectionText = (Map<String, String>) section;
-                String mdHtml = mdHelper.apply(sectionText.get("markdown"), options).toString();
-                String mdWordCount = StringHelper.wordCount.apply(mdHtml, options).toString();
-                String titleWordCount = StringHelper.wordCount.apply(sectionText.get("title"), options).toString();
+
+                String md = sectionText.get("markdown");
+                String mdWordCount = "0";
+                if(md != null && !md.isEmpty()) {
+                    String mdHtml = mdHelper.apply(md, options).toString();
+                    mdWordCount = StringHelper.wordCount.apply(mdHtml, options).toString();
+                }
+
+                String titleWordCount = "0";
+                String title = sectionText.get("title");
+                if(title != null && !title.isEmpty()) {
+                    titleWordCount = StringHelper.wordCount.apply(title, options).toString();
+                }
+
                 runningWordCount = Integer.parseInt(titleWordCount) + Integer.parseInt(mdWordCount) + runningWordCount;
             }
             return runningWordCount.toString();

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
@@ -22,19 +22,19 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
                 return null;
             }
 
-            Integer runningWordCount = 0;
+            int runningWordCount = 0;
             for (Object section : (List<Object>) context) {
                 Map<String, String> sectionText = (Map<String, String>) section;
 
                 String md = sectionText.get("markdown");
-                String mdWordCount = calculateWordCountFromMarkdown(md, options);
+                int mdWordCount = calculateWordCountFromMarkdown(md, options);
 
                 String title = sectionText.get("title");
-                String titleWordCount = calculateWordCountFromSection(title, options);
+                int titleWordCount = calculateWordCountFromSection(title, options);
 
-                runningWordCount = Integer.parseInt(titleWordCount) + Integer.parseInt(mdWordCount) + runningWordCount;
+                runningWordCount = titleWordCount + mdWordCount + runningWordCount;
             }
-            return runningWordCount.toString();
+            return Integer.toString(runningWordCount);
         }
 
         @Override
@@ -42,22 +42,24 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
             handlebars.registerHelper(this.name(), this);
         }
 
-        private String calculateWordCountFromMarkdown(String md, Options options) throws IOException {
+        private int calculateWordCountFromMarkdown(String md, Options options) throws IOException {
             if (md == null || md.isEmpty()) {
-                return "0";
+                return 0;
             }
 
             CustomMarkdownHelper mdHelper = new CustomMarkdownHelper();
             String mdHtml = mdHelper.apply(md, options).toString();
-            return StringHelper.wordCount.apply(mdHtml, options).toString();
+            String wordCount = StringHelper.wordCount.apply(mdHtml, options).toString();
+            return Integer.parseInt(wordCount);
         }
 
-        private String calculateWordCountFromSection(String title, Options options) throws IOException {
+        private int calculateWordCountFromSection(String title, Options options) throws IOException {
             if (title == null || title.isEmpty()) {
-                return "0";
+                return 0;
             }
 
-            return StringHelper.wordCount.apply(title, options).toString();
+            String wordCount = StringHelper.wordCount.apply(title, options).toString();
+            return Integer.parseInt(wordCount);
         }
 
         private boolean isEmpty(Object context, Options options) {

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
@@ -17,16 +17,18 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
     totalWordCount {
         @Override
         public CharSequence apply(Object context, Options options) throws IOException {
+            if (options.isFalsy(context)) {
+                return null;
+            }
+
             CustomMarkdownHelper mdHelper = new CustomMarkdownHelper();
             Integer runningWordCount = 0;
-            if (context != null) {
-                for (Object section : (List<Object>) context) {
-                    Map<String, String> sectionText = (Map<String, String>) section;
-                    String mdHtml = mdHelper.apply(sectionText.get("markdown"), options).toString();
-                    String mdWordCount = StringHelper.wordCount.apply(mdHtml, options).toString();
-                    String titleWordCount = StringHelper.wordCount.apply(sectionText.get("title"), options).toString();
-                    runningWordCount = Integer.parseInt(titleWordCount) + Integer.parseInt(mdWordCount) + runningWordCount;
-                }
+            for (Object section : (List<Object>) context) {
+                Map<String, String> sectionText = (Map<String, String>) section;
+                String mdHtml = mdHelper.apply(sectionText.get("markdown"), options).toString();
+                String mdWordCount = StringHelper.wordCount.apply(mdHtml, options).toString();
+                String titleWordCount = StringHelper.wordCount.apply(sectionText.get("title"), options).toString();
+                runningWordCount = Integer.parseInt(titleWordCount) + Integer.parseInt(mdWordCount) + runningWordCount;
             }
             return runningWordCount.toString();
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
@@ -1,0 +1,40 @@
+package com.github.onsdigital.babbage.template.handlebars.helpers;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Options;
+import com.github.onsdigital.babbage.template.handlebars.helpers.base.BabbageHandlebarsHelper;
+import com.github.onsdigital.babbage.template.handlebars.helpers.markdown.CustomMarkdownHelper;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by angela on 04/06/21.
+ */
+public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
+
+    totalWordCount {
+        @Override
+        public CharSequence apply(Object context, Options options) throws IOException {
+            CustomMarkdownHelper mdHelper = new CustomMarkdownHelper();
+            Integer runningWordCount = 0;
+            if (context != null) {
+                for (Object section : (List<Object>) context) {
+                    Map<String, String> sectionText = (Map<String, String>) section;
+                    String mdHtml = mdHelper.apply(sectionText.get("markdown"), options).toString();
+                    String mdWordCount = StringHelper.wordCount.apply(mdHtml, options).toString();
+                    String titleWordCount = StringHelper.wordCount.apply(sectionText.get("title"), options).toString();
+                    runningWordCount = Integer.parseInt(titleWordCount) + Integer.parseInt(mdWordCount) + runningWordCount;
+                }
+            }
+            return runningWordCount.toString();
+        }
+
+        @Override
+        public void register(Handlebars handlebars) {
+            handlebars.registerHelper(this.name(), this);
+        }
+    }
+}
+

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
@@ -5,6 +5,9 @@ import com.github.jknack.handlebars.Options;
 import com.github.onsdigital.babbage.template.handlebars.helpers.base.BabbageHandlebarsHelper;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Created by bren on 16/08/15.
@@ -55,7 +58,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
             if (options.isFalsy(context) || options.params.length == 0) {
                 return null;
             }
-            return context.startsWith(options.<String>param(0)) ? "true" : null;
+            return context.startsWith(options.param(0)) ? "true" : null;
         }
 
         @Override
@@ -70,7 +73,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
             if (options.isFalsy(context) || options.params.length == 0) {
                 return null;
             }
-            return context.endsWith(options.<String>param(0)) ? "true" : null;
+            return context.endsWith(options.param(0)) ? "true" : null;
         }
 
         @Override
@@ -99,5 +102,30 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
         public void register(Handlebars handlebars) {
             handlebars.registerHelper(this.name(), this);
         }
-    }
+    },
+
+    wordCount {
+        /**
+         * The HTML tag pattern.
+         */
+        private final Pattern pattern = Pattern.compile("\\<[^>]*>");
+
+        @Override
+        public CharSequence apply(String context, Options options) throws IOException {
+            if (options.isFalsy(context)) {
+                return null;
+            }
+
+            // First strip the html from the text
+            Matcher matcher = pattern.matcher(context);
+            String text = matcher.replaceAll("").toLowerCase();
+            Integer count = Arrays.stream(text.split(" ")).map(word -> word.trim()).filter(word -> word != null && !word.isEmpty()).toArray().length;
+            return count.toString();
+        }
+
+        @Override
+        public void register(Handlebars handlebars) {
+            handlebars.registerHelper(this.name(), this);
+        }
+    },
 }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
@@ -58,7 +58,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
             if (options.isFalsy(context) || options.params.length == 0) {
                 return null;
             }
-            return context.startsWith(options.param(0)) ? "true" : null;
+            return context.startsWith(options.<String>param(0)) ? "true" : null;
         }
 
         @Override
@@ -73,7 +73,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
             if (options.isFalsy(context) || options.params.length == 0) {
                 return null;
             }
-            return context.endsWith(options.param(0)) ? "true" : null;
+            return context.endsWith(options.<String>param(0)) ? "true" : null;
         }
 
         @Override

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
@@ -105,9 +105,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
     },
 
     wordCount {
-        /**
-         * The HTML tag pattern.
-         */
+        // HTML tag regex pattern
         private final Pattern pattern = Pattern.compile("\\<[^>]*>");
 
         @Override

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
@@ -105,8 +105,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
     },
 
     wordCount {
-        // HTML tag regex pattern
-        private final Pattern pattern = Pattern.compile("\\<[^>]*>");
+        private final Pattern htmlTagRegexPattern = Pattern.compile("\\<[^>]*>");
 
         @Override
         public CharSequence apply(String context, Options options) throws IOException {
@@ -115,7 +114,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
             }
 
             // First strip the html from the text
-            Matcher matcher = pattern.matcher(context);
+            Matcher matcher = htmlTagRegexPattern.matcher(context);
             String text = matcher.replaceAll("").toLowerCase();
             Integer count = Arrays.stream(text.split(" ")).map(word -> word.trim()).filter(word -> word != null && !word.isEmpty()).toArray().length;
             return count.toString();

--- a/src/main/web/templates/handlebars/partials/gtm-data-layer.handlebars
+++ b/src/main/web/templates/handlebars/partials/gtm-data-layer.handlebars
@@ -64,6 +64,12 @@
         {{/unless}}
     {{/if_any}}
 
+    {{!-- Add word count for sections to dataLayer --}}
+    {{#if_any (eq type "bulletin") (eq type "article")}}
+        {{#if sections}}
+            dataLayer[0]["wordCount"] = {{totalWordCount sections}}
+        {{/if}}
+    {{/if_any}}
 
     {{!-- Update Google Tag Manager data layer with information about corrections and notices --}}
     {{#if alerts}}

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
@@ -1,8 +1,5 @@
 package com.github.onsdigital.babbage.template.handlebars.helpers;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
-
 import com.github.jknack.handlebars.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,6 +9,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.*;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
 @RunWith(MockitoJUnitRunner.class)
 public class SectionsHelperTest {
 
@@ -19,7 +19,7 @@ public class SectionsHelperTest {
 
     @Before
     public void setup() throws Exception {
-        Map<String, String> uriMock =  new LinkedHashMap<>();
+        Map<String, String> uriMock = new LinkedHashMap<>();
         uriMock.put("uri", "/economy/bulletin/sometitle");
 
         Handlebars handlebars = Mockito.mock(Handlebars.class);
@@ -30,11 +30,11 @@ public class SectionsHelperTest {
         Context.Builder contextBuilder = Context.newBuilder(parentContext.build(), "test");
 
         Options.Builder builder = new Options.Builder(
-                                    handlebars,
-                                    "SectionsHelper",
-                                    tagType,
-                                    contextBuilder.build(),
-                                    template);
+                handlebars,
+                "SectionsHelper",
+                tagType,
+                contextBuilder.build(),
+                template);
         options = builder.build();
     }
 
@@ -42,7 +42,7 @@ public class SectionsHelperTest {
     public void testTotalWordCount_WithMarkdownSection_ReturnsCorrectCount() throws Exception {
         List<Map<String, String>> sections = new ArrayList<>();
 
-        Map<String, String> section1 =  new HashMap<>();
+        Map<String, String> section1 = new HashMap<>();
         section1.put("markdown", "- some test text");
         section1.put("title", "title example");
         sections.add(section1);
@@ -55,7 +55,7 @@ public class SectionsHelperTest {
     public void testTotalWordCount_WithPlainTextSection_ReturnsCorrectCount() throws Exception {
         List<Map<String, String>> sections = new ArrayList<>();
 
-        Map<String, String> section1 =  new HashMap<>();
+        Map<String, String> section1 = new HashMap<>();
         section1.put("markdown", "some different test text");
         section1.put("title", "title example 2");
         sections.add(section1);
@@ -68,7 +68,7 @@ public class SectionsHelperTest {
     public void testTotalWordCount_WithoutTitle_ReturnsCorrectCount() throws Exception {
         List<Map<String, String>> sections = new ArrayList<>();
 
-        Map<String, String> section1 =  new HashMap<>();
+        Map<String, String> section1 = new HashMap<>();
         section1.put("markdown", "some more test text");
         section1.put("title", "");
         sections.add(section1);
@@ -81,7 +81,7 @@ public class SectionsHelperTest {
     public void testTotalWordCount_WithoutMarkdownText_ReturnsCorrectCount() throws Exception {
         List<Map<String, String>> sections = new ArrayList<>();
 
-        Map<String, String> section1 =  new HashMap<>();
+        Map<String, String> section1 = new HashMap<>();
         section1.put("markdown", "");
         section1.put("title", "some example title");
         sections.add(section1);
@@ -94,12 +94,12 @@ public class SectionsHelperTest {
     public void testTotalWordCount_WithMultipleSections_ReturnsCorrectCount() throws Exception {
         List<Map<String, String>> sections = new ArrayList<>();
 
-        Map<String, String> section1 =  new HashMap<>();
+        Map<String, String> section1 = new HashMap<>();
         section1.put("markdown", "- some test text");
         section1.put("title", "title example 1");
         sections.add(section1);
 
-        Map<String, String> section2 =  new HashMap<>();
+        Map<String, String> section2 = new HashMap<>();
         section2.put("markdown", "some more test text");
         section2.put("title", "title example 2");
         sections.add(section2);

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
@@ -1,0 +1,14 @@
+package com.github.onsdigital.babbage.template.handlebars.helpers;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class SectionsHelperTest {
+
+
+
+}

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
@@ -1,14 +1,118 @@
 package com.github.onsdigital.babbage.template.handlebars.helpers;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import com.github.jknack.handlebars.*;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Answers;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.*;
+
+@RunWith(MockitoJUnitRunner.class)
 public class SectionsHelperTest {
 
+    private Options options;
 
+    @Before
+    public void setup() throws Exception {
+        Map<String, String> uriMock =  new LinkedHashMap<>();
+        uriMock.put("uri", "/economy/bulletin/sometitle");
 
+        Handlebars handlebars = Mockito.mock(Handlebars.class);
+        TagType tagType = Mockito.mock(TagType.class);
+        Template template = Mockito.mock(Template.class);
+
+        Context.Builder parentContext = Context.newBuilder(uriMock);
+        Context.Builder contextBuilder = Context.newBuilder(parentContext.build(), "test");
+
+        Options.Builder builder = new Options.Builder(
+                                    handlebars,
+                                    "SectionsHelper",
+                                    tagType,
+                                    contextBuilder.build(),
+                                    template);
+        options = builder.build();
+    }
+
+    @Test
+    public void testTotalWordCount_WithMarkdownSection_ReturnsCorrectCount() throws Exception {
+        List<Map<String, String>> sections = new ArrayList<>();
+
+        Map<String, String> section1 =  new HashMap<>();
+        section1.put("markdown", "- some test text");
+        section1.put("title", "title example");
+        sections.add(section1);
+
+        String result = SectionsHelper.totalWordCount.apply(sections, options).toString();
+        assertThat(result, equalTo("5"));
+    }
+
+    @Test
+    public void testTotalWordCount_WithPlainTextSection_ReturnsCorrectCount() throws Exception {
+        List<Map<String, String>> sections = new ArrayList<>();
+
+        Map<String, String> section1 =  new HashMap<>();
+        section1.put("markdown", "some different test text");
+        section1.put("title", "title example 2");
+        sections.add(section1);
+
+        String result = SectionsHelper.totalWordCount.apply(sections, options).toString();
+        assertThat(result, equalTo("7"));
+    }
+
+    @Test
+    public void testTotalWordCount_WithoutTitle_ReturnsCorrectCount() throws Exception {
+        List<Map<String, String>> sections = new ArrayList<>();
+
+        Map<String, String> section1 =  new HashMap<>();
+        section1.put("markdown", "some more test text");
+        section1.put("title", "");
+        sections.add(section1);
+
+        String result = SectionsHelper.totalWordCount.apply(sections, options).toString();
+        assertThat(result, equalTo("4"));
+    }
+
+    @Test
+    public void testTotalWordCount_WithoutMarkdownText_ReturnsCorrectCount() throws Exception {
+        List<Map<String, String>> sections = new ArrayList<>();
+
+        Map<String, String> section1 =  new HashMap<>();
+        section1.put("markdown", "");
+        section1.put("title", "some example title");
+        sections.add(section1);
+
+        String result = SectionsHelper.totalWordCount.apply(sections, options).toString();
+        assertThat(result, equalTo("3"));
+    }
+
+    @Test
+    public void testTotalWordCount_WithMultipleSections_ReturnsCorrectCount() throws Exception {
+        List<Map<String, String>> sections = new ArrayList<>();
+
+        Map<String, String> section1 =  new HashMap<>();
+        section1.put("markdown", "- some test text");
+        section1.put("title", "title example 1");
+        sections.add(section1);
+
+        Map<String, String> section2 =  new HashMap<>();
+        section2.put("markdown", "some more test text");
+        section2.put("title", "title example 2");
+        sections.add(section2);
+
+        String result = SectionsHelper.totalWordCount.apply(sections, options).toString();
+        assertThat(result, equalTo("13"));
+    }
+
+    @Test
+    public void testTotalWordCount_WithNoSections_ReturnsNull() throws Exception {
+        List<Map<String, String>> sections = new ArrayList<>();
+
+        CharSequence result = SectionsHelper.totalWordCount.apply(sections, options);
+        assertThat(result, equalTo(null));
+    }
 }

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelperTest.java
@@ -1,16 +1,16 @@
 package com.github.onsdigital.babbage.template.handlebars.helpers;
 
+import com.github.jknack.handlebars.Options;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-
-import com.github.jknack.handlebars.Options;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StringHelperTest {

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelperTest.java
@@ -9,7 +9,6 @@ import com.github.jknack.handlebars.Options;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -51,7 +50,7 @@ public class StringHelperTest {
     @Test
     public void testWordCount_WithEmptyString_ReturnsNull() throws Exception {
         when(options.isFalsy(any())).thenReturn(true);
-        String result = StringHelper.wordCount.apply("", options).toString();
+        CharSequence result = StringHelper.wordCount.apply("", options);
         assertThat(result, equalTo(null));
     }
 }

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelperTest.java
@@ -1,0 +1,57 @@
+package com.github.onsdigital.babbage.template.handlebars.helpers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import com.github.jknack.handlebars.Options;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StringHelperTest {
+
+    @Mock
+    private Options options;
+
+    @Before
+    public void setup() throws Exception {
+        when(options.isFalsy(any())).thenReturn(false);
+    }
+
+    @Test
+    public void testWordCount_WithHTMLString_ReturnsCorrectCount() throws Exception {
+        String result = StringHelper.wordCount.apply("<h1>some title</h1>", options).toString();
+        assertThat(result, equalTo("2"));
+    }
+
+    @Test
+    public void testWordCount_WithNoHTML_ReturnsCorrectCount() throws Exception {
+        String result = StringHelper.wordCount.apply("some more test words", options).toString();
+        assertThat(result, equalTo("4"));
+    }
+
+    @Test
+    public void testWordCount_WithSymbol_ReturnsCorrectCount() throws Exception {
+        String result = StringHelper.wordCount.apply("with punctuation symbol!", options).toString();
+        assertThat(result, equalTo("3"));
+    }
+
+    @Test
+    public void testWordCount_WithWhiteSpace_ReturnsZero() throws Exception {
+        String result = StringHelper.wordCount.apply(" ", options).toString();
+        assertThat(result, equalTo("0"));
+    }
+
+    @Test
+    public void testWordCount_WithEmptyString_ReturnsNull() throws Exception {
+        when(options.isFalsy(any())).thenReturn(true);
+        String result = StringHelper.wordCount.apply("", options).toString();
+        assertThat(result, equalTo(null));
+    }
+}


### PR DESCRIPTION
### What

Added word counts to the data layer of bulletins and articles pages

### How to review

Pull the changes from this branch into local babbage instance.
Run web stack.
Navigate to an article or bulletin page.
Open browser developer console and run the following javascript: `console.log(dataLayer[0])`.
In the result object you should see a wordCount property with the total number words in all sections on the page.

### Who can review

Anyone
