### PR TITLE
Refactor template service

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/highcharts/ChartRenderer.java
+++ b/src/main/java/com/github/onsdigital/babbage/highcharts/ChartRenderer.java
@@ -9,6 +9,8 @@ import com.github.onsdigital.babbage.response.BabbageContentBasedStringResponse;
 import com.github.onsdigital.babbage.response.BabbageStringResponse;
 import com.github.onsdigital.babbage.response.base.BabbageResponse;
 import com.github.onsdigital.babbage.template.TemplateService;
+import com.github.onsdigital.babbage.util.json.JsonUtil;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -128,7 +130,7 @@ public class ChartRenderer {
         if (assertUri(uri, request, response)) {
             ContentResponse contentResponse = contentClient.getContent(uri);
             String jsonRequest = contentResponse.getAsString();
-            Map<String, Object> json = (Map<String, Object>) templateService.sanitize(jsonRequest);
+            Map<String, Object> json = JsonUtil.toMap(jsonRequest);
             Integer width = getWidth(request);
             Map<String, Object> additionalData = new ChartConfigBuilder().width(width).getMap();
             InputStream imageInputStream = null;

--- a/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
@@ -103,7 +103,7 @@ public class TemplateService {
     }
 
     /*Converts object into map if json string or json input stream*/
-    public static Object sanitize(Object data) throws IOException {
+    private static Object sanitize(Object data) throws IOException {
         if (data instanceof String) {
             return toMap((String) data);
         } else if (data instanceof InputStream) {

--- a/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
@@ -2,11 +2,11 @@ package com.github.onsdigital.babbage.template;
 
 import com.github.onsdigital.babbage.template.handlebars.HandlebarsRenderer;
 import com.github.onsdigital.babbage.util.ThreadContext;
-import org.apache.commons.lang3.ArrayUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
@@ -86,7 +86,7 @@ public class TemplateService {
      * @throws IOException
      */
     public String renderTemplate(String templateName, Object data) throws IOException {
-        return renderTemplate(templateName, data, ThreadContext.getAllData());
+        return renderTemplate(templateName, data, null);
     }
 
     /**
@@ -114,13 +114,18 @@ public class TemplateService {
     }
 
     /**
-     * Add current thread context to map array
+     * Returns a new map containing all elements in the map passed as parameter plus the current thread context
      *
      * @param data
      * @return
      */
-    private Map<String, Object>[] addThreadContext(Map<String, Object>... data) {
-        return ArrayUtils.add(data, ThreadContext.getAllData());
+    private Map<String, Object> addThreadContext(Map<String, Object> data) {
+        Map<String, Object> r = new HashMap<String, Object>();
+        if (data != null) {
+            r.putAll(data);
+        }
+        r.putAll(ThreadContext.getAllData());
+        return r;
     }
 
 }

--- a/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
@@ -31,15 +31,27 @@ public class TemplateService {
         return instance;
     }
 
+    
     /**
      * Renders data using main template, current ThreadContext data is added to context as additional data
      *
      * @param data           Main data to render template with
-     * @param additionalData optional additional data map, map keys will be set as the object name when combined with main data
      * @return
      * @throws IOException
      */
-    public String renderContent(Object data, Map<String, Object>... additionalData) throws IOException {
+    public String renderContent(Object data) throws IOException {
+        return renderContent(data, null);
+    }
+    
+    /**
+     * Renders data using main template, current ThreadContext data is added to context as additional data
+     *
+     * @param data           Main data to render template with
+     * @param additionalData additional data map, map keys will be set as the object name when combined with main data
+     * @return
+     * @throws IOException
+     */
+    public String renderContent(Object data, Map<String, Object> additionalData) throws IOException {
         return renderer.render(appConfig().handlebars().getMainContentTemplateName(), sanitize(data), addThreadContext(additionalData));
     }
 
@@ -47,11 +59,11 @@ public class TemplateService {
      * Renders chart configuration using main chart configuration template, current ThreadContext data is added to context as additional data
      *
      * @param data           Main data to render template with
-     * @param additionalData optional additional data map, map keys will be set as the object name when combined with main data
+     * @param additionalData additional data map, map keys will be set as the object name when combined with main data
      * @return
      * @throws IOException
      */
-    public String renderChartConfiguration(Object data, Map<String, Object>... additionalData) throws IOException {
+    public String renderChartConfiguration(Object data, Map<String, Object> additionalData) throws IOException {
         return renderer.render(appConfig().handlebars().getMainChartConfigTemplateName(), sanitize(data), addThreadContext(additionalData));
     }
 
@@ -63,7 +75,18 @@ public class TemplateService {
      * @throws IOException
      */
     public String renderTemplate(String templateName) throws IOException {
-        return renderer.render(templateName, Collections.emptyMap(), ThreadContext.getAllData());
+        return renderTemplate(templateName, Collections.emptyMap());
+    }
+
+    /**
+     * Renders template with given name using given data and current thread context
+     *
+     * @param templateName
+     * @return
+     * @throws IOException
+     */
+    public String renderTemplate(String templateName, Object data) throws IOException {
+        return renderTemplate(templateName, data, ThreadContext.getAllData());
     }
 
     /**
@@ -71,11 +94,11 @@ public class TemplateService {
      *
      * @param templateName
      * @param data
-     * @param additionalData optional additional data
+     * @param additionalData additional data
      * @return
      * @throws IOException
      */
-    public String renderTemplate(String templateName, Object data, Map<String, Object>... additionalData) throws IOException {
+    public String renderTemplate(String templateName, Object data, Map<String, Object> additionalData) throws IOException {
         return renderer.render(templateName, sanitize(data), addThreadContext(additionalData));
     }
 

--- a/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/TemplateService.java
@@ -52,7 +52,8 @@ public class TemplateService {
      * @throws IOException
      */
     public String renderContent(Object data, Map<String, Object> additionalData) throws IOException {
-        return renderer.render(appConfig().handlebars().getMainContentTemplateName(), sanitize(data), addThreadContext(additionalData));
+        String templateName = appConfig().handlebars().getMainContentTemplateName();
+        return renderTemplate(templateName, data, additionalData);
     }
 
     /**
@@ -64,7 +65,8 @@ public class TemplateService {
      * @throws IOException
      */
     public String renderChartConfiguration(Object data, Map<String, Object> additionalData) throws IOException {
-        return renderer.render(appConfig().handlebars().getMainChartConfigTemplateName(), sanitize(data), addThreadContext(additionalData));
+        String templateName = appConfig().handlebars().getMainChartConfigTemplateName();
+        return renderTemplate(templateName, data, additionalData);
     }
 
     /**

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/HandlebarsRenderer.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/HandlebarsRenderer.java
@@ -59,7 +59,7 @@ public class HandlebarsRenderer {
      * @return
      * @throws IOException
      */
-    public String render(String templateName, Object data, Map<String, Object>... additionalData) throws IOException {
+    public String render(String templateName, Object data, Map<String, Object> additionalData) throws IOException {
         Template template = getTemplate(templateName);
 
         Context.Builder builder = Context
@@ -67,13 +67,8 @@ public class HandlebarsRenderer {
                 .resolver(MapValueResolver.INSTANCE, FieldValueResolver.INSTANCE);
 
         if (additionalData != null) {
-            for (Map<String, Object> next : additionalData) {
-                if (next != null) {
-                    for (Map.Entry<String, Object> entry : next.entrySet()) {
-                        builder.combine(entry.getKey(), entry.getValue());
-                    }
-                }
-
+            for (Map.Entry<String, Object> entry : additionalData.entrySet()) {
+                builder.combine(entry.getKey(), entry.getValue());
             }
 
         }


### PR DESCRIPTION
### What

The public `renderXXX` methods are accepting a var args of type `Map<String, Object>`  only to make that parameter optional. It never receives multiple values but in some cases we don't provide one. 

Also, having varargs of a generic object creates a type safety issue since the compiler will remove the generic type and convert it to an array of raw types (in this case `Map[]`). There is the danger that developers will mistakenly assign incorrect values and the compiler will not trigger any error. 

Removing the varargs parameter and providing overloaded methods without the `additionalData` parameter to keep it optional. 

Additionally, reduced the visibility of the `sanitize` method that should not be exposed. And made `renderContent` and `renderChartConfiguration` call `renderTemplate` to remove code duplication.

### How to review

Check the change makes sense and tests pass.
Ensure pages are still rendered correctly

### Who can review

Anyone
