### PR TITLE
Fix health check path

### DIFF
--- a/babbage.nomad
+++ b/babbage.nomad
@@ -66,7 +66,7 @@ job "babbage" {
 
         check {
           type     = "http"
-          path     = "/healthcheck"
+          path     = "/health"
           interval = "10s"
           timeout  = "2s"
         }
@@ -143,7 +143,7 @@ job "babbage" {
 
         check {
           type     = "http"
-          path     = "/healthcheck"
+          path     = "/health"
           interval = "10s"
           timeout  = "2s"
         }

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/Health.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/Health.java
@@ -6,17 +6,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
 import javax.ws.rs.core.Context;
-import java.io.IOException;
-
-/**
- * Created by mrout on 29/08/2017.
- */
 
 @Api
-public class Healthcheck {
+public class Health {
 
     @GET
-    public void get(@Context HttpServletRequest request, @Context HttpServletResponse response) throws IOException {
+    public void get(@Context HttpServletRequest request, @Context HttpServletResponse response) {
         response.setStatus(HttpServletResponse.SC_OK);
     }
 }


### PR DESCRIPTION
### What

Babbage was using the outdated standard endpoint for its health check.
Update it to ensure it is at least as compliant with the standard as the
other legacy java apps.

### How to review

Sanity check change

### Who can review

Anyone
