### PR TITLE
Hide emergency banner when no content

### DIFF
--- a/src/main/web/templates/handlebars/partials/banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/banner.handlebars
@@ -1,5 +1,5 @@
 {{#resolve "/"}}
-  {{#if emergencyBanner}}
+  {{#if_all emergencyBanner emergencyBanner.title}}
     <div class="emergency-banner emergency-banner--{{replace emergencyBanner.type "_" "-"}}" role="banner" data-nosnippet="">
     	<div class="wrapper">
 			<div class="col-wrap">
@@ -13,7 +13,7 @@
 			</div>
     	</div>
 	</div>
-  {{/if}}
+  {{/if_all}}
   {{#if serviceMessage}}
     <div class="banner">
       <div class="wrapper banner--half-padding banner--bottom-border">


### PR DESCRIPTION
### What

Currently an empty emergency banner is showing at the top of all pages rendered by babbage. This is because an `"emergencyBanner":{}` is present in the homepage data.json. 
This fix will hide the emergency banner when there is no content, following a similar approach to the one in [dp-renderer](https://github.com/ONSdigital/dp-renderer/blob/8d0b90703c47fbabc6bb4ebeab2b25eaf6de75dd/assets/templates/partials/header.tmpl#L3)

### How to review

Check changes make sense

### Who can review

Anyone
