### PR TITLE
Add endpoints returning the cache max age 

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/MaxAge.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/MaxAge.java
@@ -1,0 +1,64 @@
+package com.github.onsdigital.babbage.api.endpoint.content;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Context;
+
+import com.github.davidcarboni.cryptolite.Password;
+import com.github.davidcarboni.restolino.framework.Api;
+import com.github.onsdigital.babbage.content.client.ContentClient;
+import com.github.onsdigital.babbage.content.client.ContentReadException;
+import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.error.BabbageException;
+import com.github.onsdigital.babbage.error.BadRequestException;
+import com.github.onsdigital.logging.v2.event.SimpleEvent;
+
+/**
+ * End point for getting the maxAge for the given uri
+ */
+@Api
+public class MaxAge {
+    private static final String MAXAGE_KEY_HASH = "e9xUWB/CF33u6jd/f2yOgWIs+ig8P8OIP3VC7c6U1NZHZgpzp6nsXQVLnpIluJv0";
+
+    @GET
+    public Object get(@Context HttpServletRequest request, @Context HttpServletResponse response) throws IOException {
+        try {
+            String key = request.getParameter("key");
+            if (verifyKey(key)) {
+                return getMaxAge(request);
+            } else {
+                throw new BadRequestException("Wrong key, make sure you pass in the right key");
+            }
+        } catch (ContentReadException e) {
+            return handleError(response, e.getStatusCode(), e);
+        } catch (BabbageException e) {
+            response.setStatus(e.getStatusCode());
+            return e.getMessage();
+        } catch (Throwable t) {
+            return handleError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, t);
+        }
+    }
+
+    private String handleError(@Context HttpServletResponse response, int statusCode, Throwable e) throws IOException {
+        SimpleEvent.error().exception(e).log("api " + getApiName() + ": error calculating max age");
+        response.setStatus(statusCode);
+        return "Failed calculating max age";
+    }
+
+    protected boolean verifyKey(String key) {
+        return Password.verify(key, MAXAGE_KEY_HASH);
+    }
+
+    protected int getMaxAge(HttpServletRequest request) throws Exception {
+        String uri = request.getParameter("uri");
+        ContentResponse contentResponse = ContentClient.getInstance().getContent(uri);
+        return contentResponse.getMaxAge();
+    }
+
+    protected String getApiName() {
+        return "MaxAge";
+    }
+}

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/ReleaseCalendarMaxAge.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/ReleaseCalendarMaxAge.java
@@ -1,0 +1,74 @@
+package com.github.onsdigital.babbage.api.endpoint.content;
+
+import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.elasticsearch.index.query.QueryBuilders;
+
+import com.github.davidcarboni.restolino.framework.Api;
+import com.github.onsdigital.babbage.api.util.SearchUtils;
+import com.github.onsdigital.babbage.request.handler.list.ReleaseCalendar;
+import com.github.onsdigital.babbage.search.builders.ONSQueryBuilders;
+import com.github.onsdigital.babbage.search.helpers.ONSQuery;
+import com.github.onsdigital.babbage.search.helpers.base.SearchFilter;
+import com.github.onsdigital.babbage.search.input.SortBy;
+import com.github.onsdigital.babbage.search.model.ContentType;
+import com.github.onsdigital.babbage.search.model.SearchResult;
+import com.github.onsdigital.babbage.search.model.field.Field;
+
+/**
+ * End point for getting the maxAge for the /releasecalendar
+ */
+@Api
+public class ReleaseCalendarMaxAge extends MaxAge {
+    private static final DateFormat DATE_FORMAT = appConfig().contentAPI().defaultContentDateFormat();
+    private static final String QUERY_NAME = "nextRelease";
+
+    @Override
+    protected int getMaxAge(HttpServletRequest request) throws Exception {
+        int maxAge = appConfig().babbage().getDefaultContentCacheTime();
+        
+        Date nextReleaseDate = getNextReleaseDate();
+        Date now = new Date();
+
+        if (nextReleaseDate != null && nextReleaseDate.after(now)) {
+            Long secondsUntilNextRelease = (nextReleaseDate.getTime() - now.getTime()) / 1000;
+            if (secondsUntilNextRelease < maxAge) {
+                maxAge = secondsUntilNextRelease.intValue();
+            }
+        }
+        return maxAge;
+    }
+
+    @Override
+    protected String getApiName() {
+        return "ReleaseCalendarMaxAge";
+    }
+
+    protected Date getNextReleaseDate() throws ParseException {
+        Date nextRelease = null;
+
+        SearchFilter filter = ReleaseCalendar::filterUpcoming;
+        ONSQuery query = ONSQueryBuilders.onsQuery(QueryBuilders.matchAllQuery(), filter)
+                .name(QUERY_NAME)
+                .types(ContentType.release)
+                .fetchFields(Field.releaseDate)
+                .size(1)
+                .sortBy(SortBy.release_date_asc);
+        Map<String, SearchResult> result = SearchUtils.searchAll(() -> ONSQueryBuilders.toList(query));
+
+        if (result.get(QUERY_NAME).getResults().size() > 0) {
+            // There will be just 1 result
+            Map<String, String> description = ((Map<String, String>) result.get(QUERY_NAME).getResults().get(0).get("description"));
+            nextRelease = DATE_FORMAT.parse(description.get("releaseDate"));
+        }
+        return nextRelease;
+        
+    }
+}

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/service/RssService.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/rss/service/RssService.java
@@ -12,7 +12,6 @@ import com.github.onsdigital.babbage.search.input.SortBy;
 import com.github.onsdigital.babbage.search.model.ContentType;
 import com.github.onsdigital.babbage.search.model.SearchResult;
 import com.github.onsdigital.babbage.search.model.field.Field;
-import com.github.onsdigital.babbage.util.ThreadContext;
 import com.sun.syndication.feed.synd.SyndEntry;
 import com.sun.syndication.feed.synd.SyndFeed;
 import org.apache.commons.lang3.StringUtils;
@@ -20,15 +19,13 @@ import org.elasticsearch.index.query.QueryBuilders;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.github.onsdigital.babbage.search.builders.ONSQueryBuilders.toList;
 import static com.github.onsdigital.babbage.search.model.field.Field.releaseDate;
-import static com.github.onsdigital.babbage.util.RequestUtil.LOCATION_KEY;
-import static com.github.onsdigital.babbage.util.RequestUtil.Location;
 import static org.apache.commons.lang3.StringUtils.endsWith;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.prefixQuery;
@@ -179,7 +176,7 @@ public class RssService {
     }
 
     private Optional<SearchResult> search(SearchQueries searchQueries) {
-        LinkedHashMap<String, SearchResult> results = SearchUtils.searchAll(searchQueries);
+        Map<String, SearchResult> results = SearchUtils.searchAll(searchQueries);
         return Optional.ofNullable(results.get(RESULTS_KEY));
     }
 

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/search/AtoZ.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/search/AtoZ.java
@@ -19,7 +19,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.github.onsdigital.babbage.api.util.SearchUtils.buildBaseListQuery;
@@ -58,7 +57,7 @@ public class AtoZ {
 
     }
 
-    private LinkedHashMap<String, SearchResult> list(HttpServletRequest request, String firstLetter) throws IOException {
+    private Map<String, SearchResult> list(HttpServletRequest request, String firstLetter) throws IOException {
         return SearchUtils.searchAll(queries(request, firstLetter));
     }
 

--- a/src/main/java/com/github/onsdigital/babbage/api/util/SearchUtils.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/util/SearchUtils.java
@@ -25,7 +25,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,8 +61,8 @@ public class SearchUtils {
      * Performs search for requested search term against filtered content types and counts contents types.
      * Content results are serialised into json with key "result" and document counts are serialised as "counts".
      */
-    public static LinkedHashMap<String, SearchResult> search(String searchTerm, SearchQueries queries, boolean searchDepartments) throws IOException {
-        LinkedHashMap<String, SearchResult> results = null;
+    public static Map<String, SearchResult> search(String searchTerm, SearchQueries queries, boolean searchDepartments) throws IOException {
+        Map<String, SearchResult> results = null;
         if (searchTerm != null) {
             results = searchAll(queries);
             if (searchDepartments) {
@@ -94,7 +93,7 @@ public class SearchUtils {
     }
 
     // Execute the given search queries with internal service.
-    public static LinkedHashMap<String, SearchResult> searchAll(SearchQueries searchQueries) {
+    public static Map<String, SearchResult> searchAll(SearchQueries searchQueries) {
         List<ONSQuery> queries = searchQueries.buildQueries();
         return doSearch(queries);
     }
@@ -179,9 +178,9 @@ public class SearchUtils {
                 .highlight(true);
     }
 
-    static LinkedHashMap<String, SearchResult> doSearch(List<ONSQuery> searchQueries) {
+    static Map<String, SearchResult> doSearch(List<ONSQuery> searchQueries) {
         List<ONSSearchResponse> responseList = SearchHelper.searchMultiple(searchQueries);
-        LinkedHashMap<String, SearchResult> results = new LinkedHashMap<>();
+        Map<String, SearchResult> results = new LinkedHashMap<>();
         for (int i = 0; i < responseList.size(); i++) {
             ONSSearchResponse response = responseList.get(i);
             results.put(searchQueries.get(i).name(), response.getResult());
@@ -204,7 +203,7 @@ public class SearchUtils {
         return (String) timeSeries.get(Field.uri.fieldName());
     }
 
-    private static void searchDeparments(String searchTerm, LinkedHashMap<String, SearchResult> results) {
+    private static void searchDeparments(String searchTerm, Map<String, SearchResult> results) {
         QueryBuilder departmentsQuery = departmentQuery(searchTerm);
         SearchRequestBuilder departmentsSearch = ElasticSearchClient.getElasticsearchClient().prepareSearch(DEPARTMENTS_INDEX);
         departmentsSearch.setQuery(departmentsQuery);
@@ -226,7 +225,7 @@ public class SearchUtils {
     }
 
 
-    public static HashMap<String, SearchResult> searchTimeseriesForUri(String uriString) {
+    public static Map<String, SearchResult> searchTimeseriesForUri(String uriString) {
         QueryBuilder builder = QueryBuilders.matchAllQuery();
         SortBy sortByReleaseDate = SortBy.release_date;
 

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/TimeseriesLandingRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/TimeseriesLandingRequestHandler.java
@@ -11,7 +11,6 @@ import com.github.onsdigital.babbage.search.model.SearchResult;
 import com.github.onsdigital.babbage.util.URIUtil;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -62,7 +61,7 @@ public class TimeseriesLandingRequestHandler extends BaseRequestHandler {
 
     public static String getLatestTimeseriesUri(String uri) {
         // search the timeseries that live under this CDID
-        HashMap<String, SearchResult> data = SearchUtils.searchTimeseriesForUri(uri);
+        Map<String, SearchResult> data = SearchUtils.searchTimeseriesForUri(uri);
 
         List<Map<String, Object>> results = data.get("result").getResults();
         if (results.size() == 0) {

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/list/ReleaseCalendar.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/list/ReleaseCalendar.java
@@ -84,13 +84,13 @@ public class ReleaseCalendar extends BaseRequestHandler implements ListRequestHa
 		};
 	}
 
-	private void filterUpcoming(BoolQueryBuilder query) {
+	public static void filterUpcoming(BoolQueryBuilder query) {
 		QueryBuilder notPublishedNotCancelled = and(not(published()), not(cancelled()));
 		QueryBuilder cancelledButNotDue = and(cancelled(), not(due()));
 		query.filter(or(notPublishedNotCancelled, cancelledButNotDue));
 	}
 
-	private void filterPublished(BoolQueryBuilder query) {
+	public static void filterPublished(BoolQueryBuilder query) {
 		QueryBuilder publishedNotCancelled = and(published(), not(cancelled()));
 		QueryBuilder cancelledAndDue = and(cancelled(), due());
 		query.filter(or(publishedNotCancelled, cancelledAndDue));
@@ -103,28 +103,28 @@ public class ReleaseCalendar extends BaseRequestHandler implements ListRequestHa
 	}
 
 
-	private QueryBuilder published() {
+	private static QueryBuilder published() {
 		return termQuery(Field.published.fieldName(), true);
 	}
 
-	private QueryBuilder cancelled() {
+	private static QueryBuilder cancelled() {
 		return termQuery(Field.cancelled.fieldName(), true);
 	}
 
-	private QueryBuilder due() {
+	private static QueryBuilder due() {
 		return rangeQuery(Field.releaseDate.fieldName()).to(new Date());
 	}
 
-	private QueryBuilder not(QueryBuilder query) {
+	private static QueryBuilder not(QueryBuilder query) {
 		return boolQuery().mustNot(query);
 	}
 
 	//Or query for given two queries. Database would help a lot , wouldn't it ?
-	private QueryBuilder or(QueryBuilder q1, QueryBuilder q2) {
+	private static QueryBuilder or(QueryBuilder q1, QueryBuilder q2) {
 		return boolQuery().should(q1).should(q2);
 	}
 
-	private QueryBuilder and(QueryBuilder q1, QueryBuilder q2) {
+	private static QueryBuilder and(QueryBuilder q1, QueryBuilder q2) {
 		return boolQuery().must(q1).must(q2);
 	}
 

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpers.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpers.java
@@ -15,7 +15,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,7 +109,7 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
                 validateUri(uri);
                 String uriString = (String) uri;
 
-                HashMap<String, SearchResult> results = SearchUtils.searchTimeseriesForUri(uriString);
+                Map<String, SearchResult> results = SearchUtils.searchTimeseriesForUri(uriString);
                 LinkedHashMap<String, Object> data = SearchRendering.buildResults("list", results);
 
                 assign(options, data);

--- a/src/test/java/com/github/onsdigital/babbage/api/endpoint/content/MaxAgeTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/api/endpoint/content/MaxAgeTest.java
@@ -1,0 +1,77 @@
+package com.github.onsdigital.babbage.api.endpoint.content;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import com.github.onsdigital.babbage.content.client.ContentReadException;
+
+public class MaxAgeTest {
+    private final static String KEY_HASH = "the-key";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    @Spy
+    private MaxAge endpoint;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(endpoint.verifyKey(KEY_HASH)).thenReturn(true);
+    }
+
+    @Test
+    public void testGetNoKey() throws Exception {
+        Object result = endpoint.get(request, response);
+        assertEquals("Wrong key, make sure you pass in the right key", result);
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testGetWrongKey() throws Exception {
+        when(request.getParameter("key")).thenReturn("wrong");
+
+        Object result = endpoint.get(request, response);
+        assertEquals("Wrong key, make sure you pass in the right key", result);
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testGetEndpointErrorReadingContent() throws Exception {
+        when(request.getParameter("key")).thenReturn(KEY_HASH);
+        
+        ContentReadException ex = new ContentReadException(HttpServletResponse.SC_NOT_FOUND, "Content not found");
+        doThrow(ex).when(endpoint).getMaxAge(request);
+
+        assertEquals("Failed calculating max age", endpoint.get(request, response));
+        verify(response).setStatus(ex.getStatusCode());
+    }
+
+    @Test
+    public void testGetEndpoint() throws Exception {
+        int maxAge = 55;
+        when(request.getParameter("key")).thenReturn(KEY_HASH);
+        doReturn(maxAge).when(endpoint).getMaxAge(request);
+
+        assertEquals(maxAge, endpoint.get(request, response));
+    }
+
+}

--- a/src/test/java/com/github/onsdigital/babbage/api/endpoint/content/ReleaseCalendarMaxAgeTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/api/endpoint/content/ReleaseCalendarMaxAgeTest.java
@@ -1,0 +1,94 @@
+package com.github.onsdigital.babbage.api.endpoint.content;
+
+import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Date;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+public class ReleaseCalendarMaxAgeTest {
+    private final static String KEY_HASH = "the-key";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    @Spy
+    private ReleaseCalendarMaxAge endpoint;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(endpoint.verifyKey(KEY_HASH)).thenReturn(true);
+    }
+
+    @Test
+    public void testGetNoKey() throws Exception {
+        Object result = endpoint.get(request, response);
+        assertEquals("Wrong key, make sure you pass in the right key", result);
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testGetWrongKey() throws Exception {
+        when(request.getParameter("key")).thenReturn("wrong");
+
+        Object result = endpoint.get(request, response);
+        assertEquals("Wrong key, make sure you pass in the right key", result);
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testGetEndpoint() throws Exception {
+        when(request.getParameter("key")).thenReturn(KEY_HASH);
+        
+        int expectedMaxAge = 100;
+        
+        Instant nextReleaseDate = Instant.now().plusSeconds(expectedMaxAge);
+        doReturn(Date.from(nextReleaseDate)).when(endpoint).getNextReleaseDate();
+
+        int maxAge = (int) endpoint.get(request, response);
+        // Check max age is as expected with 1 second tolerance
+        assertTrue(expectedMaxAge-maxAge < 2);
+    }
+
+    @Test
+    public void testGetEndpointWithoutNextRelease() throws Exception {
+        when(request.getParameter("key")).thenReturn(KEY_HASH);
+
+        doReturn(null).when(endpoint).getNextReleaseDate();
+
+        int expectedMaxAge = appConfig().babbage().getDefaultContentCacheTime();
+        assertEquals(expectedMaxAge, endpoint.get(request, response));
+    }
+
+    @Test
+    public void testGetEndpointNextReleaseInThePast() throws Exception {
+        // This scenario should never happen but added for completeness
+        when(request.getParameter("key")).thenReturn(KEY_HASH);
+
+        Instant nextReleaseDate = Instant.now().minusSeconds(10);
+        doReturn(Date.from(nextReleaseDate)).when(endpoint).getNextReleaseDate();
+
+        int expectedMaxAge = appConfig().babbage().getDefaultContentCacheTime();
+        assertEquals(expectedMaxAge, endpoint.get(request, response));
+    }
+}

--- a/src/test/java/com/github/onsdigital/babbage/api/endpoint/content/ReleaseCalendarMaxAgeTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/api/endpoint/content/ReleaseCalendarMaxAgeTest.java
@@ -63,7 +63,7 @@ public class ReleaseCalendarMaxAgeTest {
         int expectedMaxAge = 100;
         
         Instant nextReleaseDate = Instant.now().plusSeconds(expectedMaxAge);
-        doReturn(Date.from(nextReleaseDate)).when(endpoint).getNextReleaseDate();
+        doReturn(nextReleaseDate).when(endpoint).getNextReleaseDate();
 
         int maxAge = (int) endpoint.get(request, response);
         // Check max age is as expected with 1 second tolerance
@@ -86,7 +86,7 @@ public class ReleaseCalendarMaxAgeTest {
         when(request.getParameter("key")).thenReturn(KEY_HASH);
 
         Instant nextReleaseDate = Instant.now().minusSeconds(10);
-        doReturn(Date.from(nextReleaseDate)).when(endpoint).getNextReleaseDate();
+        doReturn(nextReleaseDate).when(endpoint).getNextReleaseDate();
 
         int expectedMaxAge = appConfig().babbage().getDefaultContentCacheTime();
         assertEquals(expectedMaxAge, endpoint.get(request, response));


### PR DESCRIPTION
### What

Create two new endpoints returning the value needed for the cache max age header:
- For a given content page URI: time remaining until the next publication
- For the release calendar: time remaining until the next release

Note the returned value will never be higher than the default cache time, [configured to 15 minutes](https://github.com/ONSdigital/babbage/blob/9e8b02804ccf488690974c53e1a91704aeed550e/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java#L66)

https://trello.com/c/jo3rrzgN/748-add-cache-headers

### How to review

Check code and unit tests.
Endpoints can be accessed: (reach out for the valid `{KEY}` value)
- `GET http://localhost:8080/maxage?uri={URI}&key={KEY}`
- `GET http://localhost:8080/releasecalendarmaxage?key={KEY}`

Note: reach out for the valid `{KEY}` value

You'll need to have content/release due to be published in the next 15 minutes for the returned value to be different to `900`. Alternatively, you can increase [the default cache time](https://github.com/ONSdigital/babbage/blob/9e8b02804ccf488690974c53e1a91704aeed550e/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java#L66)


### Who can review

Not me