### PR TITLE
Download Welsh PDFs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.5.6</powermock.version>
         <dp-logging.version>v2.0.0-beta.2</dp-logging.version>
-        <fasterxml.jackson.version>2.13.3</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
         <jetty.version>9.4.46.v20220331</jetty.version>
         <flying-saucer.version>9.1.22</flying-saucer.version>
     </properties>

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentClient.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentClient.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.babbage.content.client;
 import com.github.onsdigital.babbage.error.ResourceNotFoundException;
 import com.github.onsdigital.babbage.publishing.PublishingManager;
 import com.github.onsdigital.babbage.publishing.model.PublishInfo;
+import com.github.onsdigital.babbage.util.RequestUtil;
 import com.github.onsdigital.babbage.util.ThreadContext;
 import com.github.onsdigital.babbage.util.http.ClientConfiguration;
 import com.github.onsdigital.babbage.util.http.PooledHttpClient;
@@ -275,7 +276,7 @@ public class ContentClient {
     private List<NameValuePair> getParameters(Map<String, String[]> parametes) {
         List<NameValuePair> nameValuePairs = new ArrayList<>();
 
-        nameValuePairs.add(new BasicNameValuePair("lang", (String) ThreadContext.getData("lang")));
+        nameValuePairs.add(new BasicNameValuePair("lang", (String) ThreadContext.getData(RequestUtil.LANG_KEY)));
         nameValuePairs.addAll(toNameValuePair(parametes));
         return nameValuePairs;
     }

--- a/src/main/java/com/github/onsdigital/babbage/locale/LocaleConfig.java
+++ b/src/main/java/com/github/onsdigital/babbage/locale/LocaleConfig.java
@@ -38,7 +38,7 @@ public class LocaleConfig {
         try {
             return LoadProperties("LabelsBundle.properties");
         } catch (IOException e) {
-            throw new RuntimeException("Failed to load search properties file", e);
+            throw new RuntimeException("Failed to load LabelsBundle properties file", e);
         }
     }
 

--- a/src/main/java/com/github/onsdigital/babbage/pdf/PDFGenerator.java
+++ b/src/main/java/com/github/onsdigital/babbage/pdf/PDFGenerator.java
@@ -13,13 +13,10 @@ import org.xhtmlrenderer.resource.XMLResource;
 import org.xml.sax.InputSource;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -27,9 +24,7 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 
 /**
  * Created by bren on 08/07/15.
@@ -39,7 +34,7 @@ public class PDFGenerator {
     private static final String TEMP_DIRECTORY_PATH = FileUtils.getTempDirectoryPath();
     private static final String URL = "http://localhost:8080";
 
-    public static Path generatePdf(String uri, String fileName, Map<String, String> cookies, String pdfTable) {
+    public static Path generatePdf(String uri, String fileName, String pdfTable) {
 
         try {
             ContentResponse contentResponse = ContentClient.getInstance().getContent(uri);

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/GeneratePDFRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/GeneratePDFRequestHandler.java
@@ -52,7 +52,7 @@ public class GeneratePDFRequestHandler extends PDFRequestHeandler {
     }
 
     private String getPDFTables(String uri) throws IOException, ContentReadException {
-        ContentResponse contentResponse = ContentClient.getInstance().getContent(uri);
+        ContentResponse contentResponse = getContent(uri, null);
         Map<String, Object> stringObjectMap = JsonUtil.toMap(contentResponse.getDataStream());
 
         List<Map<String, Object>> o = (List<Map<String, Object>>) stringObjectMap.get("pdfTable");

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/GeneratePDFRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/GeneratePDFRequestHandler.java
@@ -4,10 +4,8 @@ import com.github.onsdigital.babbage.content.client.ContentClient;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
 import com.github.onsdigital.babbage.pdf.PDFGenerator;
-import com.github.onsdigital.babbage.request.handler.base.BaseRequestHandler;
 import com.github.onsdigital.babbage.response.BabbageBinaryResponse;
 import com.github.onsdigital.babbage.response.base.BabbageResponse;
-import com.github.onsdigital.babbage.util.RequestUtil;
 import com.github.onsdigital.babbage.util.json.JsonUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -23,16 +21,16 @@ import java.util.Map;
 
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 
-
 /**
  * Request handler for the generation of pdf files based on page content
  */
-public class GeneratePDFRequestHandler extends BaseRequestHandler {
+public class GeneratePDFRequestHandler extends PDFRequestHeandler {
 
     private static final String REQUEST_TYPE = "pdf-new";
-    public static final String CONTENT_TYPE = "application/pdf";
+    private static final String CONTENT_TYPE = "application/pdf";
 
-    public BabbageResponse get(String requestedUri, HttpServletRequest requests) throws Exception {
+    @Override
+    public BabbageResponse get(String requestedUri, HttpServletRequest request) throws Exception {
 
         String uriPath = StringUtils.removeStart(requestedUri, "/");
         info().data("uri", uriPath).log("generating PDF for uri");
@@ -40,7 +38,7 @@ public class GeneratePDFRequestHandler extends BaseRequestHandler {
         if (pdfTable != null) {
             info().data("uri", uriPath).log("generating PDF table for uri");
         }
-        Path pdfFile = PDFGenerator.generatePdf(requestedUri, GetPDFRequestHandler.getTitle(requestedUri), RequestUtil.getAllCookies(requests), pdfTable);
+        Path pdfFile = PDFGenerator.generatePdf(requestedUri, getTitle(requestedUri), pdfTable);
         InputStream fin = Files.newInputStream(pdfFile);
         BabbageBinaryResponse response = new BabbageBinaryResponse(fin, CONTENT_TYPE);
         response.addHeader("Content-Length", Long.toString(FileUtils.sizeOf(pdfFile.toFile())));
@@ -53,7 +51,7 @@ public class GeneratePDFRequestHandler extends BaseRequestHandler {
         return REQUEST_TYPE;
     }
 
-    public String getPDFTables(String uri) throws IOException, ContentReadException {
+    private String getPDFTables(String uri) throws IOException, ContentReadException {
         ContentResponse contentResponse = ContentClient.getInstance().getContent(uri);
         Map<String, Object> stringObjectMap = JsonUtil.toMap(contentResponse.getDataStream());
 

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandler.java
@@ -1,24 +1,18 @@
 package com.github.onsdigital.babbage.request.handler;
 
 import com.github.onsdigital.babbage.content.client.ContentClient;
-import com.github.onsdigital.babbage.content.client.ContentFilter;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
 import com.github.onsdigital.babbage.error.LegacyPDFException;
 import com.github.onsdigital.babbage.error.ResourceNotFoundException;
-import com.github.onsdigital.babbage.request.handler.base.BaseRequestHandler;
 import com.github.onsdigital.babbage.response.BabbageContentBasedBinaryResponse;
 import com.github.onsdigital.babbage.response.base.BabbageResponse;
 import com.github.onsdigital.babbage.util.RequestUtil;
 import com.github.onsdigital.babbage.util.ThreadContext;
-import com.github.onsdigital.babbage.util.json.JsonUtil;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.Map;
 
-import static com.github.onsdigital.babbage.content.client.ContentClient.filter;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
 
@@ -26,7 +20,7 @@ import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
 /**
  * Request handler that retrieves a previously generated pdf file
  */
-public class GetPDFRequestHandler extends BaseRequestHandler {
+public class GetPDFRequestHandler extends PDFRequestHeandler {
 
     private static final String REQUEST_TYPE = "pdf";
 
@@ -45,7 +39,7 @@ public class GetPDFRequestHandler extends BaseRequestHandler {
         return REQUEST_TYPE;
     }
 
-    private static BabbageResponse getPreGeneratedPDF(String requestedUri, String language) throws ContentReadException, IOException {
+    private BabbageResponse getPreGeneratedPDF(String requestedUri, String language) throws ContentReadException, IOException {
         ContentResponse contentResponse = null;
         if ("cy".equals(language)) {
             try {
@@ -66,23 +60,5 @@ public class GetPDFRequestHandler extends BaseRequestHandler {
         contentDispositionHeader += contentResponse.getName() == null ? "" : "filename=\"" + getTitle(requestedUri) + "\"";
         response.addHeader("Content-Disposition", contentDispositionHeader);
         return response;
-    }
-
-    public static String getTitle(String uri) throws IOException, ContentReadException {
-        ContentResponse contentResponse = ContentClient.getInstance().getContent(uri, filter(ContentFilter.DESCRIPTION));
-        Map<String, Object> stringObjectMap = JsonUtil.toMap(contentResponse.getDataStream());
-
-        Map<String, Object> descriptionMap = (Map<String, Object>) stringObjectMap.get("description");
-
-        String title = (String) descriptionMap.get("title");
-        String edition = (String) descriptionMap.get("edition");
-
-        if (StringUtils.isNotEmpty(edition)) {
-            title += " " + edition;
-        }
-
-        title += ".pdf";
-
-        return title;
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandler.java
@@ -5,9 +5,12 @@ import com.github.onsdigital.babbage.content.client.ContentFilter;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
 import com.github.onsdigital.babbage.error.LegacyPDFException;
+import com.github.onsdigital.babbage.error.ResourceNotFoundException;
 import com.github.onsdigital.babbage.request.handler.base.BaseRequestHandler;
 import com.github.onsdigital.babbage.response.BabbageContentBasedBinaryResponse;
 import com.github.onsdigital.babbage.response.base.BabbageResponse;
+import com.github.onsdigital.babbage.util.RequestUtil;
+import com.github.onsdigital.babbage.util.ThreadContext;
 import com.github.onsdigital.babbage.util.json.JsonUtil;
 import org.apache.commons.lang3.StringUtils;
 
@@ -17,6 +20,7 @@ import java.util.Map;
 
 import static com.github.onsdigital.babbage.content.client.ContentClient.filter;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
 
 
 /**
@@ -25,14 +29,12 @@ import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 public class GetPDFRequestHandler extends BaseRequestHandler {
 
     private static final String REQUEST_TYPE = "pdf";
-    public static final String CONTENT_TYPE = "application/pdf";
 
-
-    public BabbageResponse get(String requestedUri, HttpServletRequest requests) throws Exception {
-
+    @Override
+    public BabbageResponse get(String requestedUri, HttpServletRequest request) throws Exception {
         try {
-            return getPreGeneratedPDF(requestedUri);
-        } catch (ContentReadException e) {
+            return getPreGeneratedPDF(requestedUri, (String) ThreadContext.getData(RequestUtil.LANG_KEY));
+        } catch (ContentReadException | ResourceNotFoundException e) {
             error().exception(e).data("uri", requestedUri).log("pre-rendered PDF not found, throwing Legacy PDF error");
             throw new LegacyPDFException();
         }
@@ -43,9 +45,22 @@ public class GetPDFRequestHandler extends BaseRequestHandler {
         return REQUEST_TYPE;
     }
 
-    static BabbageResponse getPreGeneratedPDF(String requestedUri) throws ContentReadException, IOException {
-        ContentResponse contentResponse;
-        contentResponse = ContentClient.getInstance().getResource(requestedUri + "/page.pdf");
+    private static BabbageResponse getPreGeneratedPDF(String requestedUri, String language) throws ContentReadException, IOException {
+        ContentResponse contentResponse = null;
+        if ("cy".equals(language)) {
+            try {
+                contentResponse = ContentClient.getInstance().getResource(requestedUri + "/page_cy.pdf");
+            } catch(ResourceNotFoundException e) {
+                warn().exception(e).data("uri", requestedUri).log("pre-rendered Welsh PDF not found, using English version");
+                // There is no Welsh PDF, we'll serve the English version
+                contentResponse = null;
+            }
+        }
+
+        if (contentResponse == null) {
+            // Use the English version
+            contentResponse = ContentClient.getInstance().getResource(requestedUri + "/page.pdf");
+        }
         BabbageContentBasedBinaryResponse response = new BabbageContentBasedBinaryResponse(contentResponse, contentResponse.getDataStream(), contentResponse.getMimeType());
         String contentDispositionHeader = "attachment; ";
         contentDispositionHeader += contentResponse.getName() == null ? "" : "filename=\"" + getTitle(requestedUri) + "\"";
@@ -62,8 +77,9 @@ public class GetPDFRequestHandler extends BaseRequestHandler {
         String title = (String) descriptionMap.get("title");
         String edition = (String) descriptionMap.get("edition");
 
-        if (StringUtils.isNotEmpty(edition))
+        if (StringUtils.isNotEmpty(edition)) {
             title += " " + edition;
+        }
 
         title += ".pdf";
 

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PDFRequestHeandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PDFRequestHeandler.java
@@ -17,7 +17,7 @@ import com.github.onsdigital.babbage.util.json.JsonUtil;
 public abstract class PDFRequestHeandler extends BaseRequestHandler {
 
     protected String getTitle(String uri) throws IOException, ContentReadException {
-        ContentResponse contentResponse = ContentClient.getInstance().getContent(uri, filter(ContentFilter.DESCRIPTION));
+        ContentResponse contentResponse = getContent(uri, filter(ContentFilter.DESCRIPTION));
         Map<String, Object> stringObjectMap = JsonUtil.toMap(contentResponse.getDataStream());
 
         Map<String, Object> descriptionMap = (Map<String, Object>) stringObjectMap.get("description");
@@ -32,5 +32,9 @@ public abstract class PDFRequestHeandler extends BaseRequestHandler {
         title += ".pdf";
 
         return title;
+    }
+
+    protected ContentResponse getContent(String uri, Map<String, String[]> queryParameters) throws ContentReadException {
+        return ContentClient.getInstance().getContent(uri, queryParameters);
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PDFRequestHeandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PDFRequestHeandler.java
@@ -1,0 +1,36 @@
+package com.github.onsdigital.babbage.request.handler;
+
+import static com.github.onsdigital.babbage.content.client.ContentClient.filter;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.github.onsdigital.babbage.content.client.ContentClient;
+import com.github.onsdigital.babbage.content.client.ContentFilter;
+import com.github.onsdigital.babbage.content.client.ContentReadException;
+import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.request.handler.base.BaseRequestHandler;
+import com.github.onsdigital.babbage.util.json.JsonUtil;
+
+public abstract class PDFRequestHeandler extends BaseRequestHandler {
+
+    protected String getTitle(String uri) throws IOException, ContentReadException {
+        ContentResponse contentResponse = ContentClient.getInstance().getContent(uri, filter(ContentFilter.DESCRIPTION));
+        Map<String, Object> stringObjectMap = JsonUtil.toMap(contentResponse.getDataStream());
+
+        Map<String, Object> descriptionMap = (Map<String, Object>) stringObjectMap.get("description");
+
+        String title = (String) descriptionMap.get("title");
+        String edition = (String) descriptionMap.get("edition");
+
+        if (StringUtils.isNotEmpty(edition)) {
+            title += " " + edition;
+        }
+
+        title += ".pdf";
+
+        return title;
+    }
+}

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -9,7 +9,6 @@ import com.github.onsdigital.babbage.response.base.BabbageResponse;
 import com.github.onsdigital.babbage.template.TemplateService;
 import com.github.onsdigital.babbage.util.RequestUtil;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageBinaryResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageBinaryResponse.java
@@ -32,7 +32,7 @@ public class BabbageBinaryResponse extends BabbageResponse {
         IOUtils.write(data, response.getOutputStream());
     }
 
-    protected byte[] getData() {
+    public byte[] getData() {
         return data;
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedBinaryResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedBinaryResponse.java
@@ -17,6 +17,7 @@ public class BabbageContentBasedBinaryResponse extends BabbageBinaryResponse {
         this.contentResponse = contentResponse;
     }
 
+    @Override
     protected void setCacheHeaders(HttpServletRequest request, HttpServletResponse response) {
         CacheControlHelper.setCacheHeaders(request, response, CacheControlHelper.hashData(getData()), contentResponse.getMaxAge());
     }

--- a/src/main/java/com/github/onsdigital/babbage/response/base/BabbageResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/base/BabbageResponse.java
@@ -23,7 +23,7 @@ public abstract class BabbageResponse {
     private String charEncoding = StandardCharsets.UTF_8.name();//Default encoding
     private int status = HttpServletResponse.SC_OK;//Default status
     private Long maxAge;
-    private Map<String, String> header;
+    private Map<String, String> headers;
     protected List<String> errors;
 
     public BabbageResponse(String mimeType) {
@@ -54,8 +54,8 @@ public abstract class BabbageResponse {
         response.setStatus(getStatus());
         response.setCharacterEncoding(getCharEncoding());
         response.setContentType(getMimeType());
-        if (getHeader() != null) {
-            Set<Map.Entry<String, String>> entries = getHeader().entrySet();
+        if (getHeaders() != null) {
+            Set<Map.Entry<String, String>> entries = getHeaders().entrySet();
             for (Map.Entry<String, String> next : entries) {
                 response.setHeader(next.getKey(), next.getValue());
             }
@@ -80,14 +80,18 @@ public abstract class BabbageResponse {
     }
 
     public void addHeader(String key, String value) {
-        if (header == null) {
-            header = new HashMap<>();
+        if (headers == null) {
+            headers = new HashMap<>();
         }
-        header.put(key, value);
+        headers.put(key, value);
     }
 
-    protected Map<String, String> getHeader() {
-        return header;
+    private Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public String getHeader(String key) {
+        return headers.get(key);
     }
 
     public BabbageResponse setCharEncoding(String charEncoding) {

--- a/src/main/java/com/github/onsdigital/babbage/util/RequestUtil.java
+++ b/src/main/java/com/github/onsdigital/babbage/util/RequestUtil.java
@@ -9,7 +9,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
@@ -94,8 +93,7 @@ public class RequestUtil {
             languageSegment += ".";
         }
 
-        Collection<Locale> supportedLanguages = LocaleConfig.getSupportedLanguages();
-        for (Locale supportedLanguage : supportedLanguages) {
+        for (Locale supportedLanguage : LocaleConfig.getSupportedLanguages()) {
             if (StringUtils.startsWithIgnoreCase(languageSegment, supportedLanguage.getLanguage() + ".")) {
                 return supportedLanguage;
             }

--- a/src/main/web/package-lock.json
+++ b/src/main/web/package-lock.json
@@ -313,9 +313,9 @@
             }
         },
         "uglify-js": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
-            "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw=="
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+            "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg=="
         },
         "which-module": {
             "version": "2.0.0",

--- a/src/test/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandlerTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandlerTest.java
@@ -1,0 +1,263 @@
+package com.github.onsdigital.babbage.request.handler;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.onsdigital.babbage.content.client.ContentReadException;
+import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.error.LegacyPDFException;
+import com.github.onsdigital.babbage.error.ResourceNotFoundException;
+import com.github.onsdigital.babbage.response.BabbageBinaryResponse;
+import com.github.onsdigital.babbage.util.RequestUtil;
+import com.github.onsdigital.babbage.util.ThreadContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GetPDFRequestHandlerTest {
+
+    private static final String URI = "/economy/inflationandpriceindices/pdf";
+    private static final String MIME_TYPE = "MIME_TYPE";
+    private static final byte[] DATA = "the pdf content".getBytes();
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private ContentResponse contentResponse;
+
+    @Spy
+    private GetPDFRequestHandler handler;
+
+    @Before
+    public void setup() {
+//        handler = new GetPDFRequestHandler();
+    }
+
+    @After
+    public void cleanup() {
+        ThreadContext.clear();
+    }
+
+    @Test
+    public void canHandleRequestShouldReturnTrueForPdf() {
+        assertTrue(handler.canHandleRequest(URI, "pdf"));
+    }
+
+    @Test
+    public void canHandleRequestShouldReturnFalseForNotPdf() {
+        assertFalse(handler.canHandleRequest(URI, "pdf-new"));
+    }
+
+    @Test
+    public void getRequestTypeShouldReturnPdf() {
+        assertEquals("pdf", handler.getRequestType());
+    }
+
+    @Test
+    public void getEnglishPdfOfExistingContentWithNoName() throws Exception {
+        when(contentResponse.getName()).thenReturn(null);
+        when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
+        when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getResource(URI + "/page.pdf");
+
+        BabbageBinaryResponse response = handler.get(URI, request);
+
+        String expectedContentDisposition = "attachment";
+
+        assertEquals(expectedContentDisposition, response.getHeader("Content-Disposition"));
+        assertArrayEquals(DATA, response.getData());
+        assertEquals(200, response.getStatus());
+        assertEquals(MIME_TYPE, response.getMimeType());
+        assertTrue(response.getErrors().isEmpty());
+        assertEquals("UTF-8", response.getCharEncoding());
+
+        verify(handler, never()).getResource(URI + "/page_cy.pdf");
+    }
+
+    @Test
+    public void getEnglishPdfOfExistingContentTitleAndEdition() throws Exception {
+        when(contentResponse.getName()).thenReturn("name");
+        when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
+        when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getResource(URI + "/page.pdf");
+
+        String title = "title";
+        String edition = "2.0";
+        stubContentDescription(title, edition);
+
+        BabbageBinaryResponse response = handler.get(URI, request);
+
+        String expectedContentDisposition = String.format("attachment; filename=\"%s %s.pdf\"", title, edition);
+
+        assertEquals(expectedContentDisposition, response.getHeader("Content-Disposition"));
+        assertArrayEquals(DATA, response.getData());
+        assertEquals(200, response.getStatus());
+        assertEquals(MIME_TYPE, response.getMimeType());
+        assertTrue(response.getErrors().isEmpty());
+        assertEquals("UTF-8", response.getCharEncoding());
+
+        verify(handler, never()).getResource(URI + "/page_cy.pdf");
+    }
+
+    @Test
+    public void getEnglishPdfOfExistingContentTitleAndNoEdition() throws Exception {
+        when(contentResponse.getName()).thenReturn("name");
+        when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
+        when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getResource(URI + "/page.pdf");
+
+        String title = "title";
+        String edition = "";
+        stubContentDescription(title, edition);
+
+        BabbageBinaryResponse response = handler.get(URI, request);
+
+        String expectedContentDisposition = String.format("attachment; filename=\"%s.pdf\"", title);
+
+        assertEquals(expectedContentDisposition, response.getHeader("Content-Disposition"));
+        assertArrayEquals(DATA, response.getData());
+        assertEquals(200, response.getStatus());
+        assertEquals(MIME_TYPE, response.getMimeType());
+        assertTrue(response.getErrors().isEmpty());
+        assertEquals("UTF-8", response.getCharEncoding());
+
+        verify(handler, never()).getResource(URI + "/page_cy.pdf");
+    }
+
+    @Test
+    public void getWelshPdfOfExistingContentWithNoName() throws Exception {
+        ThreadContext.addData(RequestUtil.LANG_KEY, "cy");
+        when(contentResponse.getName()).thenReturn(null);
+        when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
+        when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getResource(URI + "/page_cy.pdf");
+
+        BabbageBinaryResponse response = handler.get(URI, request);
+
+        String expectedContentDisposition = "attachment";
+
+        assertEquals(expectedContentDisposition, response.getHeader("Content-Disposition"));
+        assertArrayEquals(DATA, response.getData());
+        assertEquals(200, response.getStatus());
+        assertEquals(MIME_TYPE, response.getMimeType());
+        assertTrue(response.getErrors().isEmpty());
+        assertEquals("UTF-8", response.getCharEncoding());
+
+        verify(handler, never()).getResource(URI + "/page.pdf");
+    }
+
+    @Test
+    public void getWelshPdfOfExistingContentTitleAndEdition() throws Exception {
+        ThreadContext.addData(RequestUtil.LANG_KEY, "cy");
+        when(contentResponse.getName()).thenReturn("name");
+        when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
+        when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getResource(URI + "/page_cy.pdf");
+
+        String title = "title";
+        String edition = "2.0";
+        stubContentDescription(title, edition);
+
+        BabbageBinaryResponse response = handler.get(URI, request);
+
+        String expectedContentDisposition = String.format("attachment; filename=\"%s %s.pdf\"", title, edition);
+
+        assertEquals(expectedContentDisposition, response.getHeader("Content-Disposition"));
+        assertArrayEquals(DATA, response.getData());
+        assertEquals(200, response.getStatus());
+        assertEquals(MIME_TYPE, response.getMimeType());
+        assertTrue(response.getErrors().isEmpty());
+        assertEquals("UTF-8", response.getCharEncoding());
+
+        verify(handler, never()).getResource(URI + "/page.pdf");
+    }
+
+    @Test
+    public void getWelshPdfOfExistingContentTitleAndNoEdition() throws Exception {
+        ThreadContext.addData(RequestUtil.LANG_KEY, "cy");
+        when(contentResponse.getName()).thenReturn("name");
+        when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
+        when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getResource(URI + "/page_cy.pdf");
+
+        String title = "title";
+        String edition = "";
+        stubContentDescription(title, edition);
+
+        BabbageBinaryResponse response = handler.get(URI, request);
+
+        String expectedContentDisposition = String.format("attachment; filename=\"%s.pdf\"", title);
+
+        assertEquals(expectedContentDisposition, response.getHeader("Content-Disposition"));
+        assertArrayEquals(DATA, response.getData());
+        assertEquals(200, response.getStatus());
+        assertEquals(MIME_TYPE, response.getMimeType());
+        assertTrue(response.getErrors().isEmpty());
+        assertEquals("UTF-8", response.getCharEncoding());
+
+        verify(handler, never()).getResource(URI + "/page.pdf");
+    }
+
+    @Test
+    public void getEnglishPdfOfExistingContentWhenWelshUnavailable() throws Exception {
+        ThreadContext.addData(RequestUtil.LANG_KEY, "cy");
+        when(contentResponse.getName()).thenReturn("name");
+        when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
+        when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doThrow(new ResourceNotFoundException()).when(handler).getResource(URI + "/page_cy.pdf");
+        doReturn(contentResponse).when(handler).getResource(URI + "/page.pdf");
+
+        String title = "title";
+        String edition = "4";
+        stubContentDescription(title, edition);
+
+        BabbageBinaryResponse response = handler.get(URI, request);
+
+        String expectedContentDisposition = String.format("attachment; filename=\"%s %s.pdf\"", title, edition);
+
+        assertEquals(expectedContentDisposition, response.getHeader("Content-Disposition"));
+        assertArrayEquals(DATA, response.getData());
+        assertEquals(200, response.getStatus());
+        assertEquals(MIME_TYPE, response.getMimeType());
+        assertTrue(response.getErrors().isEmpty());
+        assertEquals("UTF-8", response.getCharEncoding());
+    }
+
+    @Test(expected = LegacyPDFException.class)
+    public void getShouldReturnAnExceptionIfContentNotFound() throws Exception {
+        doThrow(new ResourceNotFoundException()).when(handler).getResource(URI + "/page.pdf");
+
+        handler.get(URI, request);
+    }
+
+    private void stubContentDescription(String title, String edition) throws ContentReadException, IOException {
+        ContentResponse content = Mockito.mock(ContentResponse.class);
+
+        String descriptionJson = String.format("{\"description\":{\"title\":\"%s\",\"edition\":\"%s\"}}", title, edition);
+        when(content.getDataStream()).thenReturn(new ByteArrayInputStream(descriptionJson.getBytes()));
+
+        doReturn(content).when(handler).getContent(eq(URI), any());
+    }
+}


### PR DESCRIPTION
### What

Download the Welsh content PDF.
When using the Welsh language, we should download the pre generated Welsh PDF. This will be present if the content is in Welsh although it will not exist when the content is in English only. In that case, fall back to the English PDF.

Tidy some code and add test coverage for `GetPDFRequestHandler`

### How to review

Check code and refactoring is correct. Unit test coverage is adequate.

It can be tested by changing to the Welsh language and navigating to a page with Welsh content. Use the download as PDF link (Lawrlwytho fel PDF) and check the file content matches the page content in Welsh.

Note: the pdf file needs to have been pre generated. This is done on collection approval and the Welsh version of the PDF will only be generated once this [zebedee PR](https://github.com/ONSdigital/zebedee/pull/653) is merged.

### Who can review

Anyone
