### PR TITLE
Remove whitespace in related docs title

### DIFF
--- a/src/main/web/templates/handlebars/partials/related/documents.handlebars
+++ b/src/main/web/templates/handlebars/partials/related/documents.handlebars
@@ -9,12 +9,7 @@
                             <a href="{{uri}}"
                                data-gtm-title="{{description.title}}{{#if description.edition}}: {{description.edition}}{{/if}}"
                                data-gtm-type="related-publication">
-                                {{description.title}}
-                                {{#if description.edition}}
-                                    {{#if_ne description.edition 'yes'}}
-                                        : {{description.edition}}
-                                    {{/if_ne}}
-                                {{/if}}
+                                {{description.title}}{{#if description.edition}}{{#if_ne description.edition 'yes'}}: {{description.edition}}{{/if_ne}}{{/if}}
                             </a>
                         </li>
 


### PR DESCRIPTION
Causes extra spce before colon whne title and edition concatenated

### What

Remove whitespace in related docs title which causes extra space before colon when title and edition concatenated

### How to review

Ensure links have no space before colon in Related Documents section and tests pass etc.

### Who can review

Anyone but me