### PR TITLE
Exclude jackson-databind artifact due to vulnerability CVE-2023-35116

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,19 +396,19 @@
                             <version>1.6.1</version>
                         </exclude>
 
-                        <exlude>
+                        <exclude>
                             <!-- https://trello.com/c/wotCeMmc -->
                             <groupId>org.yaml</groupId>
                             <artifactId>snakeyaml</artifactId>
                             <version>1.33</version>
-                        </exlude>
+                        </exclude>
 
-                        <exlude>
+                        <exclude>
                             <!-- This is to exclude vulnerability CVE-2023-35116 -->
                             <groupId>com.fasterxml.jackson.core</groupId>
                             <artifactId>jackson-databind</artifactId>
                             <version>2.15.0</version>
-                        </exlude>
+                        </exclude>
 
                     </excludeCoordinates>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -402,6 +402,14 @@
                             <artifactId>snakeyaml</artifactId>
                             <version>1.33</version>
                         </exlude>
+
+                        <exlude>
+                            <!-- This is to exclude vulnerability CVE-2023-35116 -->
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-databind</artifactId>
+                            <version>2.15.0</version>
+                        </exlude>
+
                     </excludeCoordinates>
                 </configuration>
             </plugin>


### PR DESCRIPTION
### What

The following exclusion has been added to the pom:

```bash
 <exlude>
      <!-- This is to exclude vulnerability CVE-2023-35116 -->
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-databind</artifactId>
      <version>2.15.0</version>
  </exlude>
```
### How to review

Check that the audit tests pass.

### Who can review

Anyone.
