### PR TITLE
Add babbage metrics service to nomad

### DIFF
--- a/babbage.nomad
+++ b/babbage.nomad
@@ -56,6 +56,7 @@ job "babbage" {
 
         port_map {
           http = 8080
+          metrics = 8090
         }
       }
 
@@ -67,6 +68,19 @@ job "babbage" {
         check {
           type     = "http"
           path     = "/health"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      service {
+        name = "babbage-metrics"
+        port = "metrics"
+        tags = ["web"]
+
+        check {
+          type     = "http"
+          path     = "/metrics"
           interval = "10s"
           timeout  = "2s"
         }


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
When running babbage locally the following endpoint can be used to see the metrics produced:

http://localhost:8090/metrics

However, this metrics endpoint could not be used in any external environment unless it was added as a service in nomad. So the following file has been changed to include a new babbage-metrics service:

babbage.nomad

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct and the tests pass.

NB. It will still not be possible to use the babbage-metrics service until it has been given a "magic" port in the consul setup file.

To see the metrics locally call the following command while babbage is running:

```bash
curl -s http://localhost:8090/metrics
```

The metrics should look something like this:

```bash
# HELP publish_date_too_far_in_past_total Total requests for uris that have a past publishing date too long ago (outside a given time span)
# TYPE publish_date_too_far_in_past_total counter
publish_date_too_far_in_past_total 0.0
# HELP publish_date_too_far_in_future_total Total requests for uris that have a future publishing date later than that calculated by the default expiry time
# TYPE publish_date_too_far_in_future_total counter
publish_date_too_far_in_future_total 0.0
# HELP publish_date_not_present_total Total requests for uris that have no publishing date found
# TYPE publish_date_not_present_total counter
publish_date_not_present_total 0.0
# HELP publish_date_in_range_total Total requests for uris that have a publishing date within the range required for setting the cache expiry time
# TYPE publish_date_in_range_total counter
publish_date_in_range_total 0.0
# HELP publish_date_in_range_created Total requests for uris that have a publishing date within the range required for setting the cache expiry time
# TYPE publish_date_in_range_created gauge
publish_date_in_range_created 1.687892304077E9
# HELP publish_date_not_present_created Total requests for uris that have no publishing date found
# TYPE publish_date_not_present_created gauge
publish_date_not_present_created 1.687892304078E9
# HELP publish_date_too_far_in_future_created Total requests for uris that have a future publishing date later than that calculated by the default expiry time
# TYPE publish_date_too_far_in_future_created gauge
publish_date_too_far_in_future_created 1.687892304079E9
# HELP publish_date_too_far_in_past_created Total requests for uris that have a past publishing date too long ago (outside a given time span)
# TYPE publish_date_too_far_in_past_created gauge
publish_date_too_far_in_past_created 1.687892304078E9
```

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
