### PR TITLE
Hotfix/add caching to ajax calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,12 @@
                             <artifactId>snakeyaml</artifactId>
                             <version>1.33</version>
                         </exlude>
+
+                        <exlude>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>18.0</version>
+                        </exlude>
                     </excludeCoordinates>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,7 @@
                         </exlude>
 
                         <exlude>
+                            <!-- https://trello.com/c/hOBKeppS/1728-upgrade-guava-dependency -->
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
                             <version>18.0</version>

--- a/src/main/web/js/app/markdown-chart.js
+++ b/src/main/web/js/app/markdown-chart.js
@@ -126,11 +126,13 @@ $(function() {
         $this.empty();
 
         //Read chart configuration from server using container's width
-        var jqxhr = $.get("/chartconfig", {
+        var jqxhr = $.ajax({
+            url: "/chartconfig",
+            data: {
                 uri: chartUri,
                 width: nominalWidth
             },
-            function() {
+            success: function() {
                 chartConfig = window["chart-" + chartId];
 
                 // remove the title, subtitle and any renderers for client side display
@@ -259,7 +261,9 @@ $(function() {
 
 
                 }
-            }, "script");
-
+            }, 
+            dataType: "script",
+            cache: true
+        });
     });
 });

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -75,11 +75,14 @@ The commented code below is what needs to go in the parent.
         var chartUri = $this.data('uri');
         $this.empty();
 
-        $.get("/chartconfig", {
-              uri: chartUri,
-              width: chartWidth
-            },
-            function () {
+
+        $.ajax({
+          url: "/chartconfig",
+          data: {
+            uri: chartUri,
+            width: chartWidth
+          },
+          success: function () {
               var chartConfig = window["chart-" + chartId];
               if (chartConfig) {
                 chartConfig.chart.marginTop = 25;
@@ -92,9 +95,11 @@ The commented code below is what needs to go in the parent.
                 new Highcharts.Chart(chartConfig);
                 delete window["chart-" + chartId]; //clear data from window object after rendering
 
-                pymChild.sendHeight()
-              }
-            }, "script");
+            pymChild.sendHeight()
+          }
+        },
+        dataType: "script",
+        cache: true
       });
     }
 


### PR DESCRIPTION
### What

change to use `ajax()` instead of `get()` on calls that use `dataType: script` so we can set `cache: true` and allow browser to cache charts

note: only updated calls that are using `dataType: script` and left others as is as they will default to type `json` and will allow caching

### Who can review

Anyone
