### PR TITLE
Exclude guava 18.0 from audit checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
             <plugin>
                 <groupId>org.sonatype.ossindex.maven</groupId>
                 <artifactId>ossindex-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>audit-dependencies-critical</id>
@@ -408,6 +408,13 @@
                             <groupId>com.fasterxml.jackson.core</groupId>
                             <artifactId>jackson-databind</artifactId>
                             <version>2.15.0</version>
+                        </exclude>
+
+                        <exclude>
+                            <!-- This is to exclude vulnerability CVE-2023-2976 -->
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>18.0</version>
                         </exclude>
 
                     </excludeCoordinates>


### PR DESCRIPTION
### What

The following exclusion has been added to the pom:

```bash
 <exlude>
      <!-- This is to exclude vulnerability CVE-2023-2976 -->
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
      <version>18.0</version>
  </exlude>
```
### How to review

Check that the audit tests pass.

### Who can review

Anyone.
