### PR TITLE
Add metrics port to fix failing ship-it job in develop

### DIFF
--- a/babbage.nomad
+++ b/babbage.nomad
@@ -169,6 +169,7 @@ job "babbage" {
 
         network {
           port "http" {}
+          port "metrics" {}
         }
       }
 


### PR DESCRIPTION
### What

A port named "metrics" has been added to the nomad file to prevent the following error from occurring in the ship-it job:

```shell
error: unexpected response from client
{
  "Body": "rpc error: rpc error: 1 error occurred:\n\t* Task group web validation failed: 1 error occurred:\n\t* Task babbage-web validation failed: 1 error occurred:\n\t* 1 error occurred:\n\t* port label \"metrics\" referenced by services babbage-metrics does not exist\n\n\n\n\n\n\n\n",
  "StatusCode": 500,
  "URL": "https://10.30.142.9:4646/v1/job/babbage/plan"
}
```

### How to review

Check that the change looks correct.

### Who can review

Anyone.