### PR TITLE
Add metrics port to web task instead of publishing

### DIFF
--- a/babbage.nomad
+++ b/babbage.nomad
@@ -92,6 +92,7 @@ job "babbage" {
 
         network {
           port "http" {}
+          port "metrics" {}
         }
       }
 
@@ -169,7 +170,6 @@ job "babbage" {
 
         network {
           port "http" {}
-          port "metrics" {}
         }
       }
 


### PR DESCRIPTION
### What

The port named "metrics" had accidentally been added to the publishing group but needs to be in the web group instead.
The port should prevent the following error from occurring in the ship-it job:

```shell
error: unexpected response from client
{
  "Body": "rpc error: rpc error: 1 error occurred:\n\t* Task group web validation failed: 1 error occurred:\n\t* Task babbage-web validation failed: 1 error occurred:\n\t* 1 error occurred:\n\t* port label \"metrics\" referenced by services babbage-metrics does not exist\n\n\n\n\n\n\n\n",
  "StatusCode": 500,
  "URL": "https://10.30.142.9:4646/v1/job/babbage/plan"
}
```

### How to review

Check that the change looks correct.

### Who can review

Anyone.
