### PR TITLE
Throw NotFound if parent page for PDF doesn't exist

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandler.java
@@ -26,6 +26,16 @@ public class GetPDFRequestHandler extends PDFRequestHeandler {
 
     @Override
     public BabbageBinaryResponse get(String requestedUri, HttpServletRequest request) throws Exception {
+
+        // LegacyPDFException below only valid if parent page does not exist
+        try {
+            // Check for parent page
+            getContent(requestedUri);
+        } catch(ResourceNotFoundException e) {
+            warn().exception(e).data("uri", requestedUri).log("couldn't find parent page for pdf");
+            throw new ResourceNotFoundException();
+        }
+
         try {
             return getPreGeneratedPDF(requestedUri, (String) ThreadContext.getData(RequestUtil.LANG_KEY));
         } catch (ContentReadException | ResourceNotFoundException e) {
@@ -64,5 +74,9 @@ public class GetPDFRequestHandler extends PDFRequestHeandler {
 
     protected ContentResponse getResource(String uri) throws ContentReadException {
         return ContentClient.getInstance().getResource(uri);
+    }
+
+    protected ContentResponse getContent(String uri) throws IOException, ContentReadException {
+        return ContentClient.getInstance().getContent(uri);
     }
 }

--- a/src/test/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandlerTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/request/handler/GetPDFRequestHandlerTest.java
@@ -74,6 +74,7 @@ public class GetPDFRequestHandlerTest {
         when(contentResponse.getName()).thenReturn(null);
         when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
         when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getContent(URI);
         doReturn(contentResponse).when(handler).getResource(URI + "/page.pdf");
 
         BabbageBinaryResponse response = handler.get(URI, request);
@@ -95,6 +96,7 @@ public class GetPDFRequestHandlerTest {
         when(contentResponse.getName()).thenReturn("name");
         when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
         when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getContent(URI);
         doReturn(contentResponse).when(handler).getResource(URI + "/page.pdf");
 
         String title = "title";
@@ -120,6 +122,7 @@ public class GetPDFRequestHandlerTest {
         when(contentResponse.getName()).thenReturn("name");
         when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
         when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getContent(URI);
         doReturn(contentResponse).when(handler).getResource(URI + "/page.pdf");
 
         String title = "title";
@@ -146,6 +149,7 @@ public class GetPDFRequestHandlerTest {
         when(contentResponse.getName()).thenReturn(null);
         when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
         when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getContent(URI);
         doReturn(contentResponse).when(handler).getResource(URI + "/page_cy.pdf");
 
         BabbageBinaryResponse response = handler.get(URI, request);
@@ -168,6 +172,7 @@ public class GetPDFRequestHandlerTest {
         when(contentResponse.getName()).thenReturn("name");
         when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
         when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getContent(URI);
         doReturn(contentResponse).when(handler).getResource(URI + "/page_cy.pdf");
 
         String title = "title";
@@ -194,6 +199,7 @@ public class GetPDFRequestHandlerTest {
         when(contentResponse.getName()).thenReturn("name");
         when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
         when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getContent(URI);
         doReturn(contentResponse).when(handler).getResource(URI + "/page_cy.pdf");
 
         String title = "title";
@@ -220,6 +226,7 @@ public class GetPDFRequestHandlerTest {
         when(contentResponse.getName()).thenReturn("name");
         when(contentResponse.getMimeType()).thenReturn(MIME_TYPE);
         when(contentResponse.getDataStream()).thenReturn(new ByteArrayInputStream(DATA));
+        doReturn(contentResponse).when(handler).getContent(URI);
         doThrow(new ResourceNotFoundException()).when(handler).getResource(URI + "/page_cy.pdf");
         doReturn(contentResponse).when(handler).getResource(URI + "/page.pdf");
 
@@ -241,6 +248,7 @@ public class GetPDFRequestHandlerTest {
 
     @Test(expected = LegacyPDFException.class)
     public void getShouldReturnAnExceptionIfContentNotFound() throws Exception {
+        doReturn(contentResponse).when(handler).getContent(URI);
         doThrow(new ResourceNotFoundException()).when(handler).getResource(URI + "/page.pdf");
 
         handler.get(URI, request);
@@ -253,5 +261,12 @@ public class GetPDFRequestHandlerTest {
         when(content.getDataStream()).thenReturn(new ByteArrayInputStream(descriptionJson.getBytes()));
 
         doReturn(content).when(handler).getContent(eq(URI), any());
+    }
+
+    @Test(expected = ResourceNotFoundException.class)
+    public void getShouldReturnANotFoundExceptionIfParentPageNotFound() throws Exception {
+        doThrow(new ResourceNotFoundException()).when(handler).getContent(URI);
+
+        handler.get(URI, request);
     }
 }


### PR DESCRIPTION
### What

Put a check in for parent page for PDFs, throw 404 if there isn't one. 

### How to review

- Run Babbage + Zebedee + Sixteens
- Insert PDF in file structure in zebedee master under a page
- Check PDF request works
- Try PDF request (/pdf) for non-existing page

### Who can review

Not me. 