### PR TITLE
Remove the babbage metrics healthcheck as it causes deployment issues

### DIFF
--- a/babbage.nomad
+++ b/babbage.nomad
@@ -78,12 +78,7 @@ job "babbage" {
         port = "metrics"
         tags = ["web"]
 
-        check {
-          type     = "http"
-          path     = "/metrics"
-          interval = "10s"
-          timeout  = "2s"
-        }
+        # There is no healthcheck for the babbage metrics service as it creates problems with the deployment when metrics are not enabled
       }
 
       resources {


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Changes have been made that will allow babbage to get deployed successfully even if the new babbage-metrics service is not going to be available in nomad.

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the changes look correct.

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
