### PR TITLE
fix/breadcrumbs alignment in safari

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -12,8 +12,8 @@
         {{#if_any (eq type "bulletin") (eq type "article") (eq type "compendium_landing_page") (eq type "compendium_chapter")}}
             <link rel="canonical" href="{{uri}}" />
         {{/if_any}}
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/30948d6{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/30948d6{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/7d2d294{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/7d2d294{{/if}}/css/pdf.css">{{/if}}
 
         {{> partials/gtm-data-layer }}
 
@@ -120,8 +120,8 @@
                 {{else if_eq code 501}}{{> error/501}}
 			{{/if_eq}}
 		{{/if_eq}}
-
-        <script src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/30948d6{{/if}}/js/main.js"></script>
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+        <script src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/7d2d294{{/if}}/js/main.js"></script>
         <script src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -51,7 +51,8 @@ The commented code below is what needs to go in the parent.
     {{/if}}
   {{/if}}
 
-  <script src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/30948d6{{/if}}/js/main.js"></script>
+ 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/7d2d294{{/if}}/js/main.js"></script>
   <script src="/js/app.js"></script>
 
   <script src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What

- Fixed the alignment of breadcrumbs in safari (see images)
- Updated to latest version of Sixteens which now requires a direct jQuery reference, hence inclusion

### How to review

- Sense check
- Image check

#### Safari before
![saf](https://github.com/ONSdigital/sixteens/assets/19624419/ba05598a-e75b-4ae8-af7c-90fe56412c76)

#### Safari after
<img width="811" alt="image" src="https://github.com/ONSdigital/sixteens/assets/19624419/3d60d963-aa7c-4ac6-b51e-75bb3e35f9df">

### Who can review

!me
