### PR TITLE
Upgrading common-io dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,19 +33,9 @@
         <dependency>
             <groupId>com.github.onsdigital</groupId>
             <artifactId>restolino</artifactId>
-            <version>v0.5.0</version>
-             <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>v0.7.0</version>
         </dependency>
-         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.9.0</version>
-        </dependency>
+
 
         <dependency>
             <groupId>com.github.davidcarboni</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,17 @@
             <groupId>com.github.onsdigital</groupId>
             <artifactId>restolino</artifactId>
             <version>v0.5.0</version>
+             <exclusions>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.9.0</version>
         </dependency>
 
         <dependency>
@@ -253,6 +264,7 @@
             <artifactId>pdfbox</artifactId>
             <version>2.0.26</version>
         </dependency>
+     
 
     </dependencies>
 

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
@@ -35,7 +35,16 @@ public class ContentResponse implements Serializable {
             ContentType contentType = getContentType(response);
             mimeType = contentType.getMimeType();
             charset = contentType.getCharset();
-            data = IOUtils.toByteArray(response.getEntity().getContent());
+            // IOUtils.toByteArray has been updated to return a null pointer exception
+            // in commons-io 2.9.0.  This resulted in some failed tests so unsure how it
+            // will affect the behaviour of the system, therefore this if statement has been
+            // added to return a null and not transform any content.
+            if (response.getEntity().getContent() == null) {
+                data = null;
+            }
+            else {
+                data = IOUtils.toByteArray(response.getEntity().getContent());
+            }
             size = response.getEntity().getContentLength();
             name = extractName(response);
             Header etag = response.getFirstHeader("Etag");

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
@@ -39,7 +39,7 @@ public class ContentResponse implements Serializable {
             // in commons-io 2.9.0.  This resulted in some failed tests so unsure how it
             // will affect the behaviour of the system, therefore this if statement has been
             // added to return an empty byte array as previously returned by IOUtils.toByteArray
-            // and not transform any content.
+            // and not transform any content.  
             if (response.getEntity().getContent() == null) {
                 data = new byte[0];
             }

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
@@ -38,7 +38,8 @@ public class ContentResponse implements Serializable {
             // IOUtils.toByteArray has been updated to return a null pointer exception
             // in commons-io 2.9.0.  This resulted in some failed tests so unsure how it
             // will affect the behaviour of the system, therefore this if statement has been
-            // added to return a null and not transform any content.
+            // added to return an empty byte array as previously returned by IOUtils.toByteArray
+            // and not transform any content.
             if (response.getEntity().getContent() == null) {
                 data = new byte[0];
             }

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
@@ -39,7 +39,7 @@ public class ContentResponse implements Serializable {
             // in commons-io 2.9.0.  This resulted in some failed tests so unsure how it
             // will affect the behaviour of the system, therefore this if statement has been
             // added to return an empty byte array as previously returned by IOUtils.toByteArray
-            // and not transform any content.  
+            // and not transform any content.
             if (response.getEntity().getContent() == null) {
                 data = new byte[0];
             }

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentResponse.java
@@ -40,7 +40,7 @@ public class ContentResponse implements Serializable {
             // will affect the behaviour of the system, therefore this if statement has been
             // added to return a null and not transform any content.
             if (response.getEntity().getContent() == null) {
-                data = null;
+                data = new byte[0];
             }
             else {
                 data = IOUtils.toByteArray(response.getEntity().getContent());


### PR DESCRIPTION
### What

Upgrading the common-io dependency that sits within the restolino library as the IOUtils.closeQuietly method was deprecated and then un-deprecated in a later version.

When it was deprecated the new way of implementing this involved updating the code to use try with resources which has not occurred here.  Therefore it's possible connections are not being returned to the pool correctly, causing issues when under load.

### How to review

Ensure the tests pass and the changes make sense.

### Who can review

Anyone.
