### PR TITLE
Cache metrics via path rather than port

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Babbage runs independently. However, in order to run it locally in its publishin
 | HIGHCHARTS_EXPORT_SERVER       | http://localhost:9999/ | The URL to the highcharts export server                                                                           |
 | IS_PUBLISHING                  | N                      | Switch to use (or not) the publishing functionality                                                               |
 | MAP_RENDERER_HOST              | http://localhost:23500 | The URL to the map renderer                                                                                       |
-| METRICS_PORT                   | 8090                   | The port for the metrics URL                                                                                      |
 | REDIRECT_SECRET                | secret                 | The code for the redirect                                                                                         |
 | TABLE_RENDERER_HOST            | http://localhost:23300 | The URL to the table renderer                                                                                     |
 | POOLED_CONNECTION_TIMEOUT      | 5000                   | The number of milliseconds to wait before closing expired connections                                             |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Babbage
-========
+# Babbage
 
 Repository for ONS Website Babbage
 
@@ -10,7 +9,7 @@ Babbage contains two main areas of functionality, as follows:
 1. It creates the HTML files for the pages on the website.
 2. It creates the HTML files for the website publications in the publishing system [Florence](https://github.com/ONSdigital/florence)
 
-### Getting started
+## Getting started
 
 In the babbage repo do one of the following:
 
@@ -34,30 +33,31 @@ Babbage runs independently. However, in order to run it locally in its publishin
 
 ### Configuration
 
-| Environment variable          | Default                | Description
-| ------------------------------| -----------------------|-------------------------------------------------------------
-| CONTENT_SERVICE_MAX_CONNECTION| 50                     | The maximum number of connections Babbage can make to the content service
-| CONTENT_SERVICE_URL           | http://localhost:8082  | The URL to the content service (zebedee)
-| ELASTIC_SEARCH_SERVER         | localhost              | The elastic search host and port (The http:// scheme prefix is added programmatically)
-| ELASTIC_SEARCH_CLUSTER        |                        | The elastic search cluster
-| ENABLE_CACHE                  | N                      | Switch to use (or not) the cache
-| ENABLE_COVID19_FEATURE        |                        | Switch to use (or not) the covid feature
-| ENABLE_METRICS                | N                      | Switch to collect (or not) metrics about cache expiry times
-| HIGHCHARTS_EXPORT_SERVER      | http://localhost:9999/ | The URL to the highcharts export server
-| IS_PUBLISHING                 | N                      | Switch to use (or not) the publishing functionality
-| MAP_RENDERER_HOST             | http://localhost:23500 | The URL to the map renderer
-| METRICS_PORT                  | 8090                   | The port for the metrics URL
-| REDIRECT_SECRET               | secret                 | The code for the redirect
-| TABLE_RENDERER_HOST           | http://localhost:23300 | The URL to the table renderer
-| POOLED_CONNECTION_TIMEOUT     | 5000                   | The number of milliseconds to wait before closing expired connections
-| IDLE_CONNECTION_TIMEOUT       | 60                     | The number of seconds to wait before closing idle connections
+| Environment variable           | Default                | Description                                                                                                       |
+|--------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------|
+| CONTENT_SERVICE_MAX_CONNECTION | 50                     | The maximum number of connections Babbage can make to the content service                                         |
+| CONTENT_SERVICE_URL            | http://localhost:8082  | The URL to the content service (zebedee)                                                                          |
+| ELASTIC_SEARCH_SERVER          | localhost              | The elastic search host and port (The http:// scheme prefix is added programmatically)                            |
+| ELASTIC_SEARCH_CLUSTER         |                        | The elastic search cluster                                                                                        |
+| ENABLE_CACHE                   | N                      | Switch to use (or not) the cache                                                                                  |
+| ENABLE_COVID19_FEATURE         |                        | Switch to use (or not) the covid feature                                                                          |
+| ENABLE_METRICS                 | N                      | Switch to collect (or not) metrics about cache expiry times                                                       |
+| METRICS_FORMAT                 | Text                   | Available options are Text or Open documented here <https://prometheus.io/docs/instrumenting/exposition_formats/> |
+| HIGHCHARTS_EXPORT_SERVER       | http://localhost:9999/ | The URL to the highcharts export server                                                                           |
+| IS_PUBLISHING                  | N                      | Switch to use (or not) the publishing functionality                                                               |
+| MAP_RENDERER_HOST              | http://localhost:23500 | The URL to the map renderer                                                                                       |
+| METRICS_PORT                   | 8090                   | The port for the metrics URL                                                                                      |
+| REDIRECT_SECRET                | secret                 | The code for the redirect                                                                                         |
+| TABLE_RENDERER_HOST            | http://localhost:23300 | The URL to the table renderer                                                                                     |
+| POOLED_CONNECTION_TIMEOUT      | 5000                   | The number of milliseconds to wait before closing expired connections                                             |
+| IDLE_CONNECTION_TIMEOUT        | 60                     | The number of seconds to wait before closing idle connections                                                     |
 
 ### Metrics
 
-To see the metrics, note that the ENABLE_METRICS and ENABLE_CACHE values must be set to Y when babbage starts up. Then call the following command while babbage is running:
+To see the metrics, you need to set the ENABLE_METRICS and ENABLE_CACHE environment variables (default is N) when babbage starts up. Then call the following command while babbage is running:
 
 ```bash
-curl -s http://localhost:8090/metrics
+curl -s http://localhost:8080/metrics
 ```
 
 The metrics should look something like this:

--- a/babbage.nomad
+++ b/babbage.nomad
@@ -56,7 +56,6 @@ job "babbage" {
 
         port_map {
           http = 8080
-          metrics = 8090
         }
       }
 
@@ -73,21 +72,12 @@ job "babbage" {
         }
       }
 
-      service {
-        name = "babbage-metrics"
-        port = "metrics"
-        tags = ["web"]
-
-        # There is no healthcheck for the babbage metrics service as it creates problems with the deployment when metrics are not enabled
-      }
-
       resources {
         cpu    = "{{WEB_RESOURCE_CPU}}"
         memory = "{{WEB_RESOURCE_MEM}}"
 
         network {
           port "http" {}
-          port "metrics" {}
         }
       }
 

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/Metrics.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/Metrics.java
@@ -1,0 +1,46 @@
+package com.github.onsdigital.babbage.api.endpoint;
+
+import com.github.davidcarboni.restolino.framework.Api;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Context;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
+
+@Api
+public class Metrics {
+    @GET
+    public void get(@Context HttpServletRequest request, @Context HttpServletResponse response)
+            throws IOException {
+        if (appConfig().babbage().getMetricsEnabled()) {
+            Writer writer = new StringWriter();
+            if (appConfig().babbage().getMetricsFormat().equalsIgnoreCase("Open")) {
+                TextFormat.writeOpenMetrics100(writer,
+                        CollectorRegistry.defaultRegistry.metricFamilySamples());
+                response.setContentType(
+                        "application/openmetrics-text; version=1.0.0; charset=utf-8");
+            } else if (appConfig().babbage().getMetricsFormat().equalsIgnoreCase("Text")) {
+                TextFormat.write004(writer,
+                        CollectorRegistry.defaultRegistry.metricFamilySamples());
+                response.setContentType("text/plain; version=0.0.4; charset=utf-8");
+            } else {
+                warn().log(
+                        "Metrics log format is incorrectly set falling back to default of: Text");
+                TextFormat.write004(writer,
+                        CollectorRegistry.defaultRegistry.metricFamilySamples());
+                response.setContentType("text/plain; version=0.0.4; charset=utf-8");
+            }
+            response.getWriter().write(writer.toString());
+            response.getWriter().flush();
+            response.setStatus(HttpServletResponse.SC_OK);
+        } else {
+            response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+        }
+    }
+}

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
@@ -17,6 +17,7 @@ public class Babbage implements AppConfig {
     private static final String DEV_ENVIRONMENT_KEY = "DEV_ENVIRONMENT";
     private static final String ENABLE_CACHE_KEY = "ENABLE_CACHE";
     private static final String ENABLE_METRICS_KEY = "ENABLE_METRICS";
+    private static final String METRICS_FORMAT_KEY = "METRICS_FORMAT";
     private static final String ENABLE_NAVIGATION_KEY = "ENABLE_NAVIGATION";
     private static final String HIGHCHARTS_EXPORT_SERVER_KEY = "HIGHCHARTS_EXPORT_SERVER";
     private static final String IS_PUBLISHING_KEY = "IS_PUBLISHING";
@@ -24,7 +25,6 @@ public class Babbage implements AppConfig {
     private static final String MAXAGE_SERVICE_KEY = "MAXAGE_SERVER";
     private static final String MAX_CACHE_ENTRIES = "CACHE_ENTRIES";
     private static final String MAX_OBJECT_SIZE = "CACHE_OBJECT_SIZE";
-    private static final String METRICS_PORT_KEY = "METRICS_PORT";
     private static final String REDIRECT_SECRET_KEY = "REDIRECT_SECRET";
     private static final String REINDEX_SERVICE_KEY = "REINDEX_SERVER";
     private static final String SERVICE_AUTH_TOKEN = "SERVICE_AUTH";
@@ -68,8 +68,8 @@ public class Babbage implements AppConfig {
     private final int maxCacheEntries;
     private final int maxCacheObjectSize;
     private final int maxHighchartsServerConnections;
-    private final int metricsPort;
     private final boolean metricsEnabled;
+    private final String metricsFormat;
     private final int maxResultsPerPage;
     private final int maxVisiblePaginatorLink;
     private final int resultsPerPage;
@@ -86,15 +86,8 @@ public class Babbage implements AppConfig {
         mathjaxExportServer = getValue(MATHJAX_EXPORT_SERVER_KEY);
         maxAgeSecret = getValueOrDefault(MAXAGE_SERVICE_KEY, "mPHbKjCol7ObQ87qKVQgHz6kR3nsYJ3WJHgP7+JYyi5rSJbmbDAcQU8EQilFQ6QQ");
         metricsEnabled = getStringAsBool(ENABLE_METRICS_KEY, "N");
+        metricsFormat = getValueOrDefault(METRICS_FORMAT_KEY, "TEXT");
         reindexSecret = getValueOrDefault(REINDEX_SERVICE_KEY, "5NpB6/uAgk14nYwHzMbIQRnuI2W63MrBOS2279YlcUUY2kNOhrL+R5UFR3O066bQ");
-
-
-        if (metricsEnabled) {
-            metricsPort = Integer.parseInt(getValueOrDefault(METRICS_PORT_KEY, "8090"));
-        }   else {
-            metricsPort = 0;
-        }
-
         maxCacheEntries = defaultIfBlank(getNumberValue(MAX_OBJECT_SIZE), 3000);
         maxCacheObjectSize = defaultIfBlank(getNumberValue(MAX_CACHE_ENTRIES), 50000);
         maxHighchartsServerConnections = defaultIfBlank(getNumberValue("HIGHCHARTS_EXPORT_MAX_CONNECTION"), 50);
@@ -192,12 +185,12 @@ public class Babbage implements AppConfig {
         return searchResponseCacheTime;
     }
 
-    public int getMetricsPort() {
-        return metricsPort;
-    }
-
     public boolean getMetricsEnabled() {
         return metricsEnabled;
+    }
+
+    public String getMetricsFormat() {
+        return metricsFormat;
     }
 
     @Override
@@ -211,8 +204,8 @@ public class Babbage implements AppConfig {
         config.put("isPublishing", isPublishing);
         config.put("mathjaxExportServer", mathjaxExportServer);
         config.put("maxAgeSecret", maxAgeSecret);
-        config.put("metricsPort", metricsPort);
         config.put("metricsEnabled", metricsEnabled);
+        config.put("metricsFormat", metricsFormat);
         config.put("maxCacheEntries", maxCacheEntries);
         config.put("maxCacheObjectSize", maxCacheObjectSize);
         config.put("maxHighchartsServerConnections", maxHighchartsServerConnections);

--- a/src/main/java/com/github/onsdigital/babbage/metrics/CacheMetrics.java
+++ b/src/main/java/com/github/onsdigital/babbage/metrics/CacheMetrics.java
@@ -1,11 +1,6 @@
 package com.github.onsdigital.babbage.metrics;
 
-import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.Counter;
-
-import java.io.IOException;
-
-import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
 
 public class CacheMetrics implements Metrics {
 
@@ -14,16 +9,18 @@ public class CacheMetrics implements Metrics {
     private final Counter publishDateTooFarInPast;
     private final Counter publishDateTooFarInFuture;
 
-    public CacheMetrics() throws IOException {
-        new HTTPServer.Builder().withPort(appConfig().babbage().getMetricsPort()).build();
-
-        this.publishDateInRange = Counter.build()
-                .name("publish_date_in_range").help("Total requests for uris that have a publishing date within the range required for setting the cache expiry time").register();
-        this.publishDateNotPresent = Counter.build()
-                .name("publish_date_not_present").help("Total requests for uris that have no publishing date found").register();
-        this.publishDateTooFarInPast = Counter.build()
-                .name("publish_date_too_far_in_past").help("Total requests for uris that have a past publishing date too long ago (outside a given time span)").register();
-        this.publishDateTooFarInFuture = Counter.build().name("publish_date_too_far_in_future").help("Total requests for uris that have a future publishing date later than that calculated by the default expiry time").register();
+    public CacheMetrics() {
+        this.publishDateInRange = Counter.build().name("publish_date_in_range").help(
+                "Total requests for uris that have a publishing date within the range required for setting the cache expiry time")
+                .register();
+        this.publishDateNotPresent = Counter.build().name("publish_date_not_present")
+                .help("Total requests for uris that have no publishing date found").register();
+        this.publishDateTooFarInPast = Counter.build().name("publish_date_too_far_in_past").help(
+                "Total requests for uris that have a past publishing date too long ago (outside a given time span)")
+                .register();
+        this.publishDateTooFarInFuture = Counter.build().name("publish_date_too_far_in_future")
+                .help("Total requests for uris that have a future publishing date later than that calculated by the default expiry time")
+                .register();
     }
 
     public void incPublishDateInRange() {
@@ -38,5 +35,8 @@ public class CacheMetrics implements Metrics {
         publishDateTooFarInPast.inc();
     }
 
-    public void incPublishDateTooFarInFuture() { publishDateTooFarInFuture.inc(); }
+    public void incPublishDateTooFarInFuture() {
+        publishDateTooFarInFuture.inc();
+    }
+
 }

--- a/src/main/java/com/github/onsdigital/babbage/metrics/MetricsFactory.java
+++ b/src/main/java/com/github/onsdigital/babbage/metrics/MetricsFactory.java
@@ -1,6 +1,8 @@
 package com.github.onsdigital.babbage.metrics;
 
 import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+
 
 public class MetricsFactory {
 
@@ -8,15 +10,16 @@ public class MetricsFactory {
 
     private static boolean metricsEnabled = appConfig().babbage().getMetricsEnabled();
 
-    public static void init() throws Exception {
-        if (metrics != null) {
-            throw new Exception("Init already called");
-        }
-
-        if (metricsEnabled) {
-            metrics = new CacheMetrics();
+    public static void init() {
+        if (metrics == null) {
+            if (metricsEnabled) {
+                info().log("initialising CacheMetrics");
+                metrics = new CacheMetrics();
+            } else {
+                metrics = new NopMetricsImpl();
+            }
         } else {
-            metrics = new NopMetricsImpl();
+            info().log("CacheMetrics already initialised");
         }
     }
 
@@ -24,11 +27,11 @@ public class MetricsFactory {
         return metricsEnabled;
     }
 
-    //Use getMetrics method to get the static metrics object
-    //If metrics are enabled then it be of type CacheMetrics
-    //Or if metrics are not enabled then it will be of type NopMetricsImpl
-    public static Metrics getMetrics(){
-         return metrics;
+    // Use getMetrics method to get the static metrics object
+    // If metrics are enabled then it be of type CacheMetrics
+    // Or if metrics are not enabled then it will be of type NopMetricsImpl
+    public static Metrics getMetrics() {
+        return metrics;
     }
 
 }

--- a/src/main/java/com/github/onsdigital/babbage/metrics/NopMetricsImpl.java
+++ b/src/main/java/com/github/onsdigital/babbage/metrics/NopMetricsImpl.java
@@ -8,11 +8,15 @@ public class NopMetricsImpl implements Metrics {
         info().log("NopMetricsImpl incPublishDateInRange");
     }
 
-    public void incPublishDateNotPresent() { info().log("NopMetricsImpl incPublishDateNotPresent"); }
+    public void incPublishDateNotPresent() {
+        info().log("NopMetricsImpl incPublishDateNotPresent");
+    }
 
     public void incPublishDateTooFarInPast() {
         info().log("NopMetricsImpl incPublishDateTooFarInPast");
     }
 
-    public void incPublishDateTooFarInFuture() { info().log("NopMetricsImpl incPublishDateTooFarInFuture();");}
+    public void incPublishDateTooFarInFuture() {
+        info().log("NopMetricsImpl incPublishDateTooFarInFuture();");
+    }
 }

--- a/src/test/java/com/github/onsdigital/babbage/metrics/MetricsFactoryTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/metrics/MetricsFactoryTest.java
@@ -18,17 +18,6 @@ public class MetricsFactoryTest {
     }
 
     @Test
-    public void testInitAlreadyCalled() throws Exception {
-        //Given
-        TestsUtil.setPrivateStaticField(metricsFactory, "metrics", new NopMetricsImpl());
-
-        // Then
-        Exception exception = assertThrows(Exception.class,
-                () -> MetricsFactory.init());
-        assertTrue(exception.getMessage().contains("Init already called"));
-    }
-
-    @Test
     public void testInitMetricsEnabled() throws Exception {
         //Given
         TestsUtil.setPrivateStaticField(metricsFactory, "metrics", null);


### PR DESCRIPTION
- Moved the metrics to a Path rather than a port due to constraints of
nomad and consul
- Added new API endpoint for metrics overriding default carboni API
functionality to allow customising the content type
- Added new env var to switch metrics format between Text and Open,
defaults to Text in config and in endpoint if miss set
- Logic added to return a 501 if metrics is disabled
- Removed references to port and env var
- Removed confusing 'Init already called' exception and test
- Updated README