### PR TITLE
Fix/hotjar css bug

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -12,8 +12,8 @@
         {{#if_any (eq type "bulletin") (eq type "article") (eq type "compendium_landing_page") (eq type "compendium_chapter")}}
             <link rel="canonical" href="{{uri}}" />
         {{/if_any}}
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/7d2d294{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/7d2d294{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/f8224bf{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/f8224bf{{/if}}/css/pdf.css">{{/if}}
 
         {{> partials/gtm-data-layer }}
 
@@ -121,7 +121,7 @@
 			{{/if_eq}}
 		{{/if_eq}}
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-        <script src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/7d2d294{{/if}}/js/main.js"></script>
+        <script src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/f8224bf{{/if}}/js/main.js"></script>
         <script src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -52,7 +52,7 @@ The commented code below is what needs to go in the parent.
   {{/if}}
 
  	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/7d2d294{{/if}}/js/main.js"></script>
+  <script src="{{#if is_dev}}//{{location.hostname}}:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/f8224bf{{/if}}/js/main.js"></script>
   <script src="/js/app.js"></script>
 
   <script src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What

Fixing css bug with hotjar

### How to review

Sense check
Image check
- The image shows the query selector without the proposed change; spans at index 8-12 are the hotjar buttons
- With the new selector (the change) excluding hotjar buttons; the spans are excluded

<img width="1792" alt="hotjar buttons are displayed" src="https://github.com/ONSdigital/sixteens/assets/19624419/50e6c520-6fe6-496a-a933-7d5bbed28657">

### Who can review

!me