### PR TITLE
Stop redirect on failed categorisation

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/filter/UrlRedirectFilter.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/filter/UrlRedirectFilter.java
@@ -57,9 +57,6 @@ public class UrlRedirectFilter implements Filter {
             if (category.isPresent()) {
                 handlers.get(category.get()).handle(request, response);
                 return false;
-            } else {
-                handleError(request, response, new RedirectException(REDIRECT_URL_EXCEPTION, new Object[]{request.getRequestURI()}));
-                return false;
             }
         }
         return true;

--- a/src/test/java/com/github/onsdigital/babbage/api/filter/UrlRedirectFilterTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/api/filter/UrlRedirectFilterTest.java
@@ -101,15 +101,12 @@ public class UrlRedirectFilterTest {
 	}
 
 	@Test
-	public void shouldInvokeErrorHandler() throws Exception {
+	public void shouldNotRedirectOnFailedCategorisation() throws Exception {
 		when(mockRequest.getRequestURI())
-				.thenReturn("/ons/taxonomy/index.html")
-				.thenReturn("/somethingRandom");
+				.thenReturn("/onslogin.php");
 
-		filter.filter(mockRequest, mockResponse);
-
-		verify(mockResponse, times(1)).setStatus(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
-		verifyZeroInteractions(taxonomyHandlerMock, generalHandlerMock, dataExHandlerMock);
+		assertThat("Incorrect filter result test failed.", filter.filter(mockRequest, mockResponse), equalTo(true));
+		verifyZeroInteractions(taxonomyHandlerMock, dataExHandlerMock, generalHandlerMock);
 	}
 
 }


### PR DESCRIPTION
### What

If a request is for /ons* it currently causes a 5XX due to the category for the redirect not being found. This should 404 instead. 

### How to review

Try hitting /onslogin.php and see it 404s

### Who can review

Not me. 