### PR TITLE
Feature/upgrade handlebars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <handlebars-java-version>4.0.3</handlebars-java-version>
+        <handlebars-java-version>4.2.1</handlebars-java-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.5.6</powermock.version>
         <dp-logging.version>v2.0.0-beta.5</dp-logging.version>
@@ -84,13 +84,6 @@
             <version>${handlebars-java-version}</version>
         </dependency>
 
-        <!--Handlebars Java markdown uses an older version of pegdown with a peculiar bug, overwriting dependency explicitly-->
-        <dependency>
-            <groupId>org.pegdown</groupId>
-            <artifactId>pegdown</artifactId>
-            <version>1.4.2</version>
-        </dependency>
-
         <!-- Cryptography -->
         <dependency>
             <groupId>com.github.onsdigital</groupId>
@@ -150,6 +143,12 @@
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.14.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>4.13.0</version>
         </dependency>
 
         <!-- Test -->
@@ -249,12 +248,13 @@
             <artifactId>jackson-dataformat-cbor</artifactId>
             <version>${fasterxml.jackson.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
             <version>2.0.26</version>
         </dependency>
-     
+
 
     </dependencies>
 
@@ -372,19 +372,6 @@
                         </exclude>
 
                         <exclude>
-                            <!-- Trello card for this exclude: https://trello.com/c/ATXjzIlG/1005-upgrade-handlebars -->
-                            <groupId>com.github.jknack</groupId>
-                            <artifactId>handlebars</artifactId>
-                            <version>4.0.3</version>
-                        </exclude>
-                        <exclude>
-                            <!-- This is a transitive dependency of com.github.jknack:handlebars:4.0.3 -->
-                            <groupId>org.mozilla</groupId>
-                            <artifactId>rhino</artifactId>
-                            <version>1.7R4</version>
-                        </exclude>
-
-                        <exclude>
                             <!-- Trello card for this exclude: https://trello.com/c/1XDM7LBH/1006-upgrade-rome-rome-dependency -->
                             <groupId>rome</groupId>
                             <artifactId>rome</artifactId>
@@ -413,12 +400,17 @@
                         </exclude>
 
                         <exclude>
-                            <!-- This is to exclude vulnerability CVE-2023-2976 -->
+                            <!-- This is to exclude vulnerability CVE-2023-2976 - transitive depedency of elasticsearch -->
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
                             <version>18.0</version>
                         </exclude>
-                        
+                        <exclude>
+                            <!-- This is to exclude vulnerability CVE-2023-2976 transitive depedency of handlebars -->
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>23.0</version>
+                        </exclude>
                     </excludeCoordinates>
                 </configuration>
             </plugin>

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/ArrayHelpers.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/ArrayHelpers.java
@@ -6,10 +6,8 @@ import com.github.onsdigital.babbage.template.handlebars.helpers.base.BabbageHan
 import com.github.onsdigital.babbage.template.handlebars.helpers.util.HelperUtils;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by bren on 06/07/15.
@@ -18,7 +16,7 @@ public enum ArrayHelpers implements BabbageHandlebarsHelper<Iterable> {
 
     contains {
         @Override
-        public CharSequence apply(Iterable context, Options options) throws IOException {
+        public Object apply(Iterable context, Options options) throws IOException {
             Object value = options.param(0);
             if (options.isFalsy(context)) {
                 return options.inverse();
@@ -47,7 +45,7 @@ public enum ArrayHelpers implements BabbageHandlebarsHelper<Iterable> {
      */
     last {
         @Override
-        public CharSequence apply(Iterable context, Options options) throws IOException {
+        public Object apply(Iterable context, Options options) throws IOException {
             if (options.isFalsy(context)) {
                 return options.inverse();
             }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/ConditionHelpers.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/ConditionHelpers.java
@@ -4,7 +4,6 @@ import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Options;
 import com.github.onsdigital.babbage.template.handlebars.helpers.base.BabbageHandlebarsHelper;
 import com.github.onsdigital.babbage.template.handlebars.helpers.util.HelperUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 
@@ -16,7 +15,7 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
     //evaluates equality of given parameters
     eq {
         @Override
-        public CharSequence apply(Object context, Options o) throws IOException {
+        public Object apply(Object context, Options o) throws IOException {
             //Can not return String value of false, it will not be evaluated as falsy ( null, empty, etc, ) by handlebars java. Instead returning false
             return HelperUtils.isEqual(context, o.param(0)) ? valid() : null;
         }
@@ -31,7 +30,7 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
     //evaluates equality of given parameters
     ne {
         @Override
-        public CharSequence apply(Object context, Options o) throws IOException {
+        public Object apply(Object context, Options o) throws IOException {
             return HelperUtils.isNotEqual(context, o.param(0)) ? valid() : null;
         }
 
@@ -46,7 +45,7 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
     //evaluates equality of given parameters
     if_eq {
         @Override
-        public CharSequence apply(Object context, Options o) throws IOException {
+        public Object apply(Object context, Options o) throws IOException {
             return HelperUtils.isEqual(context, o.param(0)) ? o.fn() : o.inverse();
         }
 
@@ -61,7 +60,7 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
     //evaluates equality of given parameters
     if_ne {
         @Override
-        public CharSequence apply(Object context, Options o) throws IOException {
+        public Object apply(Object context, Options o) throws IOException {
             return HelperUtils.isNotEqual(context, o.param(0)) ? o.fn() : o.inverse();
         }
 
@@ -75,7 +74,7 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
         //evaluates existance
         if_null {
             @Override
-            public CharSequence apply(Object context, Options o) throws IOException {
+            public Object apply(Object context, Options o) throws IOException {
                 return ( context == null || "null".equals(String.valueOf(context)) ) ? o.fn() : o.inverse();
             }
     
@@ -88,7 +87,7 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
     //Render block if all given params are ok(ok as in resolves as true in javascript)
     if_all {
         @Override
-        public CharSequence apply(Object context, Options options) throws IOException {
+        public Object apply(Object context, Options options) throws IOException {
             if (options.isFalsy(context)) {
                 return options.inverse();
             } else {
@@ -113,7 +112,7 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
     //Render block if any given params are ok(ok as in resolves as true in javascript)
     if_any {
         @Override
-        public CharSequence apply(Object context, Options options) throws IOException {
+        public Object apply(Object context, Options options) throws IOException {
             if (!options.isFalsy(context)) {
                 return options.fn();
             } else {
@@ -137,7 +136,7 @@ public enum ConditionHelpers implements BabbageHandlebarsHelper<Object> {
     //Renders alternative value if value not available
     alt {
         @Override
-        public CharSequence apply(Object context, Options options) throws IOException {
+        public Object apply(Object context, Options options) throws IOException {
             if (!options.isFalsy(context)) {
                 return context.toString();
             } else {

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/DateHelpers.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/DateHelpers.java
@@ -28,7 +28,7 @@ public enum DateHelpers implements BabbageHandlebarsHelper<String> {
      */
     df {
         @Override
-        public CharSequence apply(String date, Options options) throws IOException {
+        public Object apply(String date, Options options) throws IOException {
             if (options.isFalsy(date)) {
                 return "";
             }
@@ -55,7 +55,7 @@ public enum DateHelpers implements BabbageHandlebarsHelper<String> {
         }
 
         @Override
-        public CharSequence apply(String date, Options options) throws IOException {
+        public Object apply(String date, Options options) throws IOException {
             if (options.isFalsy(date)) {
                 return null;
             }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/LookupBlockHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/LookupBlockHelper.java
@@ -20,7 +20,7 @@ public class LookupBlockHelper implements BabbageHandlebarsHelper {
 
      */
     @Override
-    public CharSequence apply(Object context, Options options) throws IOException {
+    public Object apply(Object context, Options options) throws IOException {
         if (options.params.length <= 0) {
             return options.inverse();
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/LoopHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/LoopHelper.java
@@ -24,7 +24,7 @@ public class LoopHelper extends EachHelper implements BabbageHandlebarsHelper<Ob
     public static final String HELPER_NAME = "loop";
 
     @Override
-    public CharSequence apply(Object context, Options options) throws IOException {
+    public Object apply(Object context, Options options) throws IOException {
         if (options.isFalsy(context)) {
             return options.inverse();
         }
@@ -42,12 +42,12 @@ public class LoopHelper extends EachHelper implements BabbageHandlebarsHelper<Ob
         return super.apply(buildList((Number) context), options);
     }
 
-    private CharSequence apply(final List list, final Options options, int limit)
+    private Object apply(final List list, final Options options, int limit)
             throws IOException {
         return render(list, options, limit);
     }
 
-    private CharSequence render(final List<Object> context, final Options options, int limit)
+    private Object render(final List<Object> context, final Options options, int limit)
             throws IOException {
         StringBuilder buffer = new StringBuilder();
         int index = -1;

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/MathHelpers.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/MathHelpers.java
@@ -3,8 +3,6 @@ package com.github.onsdigital.babbage.template.handlebars.helpers;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Options;
 import com.github.onsdigital.babbage.template.handlebars.helpers.base.BabbageHandlebarsHelper;
-import com.github.onsdigital.babbage.template.handlebars.helpers.util.HelperUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 
@@ -17,7 +15,7 @@ public enum MathHelpers implements BabbageHandlebarsHelper<Object> {
 
     increment {
         @Override
-        public CharSequence apply(Object context, Options options) throws IOException {
+        public Object apply(Object context, Options options) throws IOException {
             Double num = toNumber(context);
             if (num == null) {
                 return null;
@@ -34,7 +32,7 @@ public enum MathHelpers implements BabbageHandlebarsHelper<Object> {
     },
     decrement {
         @Override
-        public CharSequence apply(Object context, Options options) throws IOException {
+        public Object apply(Object context, Options options) throws IOException {
             Double num = toNumber(context);
             if (num == null) {
                 return null;
@@ -52,7 +50,7 @@ public enum MathHelpers implements BabbageHandlebarsHelper<Object> {
 
     add {
         @Override
-        public CharSequence apply(Object context, Options options) throws IOException {
+        public Object apply(Object context, Options options) throws IOException {
             Double result = toNumber(context);
             Object[] params = options.params;
             for (Object param : params) {

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/MinifyBlockHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/MinifyBlockHelper.java
@@ -3,11 +3,8 @@ package com.github.onsdigital.babbage.template.handlebars.helpers;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Options;
 import com.github.onsdigital.babbage.template.handlebars.helpers.base.BabbageHandlebarsHelper;
-import com.github.onsdigital.babbage.template.handlebars.helpers.util.HelperUtils;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 public class MinifyBlockHelper implements BabbageHandlebarsHelper {
 
@@ -26,7 +23,7 @@ public class MinifyBlockHelper implements BabbageHandlebarsHelper {
 
      */
     @Override
-    public CharSequence apply(Object context, Options options) throws IOException {
+    public Object apply(Object context, Options options) throws IOException {
         return options.fn().toString().trim().replace("\t", "").replace("\n", "");
     }
 

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/NumberFormatHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/NumberFormatHelper.java
@@ -22,7 +22,7 @@ public class NumberFormatHelper implements BabbageHandlebarsHelper<Object> {
     }
 
     @Override
-    public CharSequence apply(Object context, Options options) throws IOException {
+    public Object apply(Object context, Options options) throws IOException {
         Double number = HelperUtils.toNumber(context);
         if (number == null) {
             Object o = options.hash("alt");

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/NumberPrintHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/NumberPrintHelper.java
@@ -22,7 +22,7 @@ public class NumberPrintHelper implements BabbageHandlebarsHelper<Object> {
     }
 
     @Override
-    public CharSequence apply(Object context, Options options) throws IOException {
+    public Object apply(Object context, Options options) throws IOException {
         Double num = HelperUtils.toNumber(context);
         if (num == null) {
             return "null";

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/PathHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/PathHelper.java
@@ -18,7 +18,7 @@ public enum PathHelper implements BabbageHandlebarsHelper<String> {
 
     absolute   {
         @Override
-        public CharSequence apply(String uri, Options options) throws IOException {
+        public Object apply(String uri, Options options) throws IOException {
             if(options.isFalsy(uri)) {
                 return null;
             }
@@ -34,7 +34,7 @@ public enum PathHelper implements BabbageHandlebarsHelper<String> {
 
     parentPath {
         @Override
-        public CharSequence apply(String uri, Options options) throws IOException {
+        public Object apply(String uri, Options options) throws IOException {
             if (options.isFalsy(uri)) {
                 return null;
             }
@@ -51,7 +51,7 @@ public enum PathHelper implements BabbageHandlebarsHelper<String> {
     fe {
 
         @Override
-        public CharSequence apply(String uri, Options options) throws IOException {
+        public Object apply(String uri, Options options) throws IOException {
             if (options.isFalsy(uri)) {
                 return null;
             }
@@ -68,7 +68,7 @@ public enum PathHelper implements BabbageHandlebarsHelper<String> {
     /*File name*/
     fn {
         @Override
-        public CharSequence apply(String uri, Options options) throws IOException {
+        public Object apply(String uri, Options options) throws IOException {
             if (options.isFalsy(uri)) {
                 return null;
             }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.babbage.template.handlebars.helpers;
 
-import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Options;
 import com.github.onsdigital.babbage.template.handlebars.helpers.base.BabbageHandlebarsHelper;
@@ -17,7 +16,7 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
 
     totalWordCount {
         @Override
-        public CharSequence apply(Object context, Options options) throws IOException {
+        public Object apply(Object context, Options options) throws IOException {
             if (isEmpty(context, options)) {
                 return null;
             }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SignedURLHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SignedURLHelper.java
@@ -19,7 +19,7 @@ public enum SignedURLHelper implements BabbageHandlebarsHelper<String> {
     //Sign a URL
     sign_url {
         @Override
-        public CharSequence apply(String context, Options options) throws IOException {
+        public Object apply(String context, Options options) throws IOException {
             if (options.isFalsy(context)) {
                 return null;
             }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelper.java
@@ -17,7 +17,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
     //Concat given strings
     concat {
         @Override
-        public CharSequence apply(String context, Options options) throws IOException {
+        public Object apply(String context, Options options) throws IOException {
             if (options.isFalsy(context)) {
                 return null;
             }
@@ -39,7 +39,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
 
     lowercase {
         @Override
-        public CharSequence apply(String context, Options options) throws IOException {
+        public Object apply(String context, Options options) throws IOException {
             if (options.isFalsy(context)) {
                 return null;
             }
@@ -54,7 +54,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
 
     startsWith {
         @Override
-        public CharSequence apply(String context, Options options) throws IOException {
+        public Object apply(String context, Options options) throws IOException {
             if (options.isFalsy(context) || options.params.length == 0) {
                 return null;
             }
@@ -69,7 +69,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
 
     endsWith {
         @Override
-        public CharSequence apply(String context, Options options) throws IOException {
+        public Object apply(String context, Options options) throws IOException {
             if (options.isFalsy(context) || options.params.length == 0) {
                 return null;
             }
@@ -84,7 +84,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
 
     containsAny {
         @Override
-        public CharSequence apply(String context, Options options) throws IOException {
+        public Object apply(String context, Options options) throws IOException {
             if (options.isFalsy(context) || options.params == null) {
                 return null;
             }
@@ -108,7 +108,7 @@ public enum StringHelper implements BabbageHandlebarsHelper<String> {
         private final Pattern htmlTagRegexPattern = Pattern.compile("\\<[^>]*>");
 
         @Override
-        public CharSequence apply(String context, Options options) throws IOException {
+        public Object apply(String context, Options options) throws IOException {
             if (options.isFalsy(context)) {
                 return null;
             }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/CustomMarkdownHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/CustomMarkdownHelper.java
@@ -25,7 +25,7 @@ public class CustomMarkdownHelper extends MarkdownHelper implements BabbageHandl
     private final String HELPER_NAME = "md";
 
     @Override
-    public CharSequence apply(Object context, Options options) throws IOException {
+    public Object apply(Object context, Options options) throws IOException {
         if (options.isFalsy(context)) {
             return "";
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/SubscriptHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/SubscriptHelper.java
@@ -20,7 +20,7 @@ public class SubscriptHelper implements BabbageHandlebarsHelper<String> {
     }
 
     @Override
-    public CharSequence apply(String text, Options options) throws IOException {
+    public Object apply(String text, Options options) throws IOException {
         if (options.isFalsy(text)) {
             return "";
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/SuperscriptHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/SuperscriptHelper.java
@@ -21,7 +21,7 @@ public class SuperscriptHelper implements BabbageHandlebarsHelper<String> {
     }
 
     @Override
-    public CharSequence apply(String text, Options options) throws IOException {
+    public Object apply(String text, Options options) throws IOException {
         if (options.isFalsy(text)) {
             return "";
         }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpers.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpers.java
@@ -40,7 +40,7 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
      */
     resolve {
         @Override
-        public CharSequence apply(Object uri, Options options) throws IOException {
+        public Object apply(Object uri, Options options) throws IOException {
             ContentResponse contentResponse;
             try {
                 validateUri(uri);
@@ -74,7 +74,7 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
 
     resolveDatasets {
         @Override
-        public CharSequence apply(Object uri, Options options) throws IOException {
+        public Object apply(Object uri, Options options) throws IOException {
             ContentResponse contentResponse;
             try {
                 validateUri(uri);
@@ -105,7 +105,7 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
     resolveTimeSeriesList {
         @Override
 
-        public CharSequence apply(Object uri, Options options) throws IOException {
+        public Object apply(Object uri, Options options) throws IOException {
             try {
 
                 validateUri(uri);
@@ -132,7 +132,7 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
     //Resolve latest article or bulletin with given uri
     resolveLatest {
         @Override
-        public CharSequence apply(Object uri, Options options) throws IOException {
+        public Object apply(Object uri, Options options) throws IOException {
             ContentResponse contentResponse;
             try {
                 validateUri(uri);
@@ -169,7 +169,7 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
      */
     resolveTaxonomy {
         @Override
-        public CharSequence apply(Object uri, Options options) throws IOException {
+        public Object apply(Object uri, Options options) throws IOException {
             ContentResponse stream = null;
             Integer depth;
             try {
@@ -208,7 +208,7 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
      */
     resolveResource {
         @Override
-        public CharSequence apply(Object uri, Options options) throws IOException {
+        public Object apply(Object uri, Options options) throws IOException {
             ContentResponse contentResponse = null;
             try {
                 validateUri(uri);
@@ -239,7 +239,7 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
      */
     resolveParents {
         @Override
-        public CharSequence apply(Object uri, Options options) throws IOException {
+        public Object apply(Object uri, Options options) throws IOException {
             ContentResponse stream = null;
 
             try {
@@ -268,7 +268,7 @@ public enum DataHelpers implements BabbageHandlebarsHelper<Object> {
      */
     fs {
         @Override
-        public CharSequence apply(Object uri, Options options) throws IOException {
+        public Object apply(Object uri, Options options) throws IOException {
             if (options.isFalsy(uri)) {
                 return null;
             }

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/web/WebHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/web/WebHelper.java
@@ -14,7 +14,7 @@ public enum WebHelper implements BabbageHandlebarsHelper<Object> {
 
     query_string {
         @Override
-        public CharSequence apply(Object context, Options options) throws IOException {
+        public Object apply(Object context, Options options) throws IOException {
             Map<String, Object> queryParameters = (Map<String, Object>) options.context.get("parameters");
             String exclude = options.hash("exclude");
 

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
@@ -112,7 +112,7 @@ public class SectionsHelperTest {
     public void testTotalWordCount_WithNoSections_ReturnsNull() throws Exception {
         List<Map<String, String>> sections = new ArrayList<>();
 
-        CharSequence result = SectionsHelper.totalWordCount.apply(sections, options);
+        Object result = SectionsHelper.totalWordCount.apply(sections, options);
         assertThat(result, equalTo(null));
     }
 }

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/StringHelperTest.java
@@ -50,7 +50,7 @@ public class StringHelperTest {
     @Test
     public void testWordCount_WithEmptyString_ReturnsNull() throws Exception {
         when(options.isFalsy(any())).thenReturn(true);
-        CharSequence result = StringHelper.wordCount.apply("", options);
+        Object result = StringHelper.wordCount.apply("", options);
         assertThat(result, equalTo(null));
     }
 }

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpersTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpersTest.java
@@ -73,7 +73,7 @@ public class DataHelpersTest {
         mockDH.isPublication = false;
         mockDH.isNavigation = true;
 
-        CharSequence resolve = mockDH.resolveTaxonomy.apply(uri, options);
+        Object resolve = mockDH.resolveTaxonomy.apply(uri, options);
         assertTrue(resolve.toString().isEmpty());
     }
     @Test
@@ -88,7 +88,7 @@ public class DataHelpersTest {
         testItemList.add(ItemMapBusinessSubtopics());
         mockDH.isPublication = true;
         mockDH.isNavigation = true;
-        CharSequence resolve = mockDH.resolveTaxonomy.apply(uri, options);
+        Object resolve = mockDH.resolveTaxonomy.apply(uri, options);
         assertTrue(resolve.toString().isEmpty());
     }
 

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpersTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/resolve/DataHelpersTest.java
@@ -73,7 +73,7 @@ public class DataHelpersTest {
         mockDH.isPublication = false;
         mockDH.isNavigation = true;
 
-        Object resolve = mockDH.resolveTaxonomy.apply(uri, options);
+        Object resolve = DataHelpers.resolveTaxonomy.apply(uri, options);
         assertTrue(resolve.toString().isEmpty());
     }
     @Test
@@ -88,7 +88,7 @@ public class DataHelpersTest {
         testItemList.add(ItemMapBusinessSubtopics());
         mockDH.isPublication = true;
         mockDH.isNavigation = true;
-        Object resolve = mockDH.resolveTaxonomy.apply(uri, options);
+        Object resolve = DataHelpers.resolveTaxonomy.apply(uri, options);
         assertTrue(resolve.toString().isEmpty());
     }
 
@@ -115,7 +115,5 @@ public class DataHelpersTest {
         builder.setHash(optionMap);
         return builder.build();
     }
-
-
 
 }


### PR DESCRIPTION
### What

Upgraded handlebars - I've taken it to 4.2.1 instead of 4.3.1 as handlebars-markdown is deprecated in 4.3.1

Due to Handlebars 4.3.1 using generic Object instead of CharSequences for the Helper.Apply I went through and changed all of them. 

Added explicit dependency for antlr4 in pom.xml.
Small bit of tidying.

Removed some excludes that are no longer relevant. 

I've added an exclude for guava because we have the same vulnerability already excluded for the elasticsearch dependency that we cannot upgrade. Therefore to remove it would be timeconsuming and gain no value. I tried overriding guava to the latest version but it introduces a lot of breaking changes. 

### How to review

Ensure Babbage is still rendering things. 

### Who can review

Not me - Java engineer likely, or a FE. 