### PR TITLE
Introduce post publish micro caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,25 @@ Babbage runs independently. However, in order to run it locally in its publishin
 
 ### Configuration
 
-| Environment variable           | Default                | Description                                                                                                       |
-|--------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------|
-| CONTENT_SERVICE_MAX_CONNECTION | 50                     | The maximum number of connections Babbage can make to the content service                                         |
-| CONTENT_SERVICE_URL            | http://localhost:8082  | The URL to the content service (zebedee)                                                                          |
-| ELASTIC_SEARCH_SERVER          | localhost              | The elastic search host and port (The http:// scheme prefix is added programmatically)                            |
-| ELASTIC_SEARCH_CLUSTER         |                        | The elastic search cluster                                                                                        |
-| ENABLE_CACHE                   | N                      | Switch to use (or not) the cache                                                                                  |
-| ENABLE_COVID19_FEATURE         |                        | Switch to use (or not) the covid feature                                                                          |
-| ENABLE_METRICS                 | N                      | Switch to collect (or not) metrics about cache expiry times                                                       |
-| METRICS_FORMAT                 | Text                   | Available options are Text or Open documented here <https://prometheus.io/docs/instrumenting/exposition_formats/> |
-| HIGHCHARTS_EXPORT_SERVER       | http://localhost:9999/ | The URL to the highcharts export server                                                                           |
-| IS_PUBLISHING                  | N                      | Switch to use (or not) the publishing functionality                                                               |
-| MAP_RENDERER_HOST              | http://localhost:23500 | The URL to the map renderer                                                                                       |
-| REDIRECT_SECRET                | secret                 | The code for the redirect                                                                                         |
-| TABLE_RENDERER_HOST            | http://localhost:23300 | The URL to the table renderer                                                                                     |
-| POOLED_CONNECTION_TIMEOUT      | 5000                   | The number of milliseconds to wait before closing expired connections                                             |
-| IDLE_CONNECTION_TIMEOUT        | 60                     | The number of seconds to wait before closing idle connections                                                     |
+| Environment variable             | Default                | Description                                                                                                       |
+|----------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------|
+| CONTENT_SERVICE_MAX_CONNECTION   | 50                     | The maximum number of connections Babbage can make to the content service                                         |
+| CONTENT_SERVICE_URL              | http://localhost:8082  | The URL to the content service (zebedee)                                                                          |
+| ELASTIC_SEARCH_SERVER            | localhost              | The elastic search host and port (The http:// scheme prefix is added programmatically)                            |
+| ELASTIC_SEARCH_CLUSTER           |                        | The elastic search cluster                                                                                        |
+| ENABLE_CACHE                     | N                      | Switch to use (or not) the cache                                                                                  |
+| ENABLE_COVID19_FEATURE           |                        | Switch to use (or not) the covid feature                                                                          |
+| ENABLE_METRICS                   | N                      | Switch to collect (or not) metrics about cache expiry times                                                       |
+| METRICS_FORMAT                   | Text                   | Available options are Text or Open documented here <https://prometheus.io/docs/instrumenting/exposition_formats/> |
+| HIGHCHARTS_EXPORT_SERVER         | http://localhost:9999/ | The URL to the highcharts export server                                                                           |
+| IS_PUBLISHING                    | N                      | Switch to use (or not) the publishing functionality                                                               |
+| MAP_RENDERER_HOST                | http://localhost:23500 | The URL to the map renderer                                                                                       |
+| REDIRECT_SECRET                  | secret                 | The code for the redirect                                                                                         |
+| TABLE_RENDERER_HOST              | http://localhost:23300 | The URL to the table renderer                                                                                     |
+| POOLED_CONNECTION_TIMEOUT        | 5000                   | The number of milliseconds to wait before closing expired connections                                             |
+| IDLE_CONNECTION_TIMEOUT          | 60                     | The number of seconds to wait before closing idle connections                                                     |
+| POST_PUBLISH_CACHE_MAX_AGE       | 10                     | The cache max age for the post publish window                                                                     |
+| POST_PUBLISH_CACHE_EXPIRY_OFFSET | 180                    | The length of the post publish window                                                                             |
 
 ### Metrics
 

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
@@ -25,6 +25,8 @@ public class Babbage implements AppConfig {
     private static final String MAXAGE_SERVICE_KEY = "MAXAGE_SERVER";
     private static final String MAX_CACHE_ENTRIES = "CACHE_ENTRIES";
     private static final String MAX_OBJECT_SIZE = "CACHE_OBJECT_SIZE";
+    private static final String POST_PUBLISH_CACHE_MAX_AGE_KEY = "POST_PUBLISH_CACHE_MAX_AGE";
+    private static final String POST_PUBLISH_CACHE_EXPIRY_OFFSET_KEY = "POST_PUBLISH_CACHE_EXPIRY_OFFSET";
     private static final String REDIRECT_SECRET_KEY = "REDIRECT_SECRET";
     private static final String REINDEX_SERVICE_KEY = "REINDEX_SERVER";
     private static final String SERVICE_AUTH_TOKEN = "SERVICE_AUTH";
@@ -75,6 +77,16 @@ public class Babbage implements AppConfig {
     private final int resultsPerPage;
     private final long searchResponseCacheTime;
 
+    /**
+     * Post publish, temporary cache time to alleviate race conditions due to content copy
+     */
+    private final int postPublishCacheMaxAge;
+
+    /**
+     * Post publish, how long should we use the postPublishCacheMaxAge before going back to the default cache time
+     */
+    private final int postPublishCacheExpiryOffset;
+
     private Babbage() {
         apiRouterURL = getValueOrDefault(API_ROUTER_URL, "http://localhost:23200/v1");
         cacheEnabled = getStringAsBool(ENABLE_CACHE_KEY, "N");
@@ -93,6 +105,8 @@ public class Babbage implements AppConfig {
         maxHighchartsServerConnections = defaultIfBlank(getNumberValue("HIGHCHARTS_EXPORT_MAX_CONNECTION"), 50);
         maxResultsPerPage = 250;
         maxVisiblePaginatorLink = 5;
+        postPublishCacheMaxAge = defaultIfBlank(getNumberValue(POST_PUBLISH_CACHE_MAX_AGE_KEY), 10);
+        postPublishCacheExpiryOffset = defaultIfBlank(getNumberValue(POST_PUBLISH_CACHE_EXPIRY_OFFSET_KEY), 3 * 60);
         publishCacheTimeout = 60 * 60;
         redirectSecret = getValueOrDefault(REDIRECT_SECRET_KEY, "secret");
         resultsPerPage = 10;
@@ -177,6 +191,14 @@ public class Babbage implements AppConfig {
         return publishCacheTimeout;
     }
 
+    public int getPostPublishCacheMaxAge() {
+        return postPublishCacheMaxAge;
+    }
+
+    public int getPostPublishCacheExpiryOffset() {
+        return postPublishCacheExpiryOffset;
+    }
+
     public int getResultsPerPage() {
         return resultsPerPage;
     }
@@ -211,6 +233,8 @@ public class Babbage implements AppConfig {
         config.put("maxHighchartsServerConnections", maxHighchartsServerConnections);
         config.put("maxResultsPerPage", maxResultsPerPage);
         config.put("maxVisiblePaginatorLink", maxVisiblePaginatorLink);
+        config.put("postPublishCacheMaxAge", postPublishCacheMaxAge);
+        config.put("postPublishCacheExpiryOffset", postPublishCacheExpiryOffset);
         config.put("publishCacheTimeout", publishCacheTimeout);
         config.put("reindexSecret", reindexSecret);
         config.put("resultsPerPage", resultsPerPage);

--- a/src/test/java/com/github/onsdigital/babbage/configuration/BabbageTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/configuration/BabbageTest.java
@@ -37,6 +37,8 @@ public class BabbageTest extends junit.framework.TestCase {
         assertEquals(testInstance.isDevEnv(), false);
         assertEquals(testInstance.isDevEnvironment(), false);
         assertEquals(testInstance.isPublishing(), false);
+        assertEquals(testInstance.getPostPublishCacheMaxAge(), 10);
+        assertEquals(testInstance.getPostPublishCacheExpiryOffset(), 180);
 
         Map<String, Object> mockConfig;
         mockConfig = Babbage.getInstance().getConfig();
@@ -54,6 +56,8 @@ public class BabbageTest extends junit.framework.TestCase {
         assertEquals(mockConfig.get("searchResponseCacheTime"), testInstance.getSearchResponseCacheTime());
         assertNotNull(mockConfig.get("maxAgeSecret"));
         assertNotNull(mockConfig.get("reindexSecret"));
+        assertEquals(mockConfig.get("postPublishCacheMaxAge"), testInstance.getPostPublishCacheMaxAge());
+        assertEquals(mockConfig.get("postPublishCacheExpiryOffset"), testInstance.getPostPublishCacheExpiryOffset());
     }
     @Test
     public void testGetApiRouterURL() {
@@ -69,12 +73,13 @@ public class BabbageTest extends junit.framework.TestCase {
         assertEquals(testInstance.getServiceAuthToken(),"ahyofaem2ieVie6eipaX6ietigh1oeM0Aa1aiyaebiemiodaiJah0eenuchei1ai");
     }
 
-@Test
-public void testIsNavigationEnabled() {
-    Babbage testInstance = Babbage.getInstance();
-    assertNotNull(testInstance.isNavigationEnabled());
-    assertFalse(testInstance.isNavigationEnabled());
-}
+    @Test
+    public void testIsNavigationEnabled() {
+        Babbage testInstance = Babbage.getInstance();
+        assertNotNull(testInstance.isNavigationEnabled());
+        assertFalse(testInstance.isNavigationEnabled());
+    }
+
     @Test
     public void testGetMaxCacheEntries() {
         Babbage testInstance = Babbage.getInstance();
@@ -82,12 +87,12 @@ public void testIsNavigationEnabled() {
         assertEquals(testInstance.getMaxCacheEntries(),3000);
     }
 
-//    getMaxCacheObjectSize
-@Test
-public void testGetMaxCacheObjectSize() {
-    Babbage testInstance = Babbage.getInstance();
-    assertNotNull(testInstance.getMaxCacheObjectSize());
-    assertEquals(testInstance.getMaxCacheObjectSize(),50000);
-}
+    // getMaxCacheObjectSize
+    @Test
+    public void testGetMaxCacheObjectSize() {
+        Babbage testInstance = Babbage.getInstance();
+        assertNotNull(testInstance.getMaxCacheObjectSize());
+        assertEquals(testInstance.getMaxCacheObjectSize(),50000);
+    }
 
 }


### PR DESCRIPTION
### What

Altered the caching algorithm so that post publish it issues a non-standard amount (default 10s). It will do this for a time limit (default 3 mins) or until zebedee has notified that has been published. 

### How to review

Try to publish something and see what the caching results are. 

> 15 mins till publish = 15 min cache
< 15 mins till publish = remaining time till publish
< 3 mins post publish & has not published = 10s cache
> 3 mins post publish || has published = 15 min cache

### Who can review

Not me. 