### PR TITLE
Fix breadcrumb appearing on error pages

### DIFF
--- a/src/main/web/templates/handlebars/breadcrumbs.handlebars
+++ b/src/main/web/templates/handlebars/breadcrumbs.handlebars
@@ -37,5 +37,7 @@
         {{> list/partials/list-page-breadcrumb label=labels.previous}}
     {{/if_eq}}
 {{else}}
-    {{> partials/breadcrumb}}
+    {{#if_ne type "error"}}
+        {{> partials/breadcrumb}}
+    {{/if_ne }}
 {{/if_eq}}

--- a/src/main/web/templates/handlebars/error/401.handlebars
+++ b/src/main/web/templates/handlebars/error/401.handlebars
@@ -5,7 +5,7 @@
   </div>
   <!-- /nav-panel -->
 </div>
-<div class="wrapper panel--mar">
+<div class="wrapper panel--mar margin-bottom--8">
   <div class="grid-wrap">
     <div class="grid-col desktop-grid-full-width">
       <article>

--- a/src/main/web/templates/handlebars/error/404.handlebars
+++ b/src/main/web/templates/handlebars/error/404.handlebars
@@ -5,7 +5,7 @@
   </div>
   <!-- /nav-panel -->
 </div>
-<div class="wrapper panel--mar">
+<div class="wrapper panel--mar margin-bottom--8">
   <div class="grid-wrap">
     <div class="grid-col desktop-grid-full-width">
       <article>

--- a/src/main/web/templates/handlebars/error/500.handlebars
+++ b/src/main/web/templates/handlebars/error/500.handlebars
@@ -7,7 +7,7 @@
     </div>
     <!-- /nav-panel -->
 </div>
-<div class="wrapper panel--bottom-mar">
+<div class="wrapper panel--mar margin-bottom--8">
     <div class="grid-wrap">
         <div class="grid-col desktop-grid-full-width">
             <article>


### PR DESCRIPTION
### What

- Fix/prevent breadcrumb appearing on error pages
- Add some spacing to bottom of content on error pages

<img width="1037" alt="image" src="https://github.com/ONSdigital/babbage/assets/12159136/bf865501-80ca-49f1-b9d3-4dbfbd937829">


### Who can review

Anyone
