### PR TITLE
changed logging version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,7 @@
         <handlebars-java-version>4.0.3</handlebars-java-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.5.6</powermock.version>
-        <!--dp-logging.version>v2.0.0-beta.6</dp-logging.version-->
-         <dp-logging.version>8c01597</dp-logging.version>
+        <dp-logging.version>v2.0.0-beta.7</dp-logging.version>
         
         <fasterxml.jackson.version>2.15.0</fasterxml.jackson.version>
         <jetty.version>9.4.53.v20231009</jetty.version>


### PR DESCRIPTION
### What

Updated to latest release of dp-logging to trap unexpected errors from otel. babbage-web has something odd going on with classpaths/dependencies which leads to a NoSuchMethodError being thrown when OpenTelemetry TraceID.getFromBytes() is called, even though the dependency from dp-logging is transitive. This doesn't happen in babbage-publishing, which is even odder.

### How to review

visual check of pom. CI.

### Who can review

Fran