### PR TITLE
Avoid null exception in section word count

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,27 @@
                             <artifactId>dom4j</artifactId>
                             <version>2.1.4</version>
                         </exclude>
-                        
+
+                        <exclude>
+                            <!-- This is to exclude vulnerability CVE-2023-6378 
+                            Upgrading dp-logging causes clashes with restolino for 
+                            backing logging service. To be addressed by ANDDigital
+                            maintenance package -->
+                            <groupId>ch.qos.logback</groupId>
+                            <artifactId>logback-core</artifactId>
+                            <version>1.2.11</version>
+                        </exclude>
+
+                        <exclude>
+                            <!-- This is to exclude vulnerability CVE-2023-6378 
+                            Upgrading dp-logging causes clashes with restolino for 
+                            backing logging service. To be addressed by ANDDigital
+                            maintenance package -->
+                            <groupId>ch.qos.logback</groupId>
+                            <artifactId>logback-classic</artifactId>
+                            <version>1.2.11</version>
+                        </exclude>
+
                     </excludeCoordinates>
                 </configuration>
             </plugin>

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelper.java
@@ -49,8 +49,16 @@ public enum SectionsHelper implements BabbageHandlebarsHelper<Object> {
 
             CustomMarkdownHelper mdHelper = new CustomMarkdownHelper();
             String mdHtml = mdHelper.apply(md, options).toString();
-            String wordCount = StringHelper.wordCount.apply(mdHtml, options).toString();
-            return Integer.parseInt(wordCount);
+            
+            // String Helper returns a CharSequence that can sometimes be null.
+            CharSequence wordCountSeq = StringHelper.wordCount.apply(mdHtml, options);
+
+            if (wordCountSeq == null) {
+                return 0;
+            } else {
+                String wordCount = wordCountSeq.toString();
+                return Integer.parseInt(wordCount);
+            }
         }
 
         private int calculateWordCountFromSection(String title, Options options) throws IOException {

--- a/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/template/handlebars/helpers/SectionsHelperTest.java
@@ -115,4 +115,17 @@ public class SectionsHelperTest {
         CharSequence result = SectionsHelper.totalWordCount.apply(sections, options);
         assertThat(result, equalTo(null));
     }
+
+    @Test
+    public void testTotalWordCount_WithBlankSpace_NoErrors() throws Exception {
+        List<Map<String, String>> sections = new ArrayList<>();
+
+        Map<String, String> section1 = new HashMap<>();
+        section1.put("markdown", " ");
+        section1.put("title", "");
+        sections.add(section1);
+
+        String result = SectionsHelper.totalWordCount.apply(sections, options).toString();
+        assertThat(result, equalTo("0"));
+    }
 }


### PR DESCRIPTION
### What

Stopped 'internal error' caused by blank spaces in sections triggering wordCount errors. 

### How to review

Check ok, tests pass, optionally can create content that has a 'section' with a space in the markdown. 

### Who can review

Not me. 