### PR TITLE
Feature/wrap caching feature in feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Babbage runs independently. However, in order to run it locally in its publishin
 | ENABLE_CACHE                     | N                      | Switch to use (or not) the cache                                                                                  |
 | ENABLE_COVID19_FEATURE           |                        | Switch to use (or not) the covid feature                                                                          |
 | ENABLE_METRICS                   | N                      | Switch to collect (or not) metrics about cache expiry times                                                       |
+| ENABLE_LEGACY_CACHE_API          | N                      | Enable legacy cache API                                                                                           |
+| LEGACY_CACHE_PROXY_URL           | http://localhost:29200 | The URL to the legacy cache proxy                                                                                 |
 | METRICS_FORMAT                   | Text                   | Available options are Text or Open documented here <https://prometheus.io/docs/instrumenting/exposition_formats/> |
 | HIGHCHARTS_EXPORT_SERVER         | http://localhost:9999/ | The URL to the highcharts export server                                                                           |
 | IS_PUBLISHING                    | N                      | Switch to use (or not) the publishing functionality                                                               |

--- a/build-service-babbage.sh
+++ b/build-service-babbage.sh
@@ -1,1 +1,0 @@
-/Users/andreurbani/Downloads/ann/web/build-service-babbage.sh

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <flying-saucer.version>9.4.1</flying-saucer.version>
+        <mockito.version>3.12.4</mockito.version>
     </properties>
 
     <dependencies>
@@ -164,8 +165,14 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/MaxAge.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/MaxAge.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Context;
 
 import com.github.davidcarboni.cryptolite.Password;
 import com.github.davidcarboni.restolino.framework.Api;
+import com.github.onsdigital.babbage.api.util.LegacyCacheProxyMaxAge;
 import com.github.onsdigital.babbage.content.client.ContentClient;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
@@ -55,6 +56,13 @@ public class MaxAge {
 
     protected int getMaxAge(HttpServletRequest request) throws Exception {
         String uri = request.getParameter("uri");
+
+        if (appConfig().babbage().isLegacyCacheAPIEnabled()) {
+            String legacyCacheProxyURL = appConfig().babbage().getLegacyCacheProxyUrl();
+            LegacyCacheProxyMaxAge legacyCacheProxyMaxAge = new LegacyCacheProxyMaxAge(legacyCacheProxyURL);
+            return legacyCacheProxyMaxAge.getMaxAgeValueFromLegacyCacheProxy(uri);
+        }
+
         ContentResponse contentResponse = ContentClient.getInstance().getContent(uri);
         return contentResponse.getMaxAge();
     }

--- a/src/main/java/com/github/onsdigital/babbage/api/util/LegacyCacheProxyMaxAge.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/util/LegacyCacheProxyMaxAge.java
@@ -1,0 +1,64 @@
+package com.github.onsdigital.babbage.api.util;
+
+import java.io.IOException;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import com.github.onsdigital.logging.v2.event.SimpleEvent;
+
+public class LegacyCacheProxyMaxAge {
+    private final String legacyCacheProxyUrl;
+
+    public LegacyCacheProxyMaxAge(String legacyCacheProxyUrl) {
+        this.legacyCacheProxyUrl = legacyCacheProxyUrl;
+    }
+
+    public int getMaxAgeValueFromLegacyCacheProxy(String resourceURI) {
+        int maxAgeValue = 0;
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpUriRequest forwardRequest = buildRequest(resourceURI);
+
+            try (CloseableHttpResponse proxyResponse = httpClient.execute(forwardRequest)) {
+                maxAgeValue = extractMaxAgeValue(proxyResponse);
+            }
+        } catch (IOException e) {
+            SimpleEvent.error().exception(e).log("Error getting max-age from legacy cache proxy");
+        }
+
+        return maxAgeValue;    
+    }
+    
+    private HttpUriRequest buildRequest(String resourceURI) {
+        String requestUri = legacyCacheProxyUrl + resourceURI;
+
+        return RequestBuilder.create("GET").setUri(requestUri).build();
+    }
+
+    private int extractMaxAgeValue(HttpResponse proxyResponse) {
+        int maxAgeValue = 0;
+
+        Header cacheControlHeader = proxyResponse.getFirstHeader("Cache-Control");
+
+        if (cacheControlHeader != null) {
+            String cacheControlValue = cacheControlHeader.getValue();
+            String[] directives = cacheControlValue.split(",");
+            for (String directive : directives) {
+                String trimmedDirective = directive.trim();
+                if (trimmedDirective.startsWith("max-age=")) {
+                    String maxAgeValueAsString = trimmedDirective.split("=")[1];
+                    maxAgeValue = Integer.parseInt(maxAgeValueAsString);
+                    break;
+                }
+            }
+        }
+
+        return maxAgeValue;
+    }
+}

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
@@ -19,6 +19,8 @@ public class Babbage implements AppConfig {
     private static final String ENABLE_METRICS_KEY = "ENABLE_METRICS";
     private static final String METRICS_FORMAT_KEY = "METRICS_FORMAT";
     private static final String ENABLE_NAVIGATION_KEY = "ENABLE_NAVIGATION";
+    private static final String ENABLE_LEGACY_CACHE_API = "ENABLE_LEGACY_CACHE_API";
+    private static final String LEGACY_CACHE_PROXY_URL = "LEGACY_CACHE_PROXY_URL";
     private static final String HIGHCHARTS_EXPORT_SERVER_KEY = "HIGHCHARTS_EXPORT_SERVER";
     private static final String IS_PUBLISHING_KEY = "IS_PUBLISHING";
     private static final String MATHJAX_EXPORT_SERVER_KEY = "MATHJAX_EXPORT_SERVER";
@@ -61,6 +63,7 @@ public class Babbage implements AppConfig {
      **/
     private final String apiRouterURL;
     private final String exportSeverUrl;
+    private final String legacyCacheProxyUrl;
     private final String mathjaxExportServer;
     private final String maxAgeSecret;
     private final String reindexSecret;
@@ -69,6 +72,7 @@ public class Babbage implements AppConfig {
     private final boolean cacheEnabled;
     private final boolean isDevEnv;
     private final boolean isNavigationEnabled;
+    private final boolean isLegacyCacheAPIEnabled;
     private final boolean isPublishing;
     private final int maxCacheEntries;
     private final int maxCacheObjectSize;
@@ -96,6 +100,8 @@ public class Babbage implements AppConfig {
         cacheEnabled = getStringAsBool(ENABLE_CACHE_KEY, "N");
         defaultCacheTime = defaultIfBlank(getNumberValue(DEFAULT_CACHE_TIME), 15 * 60);
         exportSeverUrl = getValueOrDefault(HIGHCHARTS_EXPORT_SERVER_KEY, "http://localhost:9999/");
+        legacyCacheProxyUrl = getValueOrDefault(LEGACY_CACHE_PROXY_URL, "http://localhost:29200");
+        isLegacyCacheAPIEnabled = getStringAsBool(ENABLE_LEGACY_CACHE_API, "N");
         isDevEnv = getStringAsBool(DEV_ENVIRONMENT_KEY, "N");
         isNavigationEnabled = getStringAsBool(ENABLE_NAVIGATION_KEY, "N");
         isPublishing = getStringAsBool(IS_PUBLISHING_KEY, "N");
@@ -125,6 +131,14 @@ public class Babbage implements AppConfig {
 
     public String getExportSeverUrl() {
         return exportSeverUrl;
+    }
+
+    public String getLegacyCacheProxyUrl() {
+        return legacyCacheProxyUrl;
+    }
+
+    public boolean isLegacyCacheAPIEnabled() {
+        return isLegacyCacheAPIEnabled;
     }
 
     public String getMathjaxExportServer() {
@@ -231,6 +245,7 @@ public class Babbage implements AppConfig {
         config.put("defaultCacheTime", defaultCacheTime);
         config.put("exportSeverUrl", exportSeverUrl);
         config.put("isDevEnv", isDevEnv);
+        config.put("isLegacyCacheAPIEnabled", isLegacyCacheAPIEnabled);
         config.put("isNavigationEnable", isNavigationEnabled);
         config.put("isPublishing", isPublishing);
         config.put("mathjaxExportServer", mathjaxExportServer);

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentClient.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentClient.java
@@ -42,6 +42,7 @@ public class ContentClient {
     private static int postPublishCacheMaxAge = appConfig().babbage().getPostPublishCacheMaxAge();
     private static int postPublishCacheExpiryOffset = appConfig().babbage().getPostPublishCacheExpiryOffset();
     private static boolean postPublishMicroCacheEnabled = appConfig().babbage().isPostPublishMicroCacheEnabled();
+    private static final boolean legacyCacheAPIEnabled = appConfig().babbage().isLegacyCacheAPIEnabled();
 
     private static PooledHttpClient client;
     private static ContentClient instance;
@@ -145,9 +146,8 @@ public class ContentClient {
         return resolveMaxAge(uri, sendGet(getPath(GENERATOR_ENDPOINT), addUri(uri, getParameters(queryParameters))));
     }
 
-
     private ContentResponse resolveMaxAge(String uri, ContentResponse response) {
-        if (!cacheEnabled) {
+        if (!cacheEnabled || legacyCacheAPIEnabled) {
             return response;
         }
 

--- a/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.babbage.response.util;
 
-import com.github.onsdigital.babbage.metrics.MetricsFactory;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -8,10 +7,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
 
 /**
  */
 public class CacheControlHelper {
+    private static final boolean legacyCacheAPIEnabled = appConfig().babbage().isLegacyCacheAPIEnabled();
 
     /**
      * Resolves and sets response status based on request cache control headers and data to be sent to the user
@@ -21,11 +22,16 @@ public class CacheControlHelper {
      */
     public static void setCacheHeaders(HttpServletRequest request, HttpServletResponse response, String hash, long maxAge) {
         resolveHash(request, response, hash);
-        setMaxAge(response, maxAge);
+
+        if (!legacyCacheAPIEnabled) {
+            setMaxAge(response, maxAge);
+        }
     }
 
     public static void setCacheHeaders(HttpServletResponse response, long maxAge) {
-        setMaxAge(response, maxAge);
+        if (!legacyCacheAPIEnabled) {
+            setMaxAge(response, maxAge);
+        }
     }
 
     private static void setMaxAge(HttpServletResponse response, long maxAge) {

--- a/src/test/java/com/github/onsdigital/babbage/api/endpoint/content/MaxAgeTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/api/endpoint/content/MaxAgeTest.java
@@ -1,25 +1,43 @@
 package com.github.onsdigital.babbage.api.endpoint.content;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
+import com.github.onsdigital.babbage.configuration.ApplicationConfiguration;
+import com.github.onsdigital.babbage.configuration.Babbage;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 
 public class MaxAgeTest {
     private final static String KEY_HASH = "the-key";
+
+    private AutoCloseable mockitoAnnotations;
+
+    private MockedStatic<ApplicationConfiguration> mockAppConfig;
+
+    private MockedStatic<HttpClients> mockHttpClients;
 
     @Mock
     private HttpServletRequest request;
@@ -33,8 +51,18 @@ public class MaxAgeTest {
 
     @Before
     public void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        mockitoAnnotations = MockitoAnnotations.openMocks(this);
+        mockAppConfig = mockStatic(ApplicationConfiguration.class);
+        mockHttpClients = mockStatic(HttpClients.class);
+
         when(endpoint.verifyKey(KEY_HASH)).thenReturn(true);
+    }
+
+    @After
+    public void closeService() throws Exception {
+        mockitoAnnotations.close();
+        mockAppConfig.close();
+        mockHttpClients.close();
     }
 
     @Test
@@ -62,6 +90,7 @@ public class MaxAgeTest {
         assertEquals("Failed calculating max age", endpoint.get(request, response));
         verify(response).setStatus(ex.getStatusCode());
     }
+
     @Test
     public void testGetEndpoint() throws Exception {
         int maxAge = 55;
@@ -70,4 +99,30 @@ public class MaxAgeTest {
         assertEquals(maxAge, endpoint.get(request, response));
     }
 
+    @Test
+    public void testGetEndpointWithCacheAPIEnabled() throws Exception {
+        Babbage mockBabbage = mock(Babbage.class);
+        when(mockBabbage.isLegacyCacheAPIEnabled()).thenReturn(true);
+        when(mockBabbage.getLegacyCacheProxyUrl()).thenReturn("mock-legacy-cache-proxy-url");
+
+        ApplicationConfiguration mockAppConfigInstance = mock(ApplicationConfiguration.class);
+        when(mockAppConfigInstance.babbage()).thenReturn(mockBabbage);
+
+        when(ApplicationConfiguration.appConfig()).thenReturn(mockAppConfigInstance);
+
+        CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+        when(mockResponse.getFirstHeader("Cache-Control")).thenReturn(new BasicHeader("Cache-Control", "max-age=3600"));
+
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        when(mockClient.execute(any())).thenReturn(mockResponse);
+
+        mockHttpClients.when(HttpClients::createDefault).thenReturn(mockClient);
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getParameter("uri")).thenReturn("/test/uri");
+
+        int maxAge = endpoint.getMaxAge(mockRequest);
+
+        assertEquals(3600, maxAge);
+    }
 }

--- a/src/test/java/com/github/onsdigital/babbage/api/endpoint/util/LegacyCacheProxyMaxAgeTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/api/endpoint/util/LegacyCacheProxyMaxAgeTest.java
@@ -1,0 +1,65 @@
+package com.github.onsdigital.babbage.api.endpoint.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import com.github.onsdigital.babbage.api.util.LegacyCacheProxyMaxAge;
+
+import java.io.IOException;
+
+public class LegacyCacheProxyMaxAgeTest {
+    private CloseableHttpResponse mockResponse;
+    private MockedStatic<HttpClients> mockHttpClients;
+    private LegacyCacheProxyMaxAge legacyCacheProxyMaxAge;
+
+    @Before
+    public void setUp() throws IOException {
+        mockResponse = mock(CloseableHttpResponse.class);
+
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        when(mockClient.execute(any())).thenReturn(mockResponse);
+
+        mockHttpClients = mockStatic(HttpClients.class);
+        mockHttpClients.when(HttpClients::createDefault).thenReturn(mockClient);
+
+        legacyCacheProxyMaxAge = new LegacyCacheProxyMaxAge("mock-legacy-cache-proxy-url");
+    }
+
+    @After
+    public void tearDown() {
+        mockHttpClients.close();
+    }
+
+    @Test
+    public void testGetMaxAgeValueFromLegacyCacheProxy_WhenCacheControlHeaderIsNull() {
+        when(mockResponse.getFirstHeader("Cache-Control")).thenReturn(null);
+
+        int result = legacyCacheProxyMaxAge.getMaxAgeValueFromLegacyCacheProxy("/test/resource/uri");
+
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void testGetMaxAgeValueFromLegacyCacheProxy_WhenCacheControlHeaderIsDeclared() {
+        Header cacheControl = new BasicHeader("Cache-Control", "public, max-age=3600");
+
+        when(mockResponse.getFirstHeader("Cache-Control")).thenReturn(cacheControl);
+
+        int result = legacyCacheProxyMaxAge.getMaxAgeValueFromLegacyCacheProxy("/test/resource/uri");
+
+        assertEquals(3600, result);
+    }
+}


### PR DESCRIPTION
### What

Feature flag added around caching features in Babbage so that only legacy-cache-proxy deals with setting the response's cache headers
Based on [maven repository](https://mvnrepository.com/artifact/org.mockito/mockito-all) mockito-all artifact was replaced by mockito-core hence pom.xml file was updated and mockit-inline has been added for the use of mockStatic.

### How to review

All caching work that's done in Babbage and the logic that looks up information in the publish times index in elastic search should have been wrapped with the feature flag or have been documented [here](https://confluence.ons.gov.uk/pages/viewpage.action?pageId=190295186) to be removed once the solution proxy and API solutions are done. 

### Who can review

Anyone from ONS
