### PR TITLE
Revert pegdown to an earlier version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,13 @@
             <version>${handlebars-java-version}</version>
         </dependency>
 
+        <!--Handlebars Java markdown uses a newer version of pegdown with a peculiar bug, overwriting dependency explicitly-->
+        <dependency>
+            <groupId>org.pegdown</groupId>
+            <artifactId>pegdown</artifactId>
+            <version>1.4.2</version>
+        </dependency>
+
         <!-- Cryptography -->
         <dependency>
             <groupId>com.github.onsdigital</groupId>


### PR DESCRIPTION
### What

Revert pegdown to an earlier used version (1.4.2)
Latest version brought in by handlebars has a parsing bug that causes an exponential execution loop

NB. This specific dependency was removed in #720 and this PR reverts that change

### How to review

Ensure tests pass etc.

### Who can review

Anyone