### PR TITLE
Error Handler Updated

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
@@ -46,8 +46,14 @@ public class ErrorHandler implements ServerError {
             error().exception(t).log("LegacyPDFException error");
             renderErrorPage(501, response);
         } else {
-            error().exception(t).log("unknown error");
-            renderErrorPage(500, response);
+            Exception e = (Exception) t;
+            if (e.getMessage().contains("Access Token required but none provided.") || e.getMessage().contains("JWT verification failed as token is expired.")){
+                error().exception(t).log("authorization error ");
+                renderErrorPage(401, response);
+            }else {
+                error().exception(t).log("unknown error");
+                renderErrorPage(500, response);
+            }
         }
     }
 

--- a/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
@@ -47,7 +47,7 @@ public class ErrorHandler implements ServerError {
             renderErrorPage(501, response);
         } else {
             Exception e = (Exception) t;
-            //When user is not logged into the florence, expected response is 401. but currently babbage receives 200, with the following error message
+            // When user is not logged in and we request authenticated resources from Zebedee, the expected response is 401. Zebedee currently gives 200, with the following error message:
             if (e.getMessage().contains("Access Token required but none provided.") || e.getMessage().contains("JWT verification failed as token is expired.")){
                 error().exception(t).log("authorization error");
                 renderErrorPage(401, response);

--- a/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
@@ -47,6 +47,7 @@ public class ErrorHandler implements ServerError {
             renderErrorPage(501, response);
         } else {
             Exception e = (Exception) t;
+            //When user is not logged into the florence, expected response is 401. but currently babbage receives 200, with the following error message
             if (e.getMessage().contains("Access Token required but none provided.") || e.getMessage().contains("JWT verification failed as token is expired.")){
                 error().exception(t).log("authorization error");
                 renderErrorPage(401, response);

--- a/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
@@ -48,9 +48,9 @@ public class ErrorHandler implements ServerError {
         } else {
             Exception e = (Exception) t;
             if (e.getMessage().contains("Access Token required but none provided.") || e.getMessage().contains("JWT verification failed as token is expired.")){
-                error().exception(t).log("authorization error ");
+                error().exception(t).log("authorization error");
                 renderErrorPage(401, response);
-            }else {
+            } else {
                 error().exception(t).log("unknown error");
                 renderErrorPage(500, response);
             }


### PR DESCRIPTION
### What

Updated Error Handler and added new condition to handle 401 scenario.
 
When user is not logged into the Florence, expected response is 401. but currently Babbage receives 200, with the following error message Access "Token required but none provided." 


### How to review

Check for the new condition

### Who can review

@anyone 