### PR TITLE
put quotes around Etag header value - as per spec (and Cloudflare!)

### DIFF
--- a/run-publishing.sh
+++ b/run-publishing.sh
@@ -5,7 +5,7 @@
 ./build-web.sh
 
 ### 2 - BUILD API
-./build-api.sh 
+./build-api.sh
 
 ### 3 - START BABBAGE
 export JAVA_OPTS="-Xdebug -Xmx256m -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"

--- a/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
@@ -56,7 +56,7 @@ public class CacheControlHelper {
                 .data("new_hash", newHash)
                 .log("resolving cache headers");
 
-        response.setHeader("Etag", newHash);
+        response.setHeader("Etag", "\"" + newHash + "\"");
         if (StringUtils.equals(oldHash, newHash)) {
             response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
         }


### PR DESCRIPTION
### What

The `Etag` header [spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#syntax) *and [Cloudflare](https://developers.cloudflare.com/cache/reference/etag-headers/#important-remarks)* require the etag value to be quoted.

Babbage should now put it in quotes

### How to review

Ensure the Etag is quoted.

### Who can review

!me
