### PR TITLE
Fix content hash

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/Hash.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/Hash.java
@@ -5,6 +5,7 @@ import com.github.onsdigital.babbage.content.client.ContentClient;
 import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
 import com.github.onsdigital.babbage.error.BabbageException;
+import com.github.onsdigital.babbage.response.util.CacheControlHelper;
 import org.apache.commons.io.IOUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -30,6 +31,7 @@ public class Hash {
 
             String uri = request.getParameter("uri");
             ContentResponse contentResponse = ContentClient.getInstance().getResource(uri);
+            CacheControlHelper.setCacheHeaders(request, response, contentResponse.getHash());
             IOUtils.write(contentResponse.getHash(), response.getOutputStream());
         } catch (ContentReadException e) {
             handleError(response, e.getStatusCode(), e);

--- a/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/Hash.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/endpoint/content/Hash.java
@@ -31,7 +31,7 @@ public class Hash {
 
             String uri = request.getParameter("uri");
             ContentResponse contentResponse = ContentClient.getInstance().getResource(uri);
-            CacheControlHelper.setCacheHeaders(request, response, contentResponse.getHash());
+            CacheControlHelper.resolveHash(request, response, contentResponse.getHash());
             IOUtils.write(contentResponse.getHash(), response.getOutputStream());
         } catch (ContentReadException e) {
             handleError(response, e.getStatusCode(), e);

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedBinaryResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedBinaryResponse.java
@@ -20,6 +20,6 @@ public class BabbageContentBasedBinaryResponse extends BabbageBinaryResponse {
 
     @Override
     protected void setCacheHeaders(HttpServletRequest request, HttpServletResponse response) {
-        CacheControlHelper.setCacheHeaders(request, response, CacheControlHelper.hashData(getData()));
+        CacheControlHelper.resolveHash(request, response, CacheControlHelper.hashData(getData()));
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedBinaryResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedBinaryResponse.java
@@ -1,6 +1,10 @@
 package com.github.onsdigital.babbage.response;
 
 import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.response.util.CacheControlHelper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,5 +16,10 @@ public class BabbageContentBasedBinaryResponse extends BabbageBinaryResponse {
     public BabbageContentBasedBinaryResponse(ContentResponse contentResponse, InputStream data, String mimeType) throws IOException {
         super(data, mimeType);
         this.contentResponse = contentResponse;
+    }
+
+    @Override
+    protected void setCacheHeaders(HttpServletRequest request, HttpServletResponse response) {
+        CacheControlHelper.setCacheHeaders(request, response, CacheControlHelper.hashData(getData()));
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedBinaryResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedBinaryResponse.java
@@ -19,7 +19,7 @@ public class BabbageContentBasedBinaryResponse extends BabbageBinaryResponse {
     }
 
     @Override
-    protected void setCacheHeaders(HttpServletRequest request, HttpServletResponse response) {
+    protected void setContentHash(HttpServletRequest request, HttpServletResponse response) {
         CacheControlHelper.resolveHash(request, response, CacheControlHelper.hashData(getData()));
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedStringResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedStringResponse.java
@@ -3,7 +3,10 @@ package com.github.onsdigital.babbage.response;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
 
 import java.io.IOException;
+import com.github.onsdigital.babbage.response.util.CacheControlHelper;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 public class BabbageContentBasedStringResponse extends BabbageStringResponse {
 
     private ContentResponse contentResponse;
@@ -16,5 +19,10 @@ public class BabbageContentBasedStringResponse extends BabbageStringResponse {
     public BabbageContentBasedStringResponse(ContentResponse contentResponse, String data) throws IOException {
         super(data);
         this.contentResponse = contentResponse;
+    }
+
+    @Override
+    protected void setCacheHeaders(HttpServletRequest request, HttpServletResponse response) {
+        CacheControlHelper.setCacheHeaders(request, response, CacheControlHelper.hashData(getData()));
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedStringResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedStringResponse.java
@@ -22,7 +22,7 @@ public class BabbageContentBasedStringResponse extends BabbageStringResponse {
     }
 
     @Override
-    protected void setCacheHeaders(HttpServletRequest request, HttpServletResponse response) {
+    protected void setContentHash(HttpServletRequest request, HttpServletResponse response) {
         CacheControlHelper.resolveHash(request, response, CacheControlHelper.hashData(getData()));
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedStringResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageContentBasedStringResponse.java
@@ -23,6 +23,6 @@ public class BabbageContentBasedStringResponse extends BabbageStringResponse {
 
     @Override
     protected void setCacheHeaders(HttpServletRequest request, HttpServletResponse response) {
-        CacheControlHelper.setCacheHeaders(request, response, CacheControlHelper.hashData(getData()));
+        CacheControlHelper.resolveHash(request, response, CacheControlHelper.hashData(getData()));
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/response/base/BabbageResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/base/BabbageResponse.java
@@ -48,11 +48,11 @@ public abstract class BabbageResponse {
                 response.setHeader(next.getKey(), next.getValue());
             }
         }
-        setCacheHeaders(request, response);
+        setContentHash(request, response);
     }
 
-    protected void setCacheHeaders(HttpServletRequest request, HttpServletResponse response) {
-        //This method needs to be kept only because it is overridden in the BabbageContentBasedBinaryResponse and BabbageContentBasedStringResponse classes
+    protected void setContentHash(HttpServletRequest request, HttpServletResponse response) {
+        //This method needs to exist only because it is overridden in the BabbageContentBasedBinaryResponse and BabbageContentBasedStringResponse classes
     }
 
     public String getMimeType() {

--- a/src/main/java/com/github/onsdigital/babbage/response/base/BabbageResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/base/BabbageResponse.java
@@ -1,5 +1,6 @@
 package com.github.onsdigital.babbage.response.base;
 
+import com.github.onsdigital.babbage.response.util.CacheControlHelper;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -47,6 +48,11 @@ public abstract class BabbageResponse {
                 response.setHeader(next.getKey(), next.getValue());
             }
         }
+        setCacheHeaders(request, response);
+    }
+
+    protected void setCacheHeaders(HttpServletRequest request, HttpServletResponse response) {
+        //This method needs to be kept only because it is overridden in the BabbageContentBasedBinaryResponse and BabbageContentBasedStringResponse classes
     }
 
     public String getMimeType() {

--- a/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
@@ -7,12 +7,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
-import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
 
 /**
  */
 public class CacheControlHelper {
-    private static final boolean legacyCacheAPIEnabled = appConfig().babbage().isLegacyCacheAPIEnabled();
 
     /**
      * Resolves and sets response status based on request cache control headers and data to be sent to the user
@@ -20,22 +18,8 @@ public class CacheControlHelper {
      * @param request
      * @return
      */
-    public static void setCacheHeaders(HttpServletRequest request, HttpServletResponse response, String hash, long maxAge) {
+    public static void setCacheHeaders(HttpServletRequest request, HttpServletResponse response, String hash) {
         resolveHash(request, response, hash);
-
-        if (!legacyCacheAPIEnabled) {
-            setMaxAge(response, maxAge);
-        }
-    }
-
-    public static void setCacheHeaders(HttpServletResponse response, long maxAge) {
-        if (!legacyCacheAPIEnabled) {
-            setMaxAge(response, maxAge);
-        }
-    }
-
-    private static void setMaxAge(HttpServletResponse response, long maxAge) {
-        response.addHeader("cache-control", "public, max-age=" + maxAge);
     }
 
     public static String hashData(String data) {

--- a/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
@@ -12,16 +12,6 @@ import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
  */
 public class CacheControlHelper {
 
-    /**
-     * Resolves and sets response status based on request cache control headers and data to be sent to the user
-     *
-     * @param request
-     * @return
-     */
-    public static void setCacheHeaders(HttpServletRequest request, HttpServletResponse response, String hash) {
-        resolveHash(request, response, hash);
-    }
-
     public static String hashData(String data) {
         return DigestUtils.sha1Hex(data);
     }
@@ -30,7 +20,7 @@ public class CacheControlHelper {
         return DigestUtils.sha1Hex(data);
     }
 
-    private static void resolveHash(HttpServletRequest request, HttpServletResponse response, String newHash) {
+    public static void resolveHash(HttpServletRequest request, HttpServletResponse response, String newHash) {
         if (StringUtils.isEmpty(newHash)) {
             return;
         }

--- a/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/util/CacheControlHelper.java
@@ -1,0 +1,69 @@
+package com.github.onsdigital.babbage.response.util;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
+
+/**
+ */
+public class CacheControlHelper {
+    private static final boolean legacyCacheAPIEnabled = appConfig().babbage().isLegacyCacheAPIEnabled();
+
+    /**
+     * Resolves and sets response status based on request cache control headers and data to be sent to the user
+     *
+     * @param request
+     * @return
+     */
+    public static void setCacheHeaders(HttpServletRequest request, HttpServletResponse response, String hash, long maxAge) {
+        resolveHash(request, response, hash);
+
+        if (!legacyCacheAPIEnabled) {
+            setMaxAge(response, maxAge);
+        }
+    }
+
+    public static void setCacheHeaders(HttpServletResponse response, long maxAge) {
+        if (!legacyCacheAPIEnabled) {
+            setMaxAge(response, maxAge);
+        }
+    }
+
+    private static void setMaxAge(HttpServletResponse response, long maxAge) {
+        response.addHeader("cache-control", "public, max-age=" + maxAge);
+    }
+
+    public static String hashData(String data) {
+        return DigestUtils.sha1Hex(data);
+    }
+
+    public static String hashData(byte[] data) {
+        return DigestUtils.sha1Hex(data);
+    }
+
+    private static void resolveHash(HttpServletRequest request, HttpServletResponse response, String newHash) {
+        if (StringUtils.isEmpty(newHash)) {
+            return;
+        }
+        String oldHash = getOldHash(request);
+
+        info().data("old_hash", oldHash)
+                .data("new_hash", newHash)
+                .log("resolving cache headers");
+
+        response.setHeader("Etag", "\"" + newHash + "\"");
+        if (StringUtils.equals(oldHash, newHash)) {
+            response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+        }
+    }
+
+    private static String getOldHash(HttpServletRequest request) {
+        String hash = request.getHeader("If-None-Match");
+        return StringUtils.remove(hash, "--gzip");//TODO: Restolino does not seem to be removing --gzip flag on etag when request comes in
+    }
+}


### PR DESCRIPTION
### What

Relating to this Jira ticket:  https://jira.ons.gov.uk/browse/DIS-923

In a previous PR I deleted all the functionality required in the above ticket. However, the part to set the content hash should not have been deleted. I had deleted it because it was only being used by a method named 'setCacheHeaders'. However, the service replacing the setCacheHeaders functionality (the legacy cache proxy) does not set the content hash, which is needed for setting ETags. So I have put that part back in and refactored it so that setCacheHeaders is named setContentHash instead.

### How to review

Check that the changes look correct. To test it locally, if desired, you would need to publish a manual collection and/or a scheduled collection then check that they appear in legacy search `http://localhost:8080/search` successfully.

### Who can review

Anyone.
