### PR TITLE
Feature/decommission atoz banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Babbage runs independently. However, in order to run it locally in its publishin
 
 | Environment variable             | Default                | Description                                                                                                       |
 |----------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------|
+| ATOZ_DECOMMISSION_DATE           | ""                     | The date when the A to Z page will be decommissioned                                                              |
 | CONTENT_SERVICE_MAX_CONNECTION   | 50                     | The maximum number of connections Babbage can make to the content service                                         |
 | CONTENT_SERVICE_URL              | http://localhost:8082  | The URL to the content service (zebedee)                                                                          |
 | ELASTIC_SEARCH_SERVER            | localhost              | The elastic search host and port (The http:// scheme prefix is added programmatically)                            |

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
@@ -58,7 +58,7 @@ public class Babbage implements AppConfig {
 
     private Babbage() {
         apiRouterURL = getValueOrDefault(API_ROUTER_URL, "http://localhost:23200/v1");
-        atozDecommissionDate = getValueOrDefault(ATOZ_DECOMMISSION_DATE_KEY, "2021-01-01");
+        atozDecommissionDate = getValueOrDefault(ATOZ_DECOMMISSION_DATE_KEY, "");
         exportSeverUrl = getValueOrDefault(HIGHCHARTS_EXPORT_SERVER_KEY, "http://localhost:9999/");
         isDevEnv = getStringAsBool(DEV_ENVIRONMENT_KEY, "N");
         isNavigationEnabled = getStringAsBool(ENABLE_NAVIGATION_KEY, "N");

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
@@ -14,6 +14,7 @@ public class Babbage implements AppConfig {
 
     // env var keys
     private static final String API_ROUTER_URL = "API_ROUTER_URL";
+    private static final String ATOZ_DECOMMISSION_DATE_KEY = "ATOZ_DECOMMISSION_DATE";
     private static final String DEV_ENVIRONMENT_KEY = "DEV_ENVIRONMENT";
     private static final String ENABLE_NAVIGATION_KEY = "ENABLE_NAVIGATION";
     private static final String HIGHCHARTS_EXPORT_SERVER_KEY = "HIGHCHARTS_EXPORT_SERVER";
@@ -38,6 +39,7 @@ public class Babbage implements AppConfig {
     }
 
     private final String apiRouterURL;
+    private final String atozDecommissionDate;
     private final String exportSeverUrl;
     private final String mathjaxExportServer;
     private final String reindexSecret;
@@ -56,6 +58,7 @@ public class Babbage implements AppConfig {
 
     private Babbage() {
         apiRouterURL = getValueOrDefault(API_ROUTER_URL, "http://localhost:23200/v1");
+        atozDecommissionDate = getValueOrDefault(ATOZ_DECOMMISSION_DATE_KEY, "2021-01-01");
         exportSeverUrl = getValueOrDefault(HIGHCHARTS_EXPORT_SERVER_KEY, "http://localhost:9999/");
         isDevEnv = getStringAsBool(DEV_ENVIRONMENT_KEY, "N");
         isNavigationEnabled = getStringAsBool(ENABLE_NAVIGATION_KEY, "N");
@@ -75,6 +78,10 @@ public class Babbage implements AppConfig {
 
     public String getApiRouterURL() {
         return apiRouterURL;
+    }
+
+    public String getAtozDecommissionDate() {
+        return atozDecommissionDate;
     }
 
     public String getExportSeverUrl() {

--- a/src/main/java/com/github/onsdigital/babbage/util/RequestUtil.java
+++ b/src/main/java/com/github/onsdigital/babbage/util/RequestUtil.java
@@ -28,6 +28,7 @@ public class RequestUtil {
     public static final String LANG_KEY = "lang";
     public static final String IS_DEV_KEY = "is_dev";
     public static final String IS_PUBLISHING = "is_publishing";
+    public static final String ATOZ_DECOMMISSION_DATE = "atoz_decommission_date";
 
     /**
      * Saves Authentication token and collection id to thread context if available when a request is made to babbage,
@@ -46,6 +47,7 @@ public class RequestUtil {
         ThreadContext.addData(LOCATION_KEY, getLocation(request));
         ThreadContext.addData(IS_DEV_KEY, appConfig().babbage().isDevEnvironment());
         ThreadContext.addData(IS_PUBLISHING, appConfig().babbage().isPublishing());
+        ThreadContext.addData(ATOZ_DECOMMISSION_DATE, appConfig().babbage().getAtozDecommissionDate());
     }
 
     public static void clearContext() {

--- a/src/main/web/templates/handlebars/partials/decommission-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/decommission-banner.handlebars
@@ -13,10 +13,6 @@
                 <a href="https://www.ons.gov.uk/feedback" class="banner__link">Submit feedback</a> to let us know how we can improve our website.
             </p>
         </div>
-        {{!-- <p class="margin-top--0 margin-bottom--0 padding-bottom--0 padding-top--0 flex flex-wrap-wrap banner--vertical-center">
-            {{{labels.census-banner-logo}}}
-            {{{labels.census-banner-text}}}
-        </p> --}}
     </div>
 </div>
 {{/if}}

--- a/src/main/web/templates/handlebars/partials/decommission-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/decommission-banner.handlebars
@@ -1,0 +1,22 @@
+{{#if atoz_decommission_date}}
+<div class="wrapper">
+    <div class="banner banner--half-padding banner--bottom-border">
+        <div class="banner__container margin-left--0">
+            <div class="banner__heading margin-left--0">
+                Important information about this page
+            </div>
+        </div>
+        <div class="banner__body margin-left--0">
+            <p>
+                This page will be discontinued on {{ atoz_decommission_date }} and will be redirected to our list of <a href="https://www.ons.gov.uk/publications?filter=bulletin&sort=release_date" class="banner__link">published bulletins</a>. 
+                This is part of a series of improvements to our website. 
+                <a href="https://www.ons.gov.uk/feedback" class="banner__link">Submit feedback</a> to let us know how we can improve our website.
+            </p>
+        </div>
+        {{!-- <p class="margin-top--0 margin-bottom--0 padding-bottom--0 padding-top--0 flex flex-wrap-wrap banner--vertical-center">
+            {{{labels.census-banner-logo}}}
+            {{{labels.census-banner-text}}}
+        </p> --}}
+    </div>
+</div>
+{{/if}}

--- a/src/main/web/templates/handlebars/partials/header.handlebars
+++ b/src/main/web/templates/handlebars/partials/header.handlebars
@@ -129,5 +129,8 @@
 		</div>
 	{{/block}}
 	{{> partials/census-banner}}
+	{{#if (eq listType "atoz")}}
+		{{> partials/decommission-banner}}
+	{{/if}}
 	{{/if_all}}
 </header>


### PR DESCRIPTION
### What

[This](https://jira.ons.gov.uk/browse/DIS-1194) is to add a decommission banner to the AtoZ page, with an env var for date.

Banner should only appear when a date is provided.
I've left the date as a string rather than parsing it as a formatted date, so it can be changed later if we wanted it.

### How to review

Grab branch
Run `make debug-web`
Go http://localhost:8080/atoz (shouldn't be a banner)

Go to the Babbage.java file and change line 61 to have a date, eg
atozDecommissionDate = getValueOrDefault(ATOZ_DECOMMISSION_DATE_KEY, "30/07/2024");

Run `make debug-web` again (should see banner)

![image](https://github.com/user-attachments/assets/6f4f4642-bbf7-4bfa-9ad2-af7c3cfc4747)

### Who can review

Babbage expert
