### PR TITLE
Adds cache to pdf chart generation to stop duplicate HighCharts calls

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
@@ -48,7 +48,7 @@ public class ErrorHandler implements ServerError {
         } else {
             Exception e = (Exception) t;
             // When user is not logged in and we request authenticated resources from Zebedee, the expected response is 401. Zebedee currently gives 200, with the following error message:
-            if (e.getMessage().contains("Access Token required but none provided.") || e.getMessage().contains("JWT verification failed as token is expired.")){
+            if (e.getMessage() != null && (e.getMessage().contains("Access Token required but none provided.") || e.getMessage().contains("JWT verification failed as token is expired."))){
                 error().exception(t).log("authorization error");
                 renderErrorPage(401, response);
             } else {


### PR DESCRIPTION
### What

Add caching of images returned from HighCharts during pdf generation to prevent duplicated calls. 

The PDF renderer library works iteratively while laying out the page as it dynamically lays out the elements on the page. So the replacement factory is called multiple times for the same image. Caching means that only one call is made per chart, per generation. (Ie. the cache is created empty on each invocation of the generator as a new `ChartImageReplacedElementFactory` is instantiated each time.

Also fixed a couple of null pointer exception bugs uncovered whilst debugging this functionality locally.

### How to review

This needs testing in sandbox so just a sanity check and ensuring existing tests pass etc.

### Who can review

Anyone but me.