### PR TITLE
Add utility class for hiding content from pdf

### DIFF
--- a/src/main/web/templates/handlebars/pdf/pdf.handlebars
+++ b/src/main/web/templates/handlebars/pdf/pdf.handlebars
@@ -14,6 +14,9 @@
                 padding-right: 0.25in;
             }
         }
+        .print--hide {
+            display: none;
+        }
 
         * {
             font-family: Tahoma, Verdana, Arial, sans-serif !important;


### PR DESCRIPTION
### What

Added utility class to pdf styling to match sixteens `.print--hide` - this is to facilitate some custom markup that needs to be hidden from Babbage's PDF generation workflow. This workflow doesn't use sixteens so isn't inheriting from there and in general relies upon different templating. Whereas this is for custom user markup.

### How to review

Add a div with `.print--hide` to a markup block in zebedee and then hit the /pdf-new endpoint in babbage.

### Who can review

Front end dev? 