### PR TITLE
Remove max-age directive for error pages

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/api/error/ErrorHandler.java
@@ -62,8 +62,7 @@ public class ErrorHandler implements ServerError {
     public static void renderErrorPage(int statusCode, HttpServletResponse response) throws IOException {
         try {
             response.setStatus(statusCode);
-            //Prevent error pages being cached by cdn s
-            response.addHeader("cache-control", "public, max-age=0");
+
             Map<String, Object> context = new LinkedHashMap<>();
             context.put("type", "error");
             context.put("code", statusCode);


### PR DESCRIPTION
### What

Removed max age directive for error pages - this is currently causing 404s to get max-age 0 cloudflare which is bad for stability. 

By removing any setting of public / max-age this will allow the proxy to calculate upcoming release times correctly and then reflect that through to cloudflare. 

### How to review

Run and go to a 404 page - observe how the cache-control is no longer set. 

### Who can review

Not me. 