### PR TITLE
Increase ElasticSearch scroll keepalive to 2min

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/publishing/PublishingManager.java
+++ b/src/main/java/com/github/onsdigital/babbage/publishing/PublishingManager.java
@@ -50,7 +50,7 @@ public class PublishingManager {
     private static PublishingManager instance = new PublishingManager();
     private static ElasticSearchUtils searchUtils;
     private static final String PUBLISH_DATES_INDEX = "publish";
-    private final TimeValue scrollKeepAlive = new TimeValue(60, TimeUnit.SECONDS);
+    private final TimeValue scrollKeepAlive = new TimeValue(120, TimeUnit.SECONDS);
 
     private PublishingManager() {
         searchUtils = new ElasticSearchUtils(getElasticsearchClient());


### PR DESCRIPTION
### What

Increase the value of keepalive when working with Elasticsearch operations on the `publish` index which was causing publishing issues.

Consciously not using a config variable due to this code being so close to decommissioning anyway. 

### How to review

Check the change makes sense and tests pass. 

### Who can review

Anyone