### PR TITLE
Remove mathjax export server

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
@@ -26,7 +26,6 @@ public class Babbage implements AppConfig {
     private static final String ENABLE_NAVIGATION_KEY = "ENABLE_NAVIGATION";
     private static final String HIGHCHARTS_EXPORT_SERVER_KEY = "HIGHCHARTS_EXPORT_SERVER";
     private static final String IS_PUBLISHING_KEY = "IS_PUBLISHING";
-    private static final String MATHJAX_EXPORT_SERVER_KEY = "MATHJAX_EXPORT_SERVER";
     private static final String MAX_CACHE_ENTRIES = "CACHE_ENTRIES";
     private static final String MAX_OBJECT_SIZE = "CACHE_OBJECT_SIZE";
     private static final String REDIRECT_SECRET_KEY = "REDIRECT_SECRET";
@@ -47,7 +46,6 @@ public class Babbage implements AppConfig {
 
     private final String apiRouterURL;
     private final String exportSeverUrl;
-    private final String mathjaxExportServer;
     private final String reindexSecret;
     private final String redirectSecret;
     private final String serviceAuthToken;
@@ -70,7 +68,6 @@ public class Babbage implements AppConfig {
         isDevEnv = getStringAsBool(DEV_ENVIRONMENT_KEY, "N");
         isNavigationEnabled = getStringAsBool(ENABLE_NAVIGATION_KEY, "N");
         isPublishing = getStringAsBool(IS_PUBLISHING_KEY, "N");
-        mathjaxExportServer = getValue(MATHJAX_EXPORT_SERVER_KEY);
         reindexSecret = getValueOrDefault(REINDEX_SERVICE_KEY, "5NpB6/uAgk14nYwHzMbIQRnuI2W63MrBOS2279YlcUUY2kNOhrL+R5UFR3O066bQ");
         maxCacheEntries = defaultIfBlank(getNumberValue(MAX_OBJECT_SIZE), 3000);
         maxCacheObjectSize = defaultIfBlank(getNumberValue(MAX_CACHE_ENTRIES), 50000);
@@ -89,10 +86,6 @@ public class Babbage implements AppConfig {
 
     public String getExportSeverUrl() {
         return exportSeverUrl;
-    }
-
-    public String getMathjaxExportServer() {
-        return mathjaxExportServer;
     }
 
     public String getRedirectSecret() {
@@ -173,7 +166,6 @@ public class Babbage implements AppConfig {
         config.put("isDevEnv", isDevEnv);
         config.put("isNavigationEnable", isNavigationEnabled);
         config.put("isPublishing", isPublishing);
-        config.put("mathjaxExportServer", mathjaxExportServer);
         config.put("maxCacheEntries", maxCacheEntries);
         config.put("maxCacheObjectSize", maxCacheObjectSize);
         config.put("maxHighchartsServerConnections", maxHighchartsServerConnections);

--- a/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/CustomMarkdownHelper.java
+++ b/src/main/java/com/github/onsdigital/babbage/template/handlebars/helpers/markdown/CustomMarkdownHelper.java
@@ -49,7 +49,6 @@ public class CustomMarkdownHelper extends MarkdownHelper implements BabbageHandl
 
         markdown = processCustomMarkdownTags(path, markdown);
 
-        //markdown = MathjaxRenderer.render(markdown);
         return new Handlebars.SafeString(markdown) ;
     }
 

--- a/src/test/java/com/github/onsdigital/babbage/configuration/BabbageTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/configuration/BabbageTest.java
@@ -22,7 +22,6 @@ public class BabbageTest extends junit.framework.TestCase {
     public void testGetInstance_testdefaults() {
         Babbage testInstance = Babbage.getInstance();
         assertEquals(testInstance.getExportSeverUrl(), "http://localhost:9999/");
-        assertEquals(testInstance.getMathjaxExportServer(), null);
         assertEquals(testInstance.getMaxHighchartsServerConnections(), 50);
         assertEquals(testInstance.getMaxResultsPerPage(), 250);
         assertEquals(testInstance.getMaxVisiblePaginatorLink(), 5);
@@ -39,7 +38,6 @@ public class BabbageTest extends junit.framework.TestCase {
         assertEquals(mockConfig.get("exportSeverUrl"), testInstance.getExportSeverUrl());
         assertEquals(mockConfig.get("isDevEnv"), testInstance.isDevEnv());
         assertEquals(mockConfig.get("isPublishing"), testInstance.isPublishing());
-        assertEquals(mockConfig.get("mathjaxExportServer"), testInstance.getMathjaxExportServer());
         assertEquals(mockConfig.get("maxHighchartsServerConnections"), testInstance.getMaxHighchartsServerConnections());
         assertEquals(mockConfig.get("maxResultsPerPage"), testInstance.getMaxResultsPerPage());
         assertEquals(mockConfig.get("maxVisiblePaginatorLink"), testInstance.getMaxVisiblePaginatorLink());


### PR DESCRIPTION
### What

Mathjax export server does not seem to be used in Babbage so I have removed it. 

### How to review

Check looks ok, nothing unexpected has been removed. 

### Who can review

Not me. 