### PR TITLE
Update sixteen hash to read new cookie values

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -12,8 +12,8 @@
         {{#if_any (eq type "bulletin") (eq type "article") (eq type "compendium_landing_page") (eq type "compendium_chapter")}}
             <link rel="canonical" href="{{uri}}" />
         {{/if_any}}
-        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/2c5867a{{/if}}/css/main.css">
-		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/2c5867a{{/if}}/css/pdf.css">{{/if}}
+        <link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/662bc97{{/if}}/css/main.css">
+		{{#if pdf_style}}<link rel="stylesheet" type="text/css" href="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/662bc97{{/if}}/css/pdf.css">{{/if}}
 
         {{> partials/gtm-data-layer }}
 
@@ -129,7 +129,7 @@
 			{{/if_eq}}
 		{{/if_eq}}
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-        <script src="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/2c5867a{{/if}}/js/main.js"></script>
+        <script src="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/662bc97{{/if}}/js/main.js"></script>
         <script src="/js/app.js"></script>
 
         {{!-- Add extra highcharts source files if page contains any charts --}}

--- a/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
+++ b/src/main/web/templates/handlebars/partials/highcharts/embeddedchart.handlebars
@@ -52,7 +52,7 @@ The commented code below is what needs to go in the parent.
   {{/if}}
 
  	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-  <script src="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/2c5867a{{/if}}/js/main.js"></script>
+  <script src="{{#if is_dev}}http://localhost:9000/dist{{else}}//cdn.ons.gov.uk/sixteens/662bc97{{/if}}/js/main.js"></script>
   <script src="/js/app.js"></script>
 
   <script src="//pym.nprapps.org/pym.v1.min.js"></script>


### PR DESCRIPTION
### What

[Update Sixteens](https://jira.ons.gov.uk/browse/DIS-2554) has to enable reading and setting new cookie values

- Read design-system cookies `ons_cookie_policy` and `ons_cookie_message_displayed`

### How to review

- Check hash is sixteens latest release
- Go to http://localhost:8080/economy
- Check cookie values in devtools
- Accepting cookies sets all to true
![image](https://github.com/user-attachments/assets/eb997684-7d21-4a4b-9dc9-7e89bb0a7909)

- Rejecting cookies set only essential to true
![image](https://github.com/user-attachments/assets/37020cba-6a00-4e0a-8438-ef0dcefacaff)

### Who can review

!Me
