### PR TITLE
Fix Safari cookies banner

### DIFF
--- a/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
+++ b/src/main/web/templates/handlebars/partials/cookies-banner.handlebars
@@ -10,12 +10,12 @@
             </div>
             <div class="cookies-banner__buttons">
                 <div class="nojs--hide cookies-banner__button cookies-banner__button--accept">
-                    <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" data-gtm-accept-cookies="true" type="submit" data-action="accept">
+                    <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" data-gtm-accept-cookies="true" type="submit" data-action="accept" tabindex="0">
                         {{labels.cookies-banner-accept-action}}
                     </button>
                 </div>
                 <div class="nojs--hide cookies-banner__button cookies-banner__button--reject">
-                    <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-reject-cookies" data-gtm-accept-cookies="false" type="submit" data-action="reject">
+                    <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-reject-cookies" data-gtm-accept-cookies="false" type="submit" data-action="reject" tabindex="0">
                         {{labels.cookies-banner-reject-action}}
                     </button>
                 </div>


### PR DESCRIPTION
### What
Fixed issue with Safari not allowing focus when elements are unfocusable.

This has the effect of not setting cookies on Safari as the event target element becomes the body rather than the button. By setting a tabindex of 0, this convinces Safari that this is a focusable element and therefore becomes the event target.

### How to review
Run with portfowarded zebedee on safari with sixteens running.
Go to /economy
Clear cookies
Click 'accept' or 'reject' cookies.

### Who can review
Frontend dev.
