### PR TITLE
Redirect when migrationLink and latest

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -5,14 +5,21 @@ import com.github.onsdigital.babbage.content.client.ContentReadException;
 import com.github.onsdigital.babbage.content.client.ContentResponse;
 import com.github.onsdigital.babbage.request.handler.base.BaseRequestHandler;
 import com.github.onsdigital.babbage.response.BabbageContentBasedStringResponse;
+import com.github.onsdigital.babbage.response.BabbageRedirectResponse;
 import com.github.onsdigital.babbage.response.base.BabbageResponse;
 import com.github.onsdigital.babbage.template.TemplateService;
 import com.github.onsdigital.babbage.util.RequestUtil;
-
+import com.github.onsdigital.babbage.util.URIUtil;
 import javax.servlet.http.HttpServletRequest;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Arrays;
 
 import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
@@ -29,26 +36,72 @@ public class PageRequestHandler extends BaseRequestHandler {
     private static final String PDF_STYLE = "pdf_style";
     private static final String ENABLE_COVID19_FEATURE = "EnableCovid19Feature";
 
+    private static final List<String> serialisedContentTypes = Arrays.asList("bulletin", "article", "compendium_landing_page");
+
     @Override
     public BabbageResponse get(String uri, HttpServletRequest request) throws IOException, ContentReadException {
         return getPage(uri, request);
     }
 
-    public static BabbageResponse getPage(String uri, HttpServletRequest request) throws ContentReadException, IOException {
-        ContentResponse contentResponse = ContentClient.getInstance().getContent(uri);
+    public BabbageResponse getPage(String uri, HttpServletRequest request) throws ContentReadException, IOException {
+        ContentResponse contentResponse = getContent(uri);
+
+        JsonObject jsonResponse = JsonParser.parseString(contentResponse.getAsString()).getAsJsonObject();
+
+        JsonElement migrationLink = jsonResponse.getAsJsonObject("description").get("migrationLink");
+
+        if (migrationLink != null && shouldRedirect(uri, jsonResponse)) {
+            return new BabbageRedirectResponse(migrationLink.getAsString());
+        }
+
         try (InputStream dataStream = contentResponse.getDataStream()) {
             LinkedHashMap<String, Object> additionalData = new LinkedHashMap<>();
             if (RequestUtil.getQueryParameters(request).containsKey(PDF)) {
                 additionalData.put(PDF_STYLE, true);
             }
             additionalData.put(ENABLE_COVID19_FEATURE, appConfig().handlebars().isEnableCovid19Feature());
-            String html = TemplateService.getInstance().renderContent(dataStream, additionalData);
+            String html = getTemplateService().renderContent(dataStream, additionalData);
             return new BabbageContentBasedStringResponse(contentResponse, html, TEXT_HTML);
         }
+    }
+
+    /**
+     * Should redirect assess if this particular page requested should be redirected
+     * based on
+     *
+     * @param uri - uri received in Babbage
+     * @param contentType - content type from zebedee
+     * @param migrationLink - place to redirect to
+     */
+    public Boolean shouldRedirect(String uri, JsonObject jsonResponse) {
+        
+        JsonElement jsonContentType = jsonResponse.get("type");
+        JsonElement jsonMigrationLink = jsonResponse.getAsJsonObject("description").get("migrationLink");
+
+        if (jsonContentType != null && jsonMigrationLink != null){
+            Boolean matchedContentType = serialisedContentTypes.contains(jsonContentType.getAsString());
+
+            return !jsonMigrationLink.getAsString().isEmpty() && URIUtil.isLatestRequest(uri) && matchedContentType;
+        }
+        return false;
     }
 
     @Override
     public String getRequestType() {
         return REQUEST_TYPE;
+    }
+
+   /**
+     * This is an abstraction to allow mocking for unit tests.
+     */
+    protected ContentResponse getContent(String uri) throws IOException, ContentReadException {
+        return ContentClient.getInstance().getContent(uri);
+    }
+
+    /**
+     * This is an abstraction to allow mocking for unit tests.
+     */
+    protected TemplateService getTemplateService() {
+        return TemplateService.getInstance();
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -14,6 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,8 +50,9 @@ public class PageRequestHandler extends BaseRequestHandler {
         JsonObject jsonResponse = JsonParser.parseString(contentResponse.getAsString()).getAsJsonObject();
 
         JsonElement migrationLink = jsonResponse.getAsJsonObject("description").get("migrationLink");
+        JsonElement contentType = jsonResponse.get("type");
 
-        if (migrationLink != null && shouldRedirect(uri, jsonResponse)) {
+        if (migrationLink != null && contentType != null && shouldRedirect(uri, contentType.getAsString(), migrationLink.getAsString())) {
             return new BabbageRedirectResponse(migrationLink.getAsString());
         }
 
@@ -73,17 +75,11 @@ public class PageRequestHandler extends BaseRequestHandler {
      * @param contentType - content type from zebedee
      * @param migrationLink - place to redirect to
      */
-    public Boolean shouldRedirect(String uri, JsonObject jsonResponse) {
-        
-        JsonElement jsonContentType = jsonResponse.get("type");
-        JsonElement jsonMigrationLink = jsonResponse.getAsJsonObject("description").get("migrationLink");
+    public boolean shouldRedirect(String uri, String contentType, String migrationLink) {
 
-        if (jsonContentType != null && jsonMigrationLink != null){
-            Boolean matchedContentType = serialisedContentTypes.contains(jsonContentType.getAsString());
+        Boolean matchedContentType = serialisedContentTypes.contains(contentType);
 
-            return !jsonMigrationLink.getAsString().isEmpty() && URIUtil.isLatestRequest(uri) && matchedContentType;
-        }
-        return false;
+        return !StringUtils.isBlank(migrationLink) && URIUtil.isLatestRequest(uri) && matchedContentType;
     }
 
     @Override

--- a/src/main/java/com/github/onsdigital/babbage/request/handler/TimeseriesLandingRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/TimeseriesLandingRequestHandler.java
@@ -55,7 +55,7 @@ public class TimeseriesLandingRequestHandler extends BaseRequestHandler {
             ContentResponse contentResponse = ContentClient.getInstance().getContent(latestTimeseriesUri, getQueryParameters(request));
             return new BabbageContentBasedStringResponse(contentResponse, contentResponse.getAsString());
         } else {
-            return PageRequestHandler.getPage(latestTimeseriesUri, request);
+            return new PageRequestHandler().getPage(latestTimeseriesUri, request);
         }
     }
 

--- a/src/main/java/com/github/onsdigital/babbage/response/BabbageRedirectResponse.java
+++ b/src/main/java/com/github/onsdigital/babbage/response/BabbageRedirectResponse.java
@@ -2,10 +2,11 @@ package com.github.onsdigital.babbage.response;
 
 import com.github.onsdigital.babbage.response.base.BabbageResponse;
 import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.http.HttpScheme;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+
 import java.io.IOException;
 
 /**
@@ -24,11 +25,13 @@ public class BabbageRedirectResponse extends BabbageResponse {
         String forwardedHost = request.getHeader(HttpHeader.X_FORWARDED_HOST.asString());
         String forwardedProto = request.getHeader(HttpHeader.X_FORWARDED_PROTO.asString());
 
+        response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+
         if ((null != forwardedHost && !forwardedHost.isEmpty()) && (null != forwardedProto && !forwardedProto.isEmpty())) {
             String url = buildHttpsRedirectUrl(forwardedProto, forwardedHost, redirectUri);
-            response.sendRedirect(url);
+            response.setHeader(HttpHeaders.LOCATION, url);
         } else {
-            response.sendRedirect(redirectUri);
+            response.setHeader(HttpHeaders.LOCATION, redirectUri);
         }
     }
 
@@ -41,8 +44,10 @@ public class BabbageRedirectResponse extends BabbageResponse {
      */
     private static String buildHttpsRedirectUrl(String scheme, String host, String redirectUri) {
         redirectUri = !redirectUri.startsWith("/") ? String.format("/%s", redirectUri) : redirectUri;
-        String url = scheme + "://" + host + redirectUri;
+        return scheme + "://" + host + redirectUri;
+    }
 
-        return url;
+    public String getRedirectUri() {
+        return redirectUri;
     }
 }

--- a/src/main/java/com/github/onsdigital/babbage/util/URIUtil.java
+++ b/src/main/java/com/github/onsdigital/babbage/util/URIUtil.java
@@ -47,7 +47,6 @@ public class URIUtil {
      */
     public static String resolveRequestType(String uriString) {
         uriString = cleanUri(uriString);
-//        validate(uriString);
         if ("/".equals(uriString)) {
             return uriString;
         }
@@ -61,6 +60,11 @@ public class URIUtil {
         return "data".equals(resolveRequestType(uriString));
     }
 
+
+    public static boolean isLatestRequest(String uriString) {
+        return "latest".equals(resolveRequestType(uriString));
+    }
+
     /**
      * Extracts resource uri from request type suffixed uris.
      * <p>
@@ -71,7 +75,6 @@ public class URIUtil {
      */
     public static String removeLastSegment(String uriString) {
         uriString = cleanUri(uriString);
-//        validate(uriString);
 
         int lastSlashIndex = StringUtils.lastIndexOf(uriString, "/");
         return StringUtils.substring(uriString, 0, lastSlashIndex);
@@ -88,7 +91,7 @@ public class URIUtil {
         }
     }
 
-    //Remove trailing slash if any and make lowercase
+    // Remove trailing slash if any and make lowercase
     public static String cleanUri(String uriString) {
         uriString = StringUtils.trim(StringUtils.defaultIfBlank(uriString, "/"));
         if ("/".equals(uriString)) {

--- a/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
@@ -1,0 +1,220 @@
+package com.github.onsdigital.babbage.request.handler;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import javax.servlet.http.HttpServletResponse;
+
+import com.github.onsdigital.babbage.content.client.ContentResponse;
+import com.github.onsdigital.babbage.response.BabbageRedirectResponse;
+import com.github.onsdigital.babbage.response.base.BabbageResponse;
+import com.github.onsdigital.babbage.util.ThreadContext;
+import com.google.gson.JsonObject;
+import com.github.onsdigital.babbage.template.TemplateService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PageRequestHandlerTest {
+
+    private static final String URI = "/economy/environmentalaccounts/bulletins/ukenvironmentalaccounts/2015-07-09";
+    private static final String MIME_TYPE = "text/html";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private ContentResponse contentResponse;
+
+    @Mock
+    private TemplateService mockTemplateService;
+
+    @Spy
+    private PageRequestHandler handler;
+
+    @After
+    public void cleanup() {
+        ThreadContext.clear();
+    }
+
+    @Test
+    public void canHandleRequestShouldReturnTrueForPage() {
+        assertTrue(handler.canHandleRequest(URI, "/"));
+    }
+
+    @Test
+    public void canHandleRequestShouldReturnFalseForNotPage() {
+        assertFalse(handler.canHandleRequest(URI, "pdf"));
+    }
+
+    @Test
+    public void getRequestTypeShouldReturnPage() {
+        assertEquals("/", handler.getRequestType());
+    }
+
+    @Test
+    public void testShouldRedirect() {
+       assertFalse(handler.shouldRedirect("/mybulletin", generateObject("bulletin", "/redirect1", "bulletin title")));
+       assertFalse(handler.shouldRedirect("/mybulletin", generateObject("bulletin", "", "bulletin title")));
+       assertFalse(handler.shouldRedirect("/mybulletin/latest", generateObject("bulletin", "", "bulletin title")));
+       assertFalse(handler.shouldRedirect("/mystatic/latest", generateObject("static_adhoc", "/redirect1", "bulletin title")));
+       assertTrue(handler.shouldRedirect("/mybulletin/latest", generateObject("bulletin", "/redirect1", "bulletin title")));
+       assertFalse(handler.shouldRedirect("/mybulletin/latest", generateObject("", "", "bulletin title")));
+    }
+
+    @Test
+    public void getPageOfExistingContent() throws Exception {
+        // Given Zebedee responds with a static_adhoc with no migration link
+        byte[] pageData = generateData("static_adhoc", "", "Adhoc title");
+
+        when(contentResponse.getAsString()).thenReturn(new String(pageData));
+
+        doReturn(mockTemplateService).when(handler).getTemplateService();
+        doReturn(contentResponse).when(handler).getContent(URI);
+
+        // When the page is requested from Babbage
+        BabbageResponse babbageResponse = handler.get(URI, request);
+
+        // Then a page is served
+        assertEquals(200, babbageResponse.getStatus());
+        assertEquals(MIME_TYPE, babbageResponse.getMimeType());
+        assertTrue(babbageResponse.getErrors().isEmpty());
+        assertEquals("UTF-8", babbageResponse.getCharEncoding());
+    }
+
+    @Test
+    public void getPageOfEditorialContent() throws Exception {
+        // Given Zebedee responds with a bulletin with no migration link
+        byte[] pageData = generateData("bulletin", "", "Bulletin title");
+
+        when(contentResponse.getAsString()).thenReturn(new String(pageData));
+        doReturn(mockTemplateService).when(handler).getTemplateService();
+        doReturn(contentResponse).when(handler).getContent(URI);
+
+        // When the page is requested from Babbage
+        BabbageResponse babbageResponse = handler.get(URI, request);
+
+        // Then a page is served
+        assertFalse(babbageResponse instanceof BabbageRedirectResponse);
+        assertEquals(200, babbageResponse.getStatus());
+        assertEquals(MIME_TYPE, babbageResponse.getMimeType());
+        assertTrue(babbageResponse.getErrors().isEmpty());
+        assertEquals("UTF-8", babbageResponse.getCharEncoding());
+    }
+
+    @Test
+    public void getPageOfEditorialContentWithRedirectNotLatest() throws Exception {
+        // Given Zebedee returns a bulletin with a migrationLink
+        byte[] pageData = generateData("bulletin", "/redirect1", "Bulletin title");
+
+        when(contentResponse.getAsString()).thenReturn(new String(pageData));
+        doReturn(mockTemplateService).when(handler).getTemplateService();
+        doReturn(contentResponse).when(handler).getContent(URI);
+
+        // And the page requested is not 'latest' endpoint
+        // When the page is requested from Babbage
+        BabbageResponse babbageResponse = handler.get(URI, request);
+
+        // Then a page is served
+        assertFalse(babbageResponse instanceof BabbageRedirectResponse);
+        assertEquals(200, babbageResponse.getStatus());
+        assertEquals(MIME_TYPE, babbageResponse.getMimeType());
+        assertTrue(babbageResponse.getErrors().isEmpty());
+        assertEquals("UTF-8", babbageResponse.getCharEncoding());
+    }
+
+    @Test
+    public void getPageOfEditorialContentWithRedirect() throws Exception {
+        String redirect = "/redirect1";
+
+        // Given Zebedee returns a bulletin with a migrationLink
+        byte[] pageData = generateData("bulletin", redirect, "Bulletin title");
+
+        // And the page requested is the 'latest' endpoint
+        String uri = URI + "/latest";
+
+        when(contentResponse.getAsString()).thenReturn(new String(pageData));
+        doReturn(contentResponse).when(handler).getContent(uri);
+
+        // When the page is requested from Babbage
+        BabbageResponse babbageResponse = handler.get(uri, request);
+
+        // Then the TemplateService is not called to render content
+        verify(mockTemplateService, never()).renderContent(isA(Object.class), anyMap());
+
+        // And a BabbageRedirectResponse is returned with the correct redirectUri
+        assertTrue(babbageResponse instanceof BabbageRedirectResponse);
+        assertTrue(babbageResponse.getErrors().isEmpty());
+        BabbageRedirectResponse babbageRedirectResponse = (BabbageRedirectResponse) babbageResponse;
+        assertEquals(redirect, babbageRedirectResponse.getRedirectUri());
+    }
+
+    @Test
+    public void getPageOfNonEditorialContentWithRedirect() throws Exception {
+        // Given Zebedee returns a dataset with a migrationLink
+        byte[] pageData = generateData("dataset_landing_page", "/redirect1", "Dataset title");
+
+        // And the page requested is the 'latest' endpoint
+        String uri = URI + "/latest";
+
+        when(contentResponse.getAsString()).thenReturn(new String(pageData));
+        doReturn(mockTemplateService).when(handler).getTemplateService();
+        doReturn(contentResponse).when(handler).getContent(uri);
+
+        // When the page is requested from Babbage
+        BabbageResponse babbageResponse = handler.get(uri, request);
+
+        // Then a page is served
+        assertFalse(babbageResponse instanceof BabbageRedirectResponse);
+        assertEquals(200, babbageResponse.getStatus());
+        assertEquals(MIME_TYPE, babbageResponse.getMimeType());
+        assertTrue(babbageResponse.getErrors().isEmpty());
+        assertEquals("UTF-8", babbageResponse.getCharEncoding());
+    }
+
+    private byte[] generateData(String contentType, String migrationLink, String title) {
+        return generateObject(contentType, migrationLink, title).toString().getBytes();
+    }
+
+    private JsonObject generateObject(String contentType, String migrationLink, String title) {
+        JsonObject json = new JsonObject();
+
+        JsonObject description = new JsonObject();
+
+        if (!migrationLink.isEmpty()) {
+            description.addProperty("migrationLink", migrationLink);
+        }
+
+        if (!title.isEmpty()){
+            description.addProperty("title", title);
+        }
+
+        if (!contentType.isEmpty()) {
+            json.addProperty("type", contentType);
+        }
+
+        json.add("description", description);
+
+        return json;
+    }
+    
+
+}
+
+

--- a/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
@@ -70,12 +70,13 @@ public class PageRequestHandlerTest {
 
     @Test
     public void testShouldRedirect() {
-       assertFalse(handler.shouldRedirect("/mybulletin", generateObject("bulletin", "/redirect1", "bulletin title")));
-       assertFalse(handler.shouldRedirect("/mybulletin", generateObject("bulletin", "", "bulletin title")));
-       assertFalse(handler.shouldRedirect("/mybulletin/latest", generateObject("bulletin", "", "bulletin title")));
-       assertFalse(handler.shouldRedirect("/mystatic/latest", generateObject("static_adhoc", "/redirect1", "bulletin title")));
-       assertTrue(handler.shouldRedirect("/mybulletin/latest", generateObject("bulletin", "/redirect1", "bulletin title")));
-       assertFalse(handler.shouldRedirect("/mybulletin/latest", generateObject("", "", "bulletin title")));
+       assertFalse(handler.shouldRedirect("/mybulletin", "bulletin", "/redirect1"));
+       assertFalse(handler.shouldRedirect("/mybulletin", "bulletin", ""));
+       assertFalse(handler.shouldRedirect("/mybulletin/latest", "bulletin", ""));
+       assertFalse(handler.shouldRedirect("/mystatic/latest", "static_adhoc", "/redirect1"));
+       assertTrue(handler.shouldRedirect("/mybulletin/latest", "bulletin", "/redirect1"));
+       assertFalse(handler.shouldRedirect("/mybulletin/latest", "", ""));
+       assertFalse(handler.shouldRedirect("/mybulletin/latest", "", " "));
     }
 
     @Test

--- a/src/test/java/com/github/onsdigital/babbage/util/TestURIUtil.java
+++ b/src/test/java/com/github/onsdigital/babbage/util/TestURIUtil.java
@@ -5,7 +5,10 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.github.onsdigital.babbage.util.URIUtil.isLatestRequest;
 import static org.junit.Assert.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.assertFalse;
 
 /**
  * @author sullid (David Sullivan) on 10/04/2018
@@ -96,6 +99,15 @@ public class TestURIUtil {
             String cleanUri = URIUtil.cleanUri(uri);
             assertEquals(cleanUri, expected.get(uri));
         }
+    }
+
+
+    @Test
+    public void testIsLatestRequest() {
+        assertTrue(isLatestRequest("/bulletin/latest"));
+        assertFalse(isLatestRequest("/bulletin"));
+        assertFalse(isLatestRequest("/bulletin/late"));
+
     }
 
 }


### PR DESCRIPTION
### What

Added new redirect functionality -

If page is on:

- /latest
- matches a pre-defined list of content types
- has a migrationLink

Then redirect to the migrationLink

I have also changed the general Babbage redirect functionality to be 301 rather than 302. 

There's a minor change to timeseriesPageHandler as well to remove the static reference to getPage

### How to review

Run Babbage and zebedee
Modify zebedee's content store to add a page with the referenced content type (e.g. bulletin) with a description.migrationLink. 
See it redirects

Regression test. 

### Who can review

Not me. 