### PR TITLE
feature/add migration link to series banner

### DIFF
--- a/src/main/web/templates/handlebars/content/partials/latest-release-header.handlebars
+++ b/src/main/web/templates/handlebars/content/partials/latest-release-header.handlebars
@@ -1,22 +1,30 @@
 {{!-- Latest info --}}
-{{#unless (endsWith (parentPath uri) "previous")}} 
+{{#unless (endsWith (parentPath uri) "previous")}}
     {{!-- If not a previous version workout the latest link --}}
     {{#if description.latestRelease}}
         <div class="col alert-release-banner alert-release-banner__latest">
             <p class="alert-release-banner__title">{{labels.this-is-the-latest-release}}
-            <a href="{{parentPath uri}}/previousreleases">{{labels.view-previous-releases}}</a></p>
+                <a href="{{parentPath uri}}/previousreleases">{{labels.view-previous-releases}}</a>
+            </p>
         </div>
     {{else}}
-        {{#resolve (concat (parentPath uri) "/latest") filter="title"}}
+        {{#resolve (concat (parentPath uri) "/latest") filter="title" filter="description"}}
             <div class="col alert-release-banner alert-release-banner__not-latest">
                 <p class="alert-release-banner__title">{{labels.this-is-not-the-latest-release}}
-                <a class="alert-release-banner__link" href="{{uri}}">{{labels.view-latest-release}}</a></p>
+                    <a
+                        class="alert-release-banner__link"
+                        href="{{#if description.migrationLink}}{{description.migrationLink}}{{else}}{{uri}}{{/if}}"
+                    >{{labels.view-latest-release}}</a>
+                </p>
             </div>
         {{/resolve}}
     {{/if}}
 {{else}}
     {{!-- If an older version of any release link to latest version of that release --}}
     <div class="col alert-release-banner alert-release-banner__not-latest">
-        <p class="alert-release-banner__title">{{labels.this-has-been-superseded}} <a class="alert-release-banner__link" href="{{parentPath (parentPath uri)}}">{{labels.view-corrected-version}}</a></p>
+        <p class="alert-release-banner__title">{{labels.this-has-been-superseded}} <a
+                class="alert-release-banner__link"
+                href="{{parentPath (parentPath uri)}}"
+            >{{labels.view-corrected-version}}</a></p>
     </div>
 {{/unless}}

--- a/src/main/web/templates/handlebars/partials/latest-release.handlebars
+++ b/src/main/web/templates/handlebars/partials/latest-release.handlebars
@@ -1,17 +1,27 @@
-{{#unless (endsWith (parentPath uri) "previous")}} 
+{{#unless (endsWith (parentPath uri) "previous")}}
 	{{!-- If not a previous version workout the latest link --}}
 	{{#if description.latestRelease}}
 		<p class="alert__title">{{labels.this-is-the-latest-release}}</p>
-        <a class="alert__link" href="{{parentPath uri}}/previousreleases">{{labels.view-previous-releases}}</a>
+		<a
+			class="alert__link"
+			href="{{parentPath uri}}/previousreleases"
+		>{{labels.view-previous-releases}}</a>
 	{{else}}
-		{{#resolve (concat (parentPath uri) "/latest") filter="title"}}
-			<p class="alert__title">{{labels.this-is-not-the-latest-release}}</p> <a class="btn btn--primary print--hide" href="{{uri}}">{{labels.view-latest-release}}</a>
+		{{#resolve (concat (parentPath uri) "/latest") filter="title" filter="description"}}
+			<p class="alert__title">{{labels.this-is-not-the-latest-release}}</p>
+			<a
+				class="btn btn--primary print--hide"
+				href="{{#if description.migrationLink}}{{description.migrationLink}}{{else}}{{uri}}{{/if}}"
+			>{{labels.view-latest-release}}</a>
 		{{/resolve}}
 	{{/if}}
 {{else}}
 	{{!-- If an older version of any release link to latest version of that release --}}
 	<div class="alert--warning">
 		<div class="alert--warning__icon"></div>
-		<h2 class="alert--warning__title">{{labels.this-has-been-superseded}}</h2> <a class="btn btn--primary print--hide alert--warning__content" href="{{parentPath (parentPath uri)}}">{{labels.view-corrected-version}}</a>
+		<h2 class="alert--warning__title">{{labels.this-has-been-superseded}}</h2> <a
+			class="btn btn--primary print--hide alert--warning__content"
+			href="{{parentPath (parentPath uri)}}"
+		>{{labels.view-corrected-version}}</a>
 	</div>
 {{/unless}}


### PR DESCRIPTION
### What

Added view logic to render `migrationLink` in the href when present and the `latestRelease` is `false` - aka ✅ [Update series banners to work with migrationLink](https://jira.ons.gov.uk/browse/DIS-3287)

### How to review

Sense check

### Who can review

!me
