### PR TITLE
Fix error returned when no description

### DIFF
--- a/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
+++ b/src/main/java/com/github/onsdigital/babbage/request/handler/PageRequestHandler.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 import java.util.Arrays;
 
 import static com.github.onsdigital.babbage.configuration.ApplicationConfiguration.appConfig;
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 
 /**
@@ -43,7 +42,7 @@ public class PageRequestHandler extends BaseRequestHandler {
 
     private static final List<String> serialisedContentTypes = Arrays.asList("bulletin", "article", "compendium_landing_page");
 
-    private final static Pattern latestTimeseriesRequest = Pattern.compile(".*/timeseries/[^/]+/latest?/?");
+    private static final Pattern latestTimeseriesRequest = Pattern.compile(".*/timeseries/[^/]+/latest?/?");
 
     @Override
     public BabbageResponse get(String uri, HttpServletRequest request) throws IOException, ContentReadException {
@@ -60,7 +59,8 @@ public class PageRequestHandler extends BaseRequestHandler {
 
         JsonObject jsonResponse = JsonParser.parseString(contentResponse.getAsString()).getAsJsonObject();
 
-        JsonElement migrationLink = jsonResponse.getAsJsonObject("description").get("migrationLink");
+        JsonElement description = jsonResponse.get("description");
+        JsonElement migrationLink = description != null ? description.getAsJsonObject().get("migrationLink") : null;
         JsonElement contentType = jsonResponse.get("type");
 
         if (migrationLink != null && contentType != null && shouldRedirect(uri, contentType.getAsString(), migrationLink.getAsString())) {

--- a/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/request/handler/PageRequestHandlerTest.java
@@ -199,6 +199,27 @@ public class PageRequestHandlerTest {
     }
 
     @Test
+    public void getPageWithNoDescription() throws Exception {
+        JsonObject json = new JsonObject();
+        json.addProperty("type", "chart");
+
+        // Given Zebedee returns a taxonomy_landing_page with a migrationLink
+        byte[] pageData = json.toString().getBytes();
+
+        when(contentResponse.getAsString()).thenReturn(new String(pageData));
+        doReturn(contentResponse).when(handler).getContent(URI);
+
+        // When the page is requested from Babbage
+        BabbageResponse babbageResponse = handler.get(URI, request);
+
+        // Then a page is served
+        assertEquals(200, babbageResponse.getStatus());
+        assertEquals(MIME_TYPE, babbageResponse.getMimeType());
+        assertTrue(babbageResponse.getErrors().isEmpty());
+        assertEquals("UTF-8", babbageResponse.getCharEncoding());
+    }
+
+    @Test
     public void getPageOfNonEditorialContentWithoutRedirect() throws Exception {
         // Given Zebedee returns a taxonomy_landing_page without a migrationLink
         byte[] pageData = generateData("taxonomy_landing_page", "", "Topic title");


### PR DESCRIPTION
### What

There's an error returned if the json returned by Zebedee has no description. This fixes that.

### How to review

Check looks ok - alternatively, you can port forward to web sandbox, switch to web mode running and go to a page with no description, like /employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/uklabourmarket/august2016/c85b7a52

### Who can review

Not me. 