### PR TITLE
Exclude CVE-2026-55760

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <!-- If moving beyond version 4.2.1 there is a dependency on handlebars-humanize that 
+         must be resolved -->
         <handlebars-java-version>4.2.1</handlebars-java-version>
         <handlebars-markdown-java-version>4.2.0</handlebars-markdown-java-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -337,6 +339,9 @@
                          -->
                         <exclude>CVE-2026-2332</exclude>
                         <!-- End DIS-4777 -->
+                        <!-- DIS-5047 -->
+                        <exclude>CVE-2026-55760</exclude>
+                        <!-- End DIS-5047 -->
                     </excludeVulnerabilityIds>
                 </configuration>
                 <executions>


### PR DESCRIPTION
### What

Exclude CVE-2026-55760 from audit.

### How to review

Check looks ok - read through the advisory: https://github.com/advisories/GHSA-r4gv-qr8j-p3pg and the referenced ticket. 

### Who can review

Not me. 