### PR TITLE
use service auth for taxonomy etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,25 +57,26 @@ Babbage runs independently. However, it requires other services to run in web an
 can be used in `dp-compose`
 
 * In order to run it locally, with the other required services;
-  * For web mode, use [legacy-core-web](https://github.com/ONSdigital/dp-compose/tree/main/v2/stacks/legacy-core-web)
-  * For publishing mode run Babbage
+    * For web mode, use [legacy-core-web](https://github.com/ONSdigital/dp-compose/tree/main/v2/stacks/legacy-core-web)
+    * For publishing mode run Babbage
       with [homepage publishing](https://github.com/ONSdigital/dp-compose/tree/main/v2/stacks/homepage-publishing)
 
 ### Configuration
 
-| Environment variable           | Default                  | Description                                                                            |
-|--------------------------------|--------------------------|----------------------------------------------------------------------------------------|
-| CONTENT_SERVICE_MAX_CONNECTION | 50                       | The maximum number of connections Babbage can make to the content service              |
-| CONTENT_SERVICE_URL            | <http://localhost:8082>  | The URL to the content service (zebedee)                                               |
-| ENABLE_COVID19_FEATURE         |                          | Switch to use (or not) the covid feature                                               |
-| HIGHCHARTS_EXPORT_SERVER       | <http://localhost:9999/> | The URL to the highcharts export server                                                |
-| IS_PUBLISHING                  | N                        | Switch to use (or not) the publishing functionality                                    |
-| TABLE_RENDERER_HOST            | <http://localhost:23300> | The URL to the table renderer                                                          |
-| POOLED_CONNECTION_TIMEOUT      | 5000                     | The number of milliseconds to wait before closing expired connections                  |
-| IDLE_CONNECTION_TIMEOUT        | 60                       | The number of seconds to wait before closing idle connections                          |
-| OTEL_EXPORTER_OTLP_ENDPOINT    | <http://localhost:4317>  | URL for OpenTelemetry endpoint                                                         |
-| OTEL_SERVICE_NAME              |                          | Service name to report to telemetry tools                                              |
-| DEPRECATION_CONFIG             | []                       | See below                                                                              |
+| Environment variable           | Default                  | Description                                                               |
+|--------------------------------|--------------------------|---------------------------------------------------------------------------|
+| CONTENT_SERVICE_MAX_CONNECTION | 50                       | The maximum number of connections Babbage can make to the content service |
+| CONTENT_SERVICE_URL            | <http://localhost:8082>  | The URL to the content service (zebedee)                                  |
+| ENABLE_COVID19_FEATURE         |                          | Switch to use (or not) the covid feature                                  |
+| HIGHCHARTS_EXPORT_SERVER       | <http://localhost:9999/> | The URL to the highcharts export server                                   |
+| IS_PUBLISHING                  | N                        | Switch to use (or not) the publishing functionality                       |
+| TABLE_RENDERER_HOST            | <http://localhost:23300> | The URL to the table renderer                                             |
+| POOLED_CONNECTION_TIMEOUT      | 5000                     | The number of milliseconds to wait before closing expired connections     |
+| IDLE_CONNECTION_TIMEOUT        | 60                       | The number of seconds to wait before closing idle connections             |
+| OTEL_EXPORTER_OTLP_ENDPOINT    | <http://localhost:4317>  | URL for OpenTelemetry endpoint                                            |
+| OTEL_SERVICE_NAME              |                          | Service name to report to telemetry tools                                 |
+| DEPRECATION_CONFIG             | []                       | See below                                                                 |
+| SERVICE_AUTH_TOKEN             |                          | The service auth token for non user scoped requests                       | 
 
 #### DEPRECATION_CONFIG
 

--- a/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
+++ b/src/main/java/com/github/onsdigital/babbage/configuration/Babbage.java
@@ -20,7 +20,7 @@ public class Babbage implements AppConfig {
     private static final String IS_PUBLISHING_KEY = "IS_PUBLISHING";
     private static final String MAX_CACHE_ENTRIES = "CACHE_ENTRIES";
     private static final String MAX_OBJECT_SIZE = "CACHE_OBJECT_SIZE";
-    private static final String SERVICE_AUTH_TOKEN = "SERVICE_AUTH";
+    private static final String SERVICE_AUTH_TOKEN = "SERVICE_AUTH_TOKEN";
     private static Babbage INSTANCE;
 
     static Babbage getInstance() {
@@ -61,8 +61,7 @@ public class Babbage implements AppConfig {
         maxResultsPerPage = 250;
         maxVisiblePaginatorLink = 5;
         resultsPerPage = 10;
-        serviceAuthToken = getValueOrDefault(SERVICE_AUTH_TOKEN,
-                "ahyofaem2ieVie6eipaX6ietigh1oeM0Aa1aiyaebiemiodaiJah0eenuchei1ai");
+        serviceAuthToken = getValueOrDefault(SERVICE_AUTH_TOKEN, "");
     }
 
     public String getApiRouterURL() {

--- a/src/main/java/com/github/onsdigital/babbage/content/client/ContentClientCache.java
+++ b/src/main/java/com/github/onsdigital/babbage/content/client/ContentClientCache.java
@@ -30,7 +30,8 @@ import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
  */
 public class ContentClientCache {
     private static final String BearerPrefix = "Bearer ";
-    private static final String TOKEN_HEADER = "X-Florence-Token";
+    private static final String X_FLORENCE_TOKEN = "X-Florence-Token";
+    public static final String AUTHORIZATION = "Authorization";
 
     private static CacheHttpClient client;
     private static ContentClientCache instance;
@@ -123,12 +124,10 @@ public class ContentClientCache {
 
     //Reads collection cookie saved in thread context
     private Map<String, String> getHeaders() {
-        Map<String, String> cookies = (Map<String, String>) ThreadContext.getData("cookies");
         HashMap<String, String> headers = new HashMap<>();
-        headers.put("Authorization", BearerPrefix+appConfig().babbage().getServiceAuthToken());
-        if (cookies != null) {
-            headers.put(TOKEN_HEADER, cookies.get("access_token"));
-        }
+        String serviceAuthToken = BearerPrefix + appConfig().babbage().getServiceAuthToken();
+        headers.put(AUTHORIZATION, serviceAuthToken);
+        headers.put(X_FLORENCE_TOKEN, serviceAuthToken);
         return headers;
 
     }

--- a/src/test/java/com/github/onsdigital/babbage/configuration/BabbageTest.java
+++ b/src/test/java/com/github/onsdigital/babbage/configuration/BabbageTest.java
@@ -1,4 +1,5 @@
 package com.github.onsdigital.babbage.configuration;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.Before;
 import java.util.Map;
@@ -47,9 +48,10 @@ public class BabbageTest extends junit.framework.TestCase {
 
     @Test
     public void testGetServiceAuthToken() {
+        String envSvcToken = StringUtils.defaultIfBlank(System.getenv("SERVICE_AUTH_TOKEN"),"");
         Babbage testInstance = Babbage.getInstance();
         assertNotNull(testInstance.getServiceAuthToken());
-        assertEquals(testInstance.getServiceAuthToken(),"ahyofaem2ieVie6eipaX6ietigh1oeM0Aa1aiyaebiemiodaiJah0eenuchei1ai");
+        assertEquals(envSvcToken, testInstance.getServiceAuthToken());
     }
 
     @Test


### PR DESCRIPTION
### What

The caching client used for getting the taxonomy from zebedee was supplying both a service and a user auth token when it should just be one or the other. We have settled on service token because the same cached result is used for multiple users and collection context isn't passed through. Fixing this would be a bigger piece of work.

This also uses an env var for the token that is consistent with other services and removes the hard-coded default.

### How to review

Ensure changes make sense and tests pass.

### Who can review

Anyone