### PR TITLE
Fix/preview pane

### DIFF
--- a/src/main/web/templates/handlebars/main.handlebars
+++ b/src/main/web/templates/handlebars/main.handlebars
@@ -52,12 +52,16 @@
                       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
-        {{!-- Sends a message out of window - for Florance preview use, so that she can see when the preview window is loading (rather than looking for the iframe onload event which is only fired after all JS has loaded) --}}
+        {{!-- 
+			Sends a message out of window - for Florance preview use, so that she can see 
+			when the preview window is loading (rather than looking for the iframe onload event 
+			which is only fired after all JS has loaded) 
+		--}}
         {{#if is_publishing}}
-             <script>
-                 window.onunload = function(){
-                     top.postMessage('load', '*');
-                 }
+            <script>	
+                window.addEventListener('pagehide', function(){
+                    top.postMessage('load', '*');
+                });
              </script>
         {{/if}}
 		{{#if is_dev}}


### PR DESCRIPTION
### What

Swapped onunload for pagehide due to browser deprecation
Upgraded some httpcomponents

### How to review

Run:
- Florence
- Babbage
- Sixteens
- portforward api router and zebedee addresses to sandbox

Login and access a collection, then browse via the preview pane. Now works (only for babbage pages)

### Who can review

Not me. 