### PR TITLE
Add human readable title to table downloads

### DIFF
--- a/src/main/web/templates/handlebars/partials/table-v2.handlebars
+++ b/src/main/web/templates/handlebars/partials/table-v2.handlebars
@@ -7,6 +7,6 @@
     </div>
 
     <h4 class="print--hide font-size--h6 padding-top--0"><span role="text">Download this table <span class="visuallyhidden">{{title}}</span></span></h4>
-    <a href="/download/table?format=xlsx&uri={{uri}}.json" title="Download as xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xlsx" aria-label="Download {{title}} as xls">.xls</a>
-    <a href="/download/table?format=csv&uri={{uri}}.json" title="Download as csv" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-csv" aria-label="Download {{title}} as csv">.csv</a>
+    <a href="/download/table?format=xlsx&uri={{uri}}.json" title="Download as xls" download="{{title}}.xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xlsx" aria-label="Download {{title}} as xls">.xls</a>
+    <a href="/download/table?format=csv&uri={{uri}}.json" title="Download as csv" download="{{title}}.csv" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-csv" aria-label="Download {{title}} as csv">.csv</a>
 </div>

--- a/src/main/web/templates/handlebars/partials/table.handlebars
+++ b/src/main/web/templates/handlebars/partials/table.handlebars
@@ -9,5 +9,5 @@
         </div>
     {{/resolveResource}}
     <h4 class="print--hide font-size--h6 margin-top--1 padding-top--0"><span role="text">Download this table <span class="visuallyhidden">{{title}}</span></span></h4>
-    <a href="/file?uri={{uri}}.xls" title="Download as xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xls" aria-label="Download table {{title}} as xls ({{fs(concat uri ".xls")}})">.xls ({{fs(concat uri ".xls")}})</a>
+    <a href="/file?uri={{uri}}.xls" title="Download as xls" download="{{title}}.xls" class="btn btn--primary print--hide" data-gtm-title="{{{sub (sup title)}}}" data-gtm-type="download-table-xls" aria-label="Download table {{title}} as xls ({{fs(concat uri ".xls")}})">.xls ({{fs(concat uri ".xls")}})</a>
 </div>


### PR DESCRIPTION
### What

Added download attribute to ensure human readable titles for table downloads.

### How to review

Check looks ok - to test:

- run babbage in web mode
- portforward zebedee to sandbox
- portforward dp-table-renderer to sandbox

Find a page with a v2 table, e.g. /economy/environmentalaccounts/articles/developingsupplyandusetablesforuknaturalcapitalaccounts/2023

and then use the download link (the one above actually has a table character in it so appears slightly strange). The download will fail as the file isn't there but the file name will be correct.

### Who can review

Not me. 