### PR TITLE
Feature/non js pym

### DIFF
--- a/src/main/web/templates/handlebars/partials/interactive.handlebars
+++ b/src/main/web/templates/handlebars/partials/interactive.handlebars
@@ -1,22 +1,24 @@
-<div class="js--show">
+<div class="pym-interactive{{#if_eq full-width "true"}} pyminteractive--full-width margin-left--0{{/if_eq}}" id="{{id}}" data-url="{{url}}" data-title="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}}"></div>
+<noscript>
+    <h3 class="font-size--18 margin-top--1">{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}}</h3>
+    <p>The embedded visualisation below may not display correctly without JavaScript enabled. <a class="underline-link" href="{{url}}">View it in full screen</a>.</p>
+    <iframe title="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}}" width="100%" height="400px" class="margin-left--0" src="{{url}}"></iframe>
+</noscript>
+<details class="details">
+    <summary class="details__summary" role="button" aria-label="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}} embed code">Embed code</summary>
+    <div class="details__body">
+        <label class="embed-code__label" for="embed-{{id}}">Embed this interactive</label>
+        <input class="embed-code__code width-md--31"
+    value='<iframe width="100%" src="{{#if (containsAny url "http" "https")}}{{url}}{{else}}{{#if is_dev}}http://{{location.host}}{{else}}https://{{location.hostname}}{{/if}}{{url}}{{/if}}"></iframe>'
+                id="embed-{{id}}"
+                name="embed-{{id}}"
+                readonly
+        />
+        <span class="embed-code__success-container">    
+            <button id="" data-id="{{id}}" type="button" class="btn btn--primary embed-code__button js-embed-code-copy">Copy</button>
+            <span role="status"></span>
+        </span>
+    </div>
+</details>
 
-    <div class="pym-interactive{{#if_eq full-width "true"}} pym-interactive--full-width margin-left--0{{/if_eq}}" id="{{id}}" data-url="{{url}}" data-title="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}}"></div>
 
-    <details class="details">
-        <summary class="details__summary" role="button" aria-label="{{#if_null title}}{{labels.interactive-chart}}{{else}}{{title}}{{/if_null}} embed code">Embed code</summary>
-        <div class="details__body">
-            <label class="embed-code__label" for="embed-{{id}}">Embed this interactive</label>
-            <input class="embed-code__code width-md--31"
-        value='<iframe width="100%" src="{{#if (containsAny url "http" "https")}}{{url}}{{else}}{{#if is_dev}}http://{{location.host}}{{else}}https://{{location.hostname}}{{/if}}{{url}}{{/if}}"></iframe>'
-                   id="embed-{{id}}"
-                   name="embed-{{id}}"
-                   readonly
-            />
-            <span class="embed-code__success-container">
-                <button id="" data-id="{{id}}" type="button" class="btn btn--primary embed-code__button js-embed-code-copy">Copy</button>
-                <span role="status"></span>
-            </span>
-        </div>
-    </details>
-
-</div>


### PR DESCRIPTION
### What

This change adds a noscript fallback for if a user doesn't have JS enabled to interactives as pym js can't be used to size them.

It locks the iframe to 100% width and 400px height, adds a title and a descriptive text with link out to view the vis directly. 

<img width="1066" height="675" alt="Screenshot 2026-08-10 at 12 11 51" src="https://github.com/user-attachments/assets/48776f2c-64e2-48ef-87ee-e5e211341c04" />
<img width="730" height="717" alt="Screenshot 2026-08-10 at 12 12 44" src="https://github.com/user-attachments/assets/0ed64194-5a5c-40f7-8e67-b248104ef9b0" />

### How to review

You can test by:
- running babbage in web mode
- portforwarding to zebedee in sandbox
- running sixteens

go to a page with a visualisation on and turn off javascript and refresh. - N.B. as covered on the screenshots, we are not in control of what gets served in the frame itself. 

### Who can review

Not me. 